### PR TITLE
fix: improve saml response

### DIFF
--- a/packages/core-js-sdk/src/sdk/saml.ts
+++ b/packages/core-js-sdk/src/sdk/saml.ts
@@ -7,39 +7,21 @@ import { stringNonEmpty, withValidations } from './validations';
 const withStartValidations = withValidations(stringNonEmpty('tenant'));
 const withExchangeValidations = withValidations(stringNonEmpty('code'));
 
-type StartFn = <B extends { redirect: boolean }>(
-  tenantNameOrEmail: string,
-  config?: B
-) => Promise<
-  B extends { redirect: true } ? undefined : SdkResponse<URLResponse>
->;
-
 const withSaml = (httpClient: HttpClient) => ({
-  // eslint-disable-next-line consistent-return
   start: withStartValidations(
-    async (
+    (
       tenantNameOrEmail: string,
       redirectUrl?: string,
-      { redirect = false } = {},
       loginOptions?: LoginOptions,
       token?: string
-    ) => {
-      const resp = await httpClient.post(
-        apiPaths.saml.start,
-        loginOptions || {},
-        {
+    ): Promise<SdkResponse<JWTResponse>> =>
+      transformResponse(
+        httpClient.post(apiPaths.saml.start, loginOptions || {}, {
           queryParams: { tenant: tenantNameOrEmail, redirectURL: redirectUrl },
           token,
-        }
-      );
-
-      if (!redirect || !resp.ok)
-        return transformResponse(Promise.resolve(resp));
-
-      const { url } = await resp.json();
-      window.location.href = url;
-    }
-  ) as StartFn,
+        })
+      )
+  ),
   exchange: withExchangeValidations(
     (code: string): Promise<SdkResponse<JWTResponse>> =>
       transformResponse(httpClient.post(apiPaths.saml.exchange, { code }))

--- a/packages/core-js-sdk/src/sdk/saml.ts
+++ b/packages/core-js-sdk/src/sdk/saml.ts
@@ -14,7 +14,7 @@ const withSaml = (httpClient: HttpClient) => ({
       redirectUrl?: string,
       loginOptions?: LoginOptions,
       token?: string
-    ): Promise<SdkResponse<JWTResponse>> =>
+    ): Promise<SdkResponse<URLResponse>> =>
       transformResponse(
         httpClient.post(apiPaths.saml.start, loginOptions || {}, {
           queryParams: { tenant: tenantNameOrEmail, redirectURL: redirectUrl },

--- a/packages/core-js-sdk/test/sdk/saml.test.ts
+++ b/packages/core-js-sdk/test/sdk/saml.test.ts
@@ -19,7 +19,7 @@ describe('saml', () => {
       expect(() => sdk.saml.start('')).toThrow('"tenant" must not be empty');
     });
 
-    it('should return the correct url when "redirect" is set to default (false)', async () => {
+    it('should return the correct url', async () => {
       delete window.location;
       window.location = new URL('https://www.example.com');
       const httpRespJson = { url: 'http://redirecturl.com/' };
@@ -49,61 +49,6 @@ describe('saml', () => {
         ok: true,
         response: httpResponse,
       });
-    });
-
-    it('should redirect the browser to the correct url when "redirect" is set to true', async () => {
-      delete window.location;
-      window.location = new URL('https://www.example.com');
-      mockHttpClient.post.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ url: 'http://redirecturl.com/' }),
-        clone: () => ({
-          json: () => Promise.resolve({ url: 'http://redirecturl.com/' }),
-        }),
-      });
-      await sdk.saml.start('tenant', undefined, { redirect: true });
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.saml.start,
-        {},
-        {
-          queryParams: {
-            tenant: 'tenant',
-          },
-        }
-      );
-
-      expect(window.location.href).toBe('http://redirecturl.com/');
-    });
-
-    it('should redirect the browser to the correct url when "redirect" is set to true and login options', async () => {
-      delete window.location;
-      window.location = new URL('https://www.example.com');
-      mockHttpClient.post.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ url: 'http://redirecturl.com/' }),
-        clone: () => ({
-          json: () => Promise.resolve({ url: 'http://redirecturl.com/' }),
-        }),
-      });
-      await sdk.saml.start(
-        'tenant',
-        undefined,
-        { redirect: true },
-        { stepup: true, customClaims: { k1: 'v1' } },
-        'token'
-      );
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        apiPaths.saml.start,
-        { stepup: true, customClaims: { k1: 'v1' } },
-        {
-          queryParams: {
-            tenant: 'tenant',
-          },
-          token: 'token',
-        }
-      );
-
-      expect(window.location.href).toBe('http://redirecturl.com/');
     });
   });
 


### PR DESCRIPTION
## Related Issues
https://github.com/descope/etc/issues/230

## Description
1. remove support of { redirect: boolean } config which should not be supported at this package as it used in JS
2. remove the type, (which didn't expose `tenantNameOrEmail` argument), as its not needed anymore
