### PR TITLE
fix: prevent console error when WebAuthn isn't supported

### DIFF
--- a/packages/web-js-sdk/src/sdk/webauthn.ts
+++ b/packages/web-js-sdk/src/sdk/webauthn.ts
@@ -159,7 +159,7 @@ export async function isSupported(
     return Promise.resolve(false);
   }
   const supported = !!(
-    PublicKeyCredential &&
+    window.PublicKeyCredential &&
     navigator.credentials &&
     navigator.credentials.create &&
     navigator.credentials.get


### PR DESCRIPTION
## Description
The `PublicKeyCredential` symbol isn't available when the webpage is running in an insecure context (i.e., `http` url that's not on `localhost`).

## Must
- [X] Tests
- [X] Documentation (if applicable)
