### PR TITLE
fix: use type locally instead of exported

### DIFF
--- a/packages/core-js-sdk/src/sdk/enchantedLink/types.ts
+++ b/packages/core-js-sdk/src/sdk/enchantedLink/types.ts
@@ -1,4 +1,4 @@
-import { Deliveries, SdkResponse, EnchantedLinkResponse, User } from '../types';
+import { SdkResponse, EnchantedLinkResponse, User } from '../types';
 
 export type EnchantedLinkSignInFn = (
   loginId: string,

--- a/packages/core-js-sdk/src/sdk/otp/types.ts
+++ b/packages/core-js-sdk/src/sdk/otp/types.ts
@@ -1,5 +1,4 @@
 import {
-  Deliveries,
   User,
   SdkResponse,
   JWTResponse,
@@ -9,6 +8,9 @@ import {
   DeliveriesMap,
   DeliveriesPhone,
   UpdateOptions,
+  Deliveries,
+  DeliveryMethods,
+  SdkFn,
 } from '../types';
 
 type VerifyFn = (
@@ -39,8 +41,16 @@ type UpdatePhoneFn = <T extends boolean>(
   loginId: string,
   phone: string,
   token?: string,
-  updateOptions? : UpdateOptions<T>
+  updateOptions?: UpdateOptions<T>
 ) => Promise<SdkResponse<MaskedPhone>>;
+
+// We locate this here because if we put it in types.ts
+// The declaration of the type will not work well along with other utility types such as ReplacePaths
+// If this type is needed elsewhere, we should find a better solution for it
+// Note that this issue manifests itself when this type is exported. see https://github.com/descope/node-sdk/pull/184
+type DeliveriesWithFunc<T extends SdkFn> = {
+  [S in DeliveryMethods]: T;
+};
 
 export enum Routes {
   signUp = 'signup',
@@ -50,7 +60,7 @@ export enum Routes {
 }
 
 export type Otp = {
-  [Routes.verify]: Deliveries<VerifyFn>;
+  [Routes.verify]: DeliveriesWithFunc<VerifyFn>;
   [Routes.signIn]: Deliveries<DeliveriesSignIn>;
   [Routes.signUp]: Deliveries<DeliveriesSignUp>;
   [Routes.updatePhone]: DeliveriesPhone<UpdatePhoneFn>;

--- a/packages/core-js-sdk/src/sdk/types.ts
+++ b/packages/core-js-sdk/src/sdk/types.ts
@@ -242,8 +242,8 @@ export type SdkResponse<T extends ResponseData> = {
 };
 
 /** Different delivery method */
-export type Deliveries<T extends Record<DeliveryMethods, SdkFn> | SdkFn> = {
-  [S in DeliveryMethods]: T extends Record<DeliveryMethods, SdkFn> ? T[S] : T;
+export type Deliveries<T extends Record<DeliveryMethods, SdkFn>> = {
+  [S in DeliveryMethods]: T[S];
 };
 
 export type DeliveriesPhone<T extends Record<DeliveryPhone, SdkFn> | SdkFn> = {
@@ -259,6 +259,6 @@ export type DeliveriesMap<EmailFn extends SdkFn, PhoneFn extends SdkFn> = {
 export type Logger = Pick<Console, 'debug' | 'log' | 'error' | 'warn'>;
 
 export type UpdateOptions<T extends boolean> = {
-  addToLoginIDs?: T,
-  onMergeUseExisting?: T extends true? boolean : never
-}
+  addToLoginIDs?: T;
+  onMergeUseExisting?: T extends true ? boolean : never;
+};


### PR DESCRIPTION

## Description
this will fix https://github.com/descope/node-sdk/pull/184

the problem is that when the type is exported, the generated type cannot be inferred well 