### PR TITLE
feat: Defer redirect when in background for Android

### DIFF
--- a/packages/web-component/src/lib/constants/index.ts
+++ b/packages/web-component/src/lib/constants/index.ts
@@ -9,6 +9,7 @@ export const URL_CODE_PARAM_NAME = 'code';
 export const URL_ERR_PARAM_NAME = 'err';
 export const URL_REDIRECT_AUTH_CHALLENGE_PARAM_NAME = 'ra-challenge';
 export const URL_REDIRECT_AUTH_CALLBACK_PARAM_NAME = 'ra-callback';
+export const URL_REDIRECT_AUTH_INITIATOR_PARAM_NAME = 'ra-initiator';
 export const DESCOPE_ATTRIBUTE_PREFIX = 'data-descope-';
 export const DESCOPE_ATTRIBUTE_EXCLUDE_FIELD = 'data-exclude-field';
 export const DESCOPE_LAST_AUTH_LOCAL_STORAGE_KEY = 'dls_last_auth';

--- a/packages/web-component/src/lib/descope-wc/DescopeWc.ts
+++ b/packages/web-component/src/lib/descope-wc/DescopeWc.ts
@@ -93,6 +93,7 @@ class DescopeWc extends BaseDescopeWc {
       webauthnOptions,
       redirectAuthCodeChallenge,
       redirectAuthCallbackUrl,
+      redirectAuthInitiator,
       oidcIdpStateId,
     } = currentState;
 
@@ -190,6 +191,13 @@ class DescopeWc extends BaseDescopeWc {
     if (action === RESPONSE_ACTIONS.redirect) {
       if (!redirectTo) {
         this.logger.error('Did not get redirect url');
+      }
+      if (redirectAuthInitiator === 'android' && document.hidden) {
+        // on android native flows, defer redirects until in foreground
+        this.flowState.update({
+          deferredRedirect: true,
+        });
+        return;
       }
       window.location.assign(redirectTo);
       return;

--- a/packages/web-component/src/lib/helpers/helpers.ts
+++ b/packages/web-component/src/lib/helpers/helpers.ts
@@ -8,6 +8,7 @@ import {
   URL_TOKEN_PARAM_NAME,
   URL_REDIRECT_AUTH_CHALLENGE_PARAM_NAME,
   URL_REDIRECT_AUTH_CALLBACK_PARAM_NAME,
+  URL_REDIRECT_AUTH_INITIATOR_PARAM_NAME,
   OIDC_IDP_STATE_ID_PARAM_NAME,
 } from '../constants';
 import { AutoFocusOptions, Direction } from '../types';
@@ -122,12 +123,20 @@ export function getRedirectAuthFromUrl() {
   const redirectAuthCallbackUrl = getUrlParam(
     URL_REDIRECT_AUTH_CALLBACK_PARAM_NAME
   );
-  return { redirectAuthCodeChallenge, redirectAuthCallbackUrl };
+  const redirectAuthInitiator = getUrlParam(
+    URL_REDIRECT_AUTH_INITIATOR_PARAM_NAME
+  );
+  return {
+    redirectAuthCodeChallenge,
+    redirectAuthCallbackUrl,
+    redirectAuthInitiator,
+  };
 }
 
 export function clearRedirectAuthFromUrl() {
   resetUrlParam(URL_REDIRECT_AUTH_CHALLENGE_PARAM_NAME);
   resetUrlParam(URL_REDIRECT_AUTH_CALLBACK_PARAM_NAME);
+  resetUrlParam(URL_REDIRECT_AUTH_INITIATOR_PARAM_NAME);
 }
 
 export function getOIDCIDPParamFromUrl() {
@@ -210,9 +219,16 @@ export const handleUrlParams = () => {
     clearExchangeErrorFromUrl();
   }
 
-  const { redirectAuthCodeChallenge, redirectAuthCallbackUrl } =
-    getRedirectAuthFromUrl();
-  if (redirectAuthCodeChallenge || redirectAuthCallbackUrl) {
+  const {
+    redirectAuthCodeChallenge,
+    redirectAuthCallbackUrl,
+    redirectAuthInitiator,
+  } = getRedirectAuthFromUrl();
+  if (
+    redirectAuthCodeChallenge ||
+    redirectAuthCallbackUrl ||
+    redirectAuthInitiator
+  ) {
     clearRedirectAuthFromUrl();
   }
 
@@ -229,6 +245,7 @@ export const handleUrlParams = () => {
     exchangeError,
     redirectAuthCodeChallenge,
     redirectAuthCallbackUrl,
+    redirectAuthInitiator,
     oidcIdpStateId,
   };
 };

--- a/packages/web-component/src/lib/types.ts
+++ b/packages/web-component/src/lib/types.ts
@@ -52,7 +52,9 @@ export type FlowState = {
   telemetryKey: string;
   redirectAuthCodeChallenge: string;
   redirectAuthCallbackUrl: string;
+  redirectAuthInitiator: string;
   oidcIdpStateId: string;
+  deferredRedirect: boolean;
 };
 
 export type StepState = {


### PR DESCRIPTION
## Related Issues

https://github.com/descope/etc/issues/310

## Description

When running flows in native Android, the final redirect cannot happen in the background, like happens with Enchanted links. This PR adds a new `redirect auth` URL parameter to know who the initiator is, and defers the redirect specifically for the case of background and android.

## Must

- [X] Tests
- [ ] Documentation (if applicable)
