### PR TITLE
fix: Replace name with ID as it's expected

### DIFF
--- a/packages/core-js-sdk/src/sdk/saml.ts
+++ b/packages/core-js-sdk/src/sdk/saml.ts
@@ -10,14 +10,14 @@ const withExchangeValidations = withValidations(stringNonEmpty('code'));
 const withSaml = (httpClient: HttpClient) => ({
   start: withStartValidations(
     (
-      tenantNameOrEmail: string,
+      tenantIdOrEmail: string,
       redirectUrl?: string,
       loginOptions?: LoginOptions,
       token?: string
     ): Promise<SdkResponse<URLResponse>> =>
       transformResponse(
         httpClient.post(apiPaths.saml.start, loginOptions || {}, {
-          queryParams: { tenant: tenantNameOrEmail, redirectURL: redirectUrl },
+          queryParams: { tenant: tenantIdOrEmail, redirectURL: redirectUrl },
           token,
         })
       )

--- a/packages/core-js-sdk/test/sdk/saml.test.ts
+++ b/packages/core-js-sdk/test/sdk/saml.test.ts
@@ -32,13 +32,13 @@ describe('saml', () => {
         status: 200,
       };
       mockHttpClient.post.mockResolvedValueOnce(httpResponse);
-      const resp = await sdk.saml.start('tenant');
+      const resp = await sdk.saml.start('tenant-ID');
       expect(mockHttpClient.post).toHaveBeenCalledWith(
         apiPaths.saml.start,
         {},
         {
           queryParams: {
-            tenant: 'tenant',
+            tenant: 'tenant-ID',
           },
         }
       );


### PR DESCRIPTION
## Related Issues

Fixes [<link_to_github_issue>](https://github.com/descope/etc/issues/2543)

## Description

SSO supports either and email address or a tenant ID. Renamed the parameter to express that.

## Must

- [X] Tests
- [X] Documentation (if applicable)
