### PR TITLE
Fix: duplicate redirect calls (one is canceled by the browser)

### DIFF
--- a/packages/web-component/src/lib/descope-wc/DescopeWc.ts
+++ b/packages/web-component/src/lib/descope-wc/DescopeWc.ts
@@ -188,9 +188,13 @@ class DescopeWc extends BaseDescopeWc {
       return;
     }
 
-    if (action === RESPONSE_ACTIONS.redirect) {
+    if (
+      action === RESPONSE_ACTIONS.redirect &&
+      (isChanged('redirectTo') || isChanged('deferredRedirect'))
+    ) {
       if (!redirectTo) {
         this.logger.error('Did not get redirect url');
+        return;
       }
       if (redirectAuthInitiator === 'android' && document.hidden) {
         // on android native flows, defer redirects until in foreground

--- a/packages/web-component/test/descope-wc.test.ts
+++ b/packages/web-component/test/descope-wc.test.ts
@@ -1001,6 +1001,25 @@ describe('web-component', () => {
     );
   });
 
+  it('When action type is "redirect" it calls location.assign one time only', async () => {
+    nextMock.mockReturnValueOnce(
+      generateSdkResponse({
+        action: RESPONSE_ACTIONS.redirect,
+        redirectUrl: 'https://myurl.com',
+      })
+    );
+
+    window.location.search = `?${URL_RUN_IDS_PARAM_NAME}=0_0&${URL_CODE_PARAM_NAME}=code1`;
+    document.body.innerHTML = `<h1>Custom element test</h1> <descope-wc flow-id="versioned-flow" project-id="1"></descope-wc>`;
+
+    await waitFor(
+      () => expect(window.location.assign).toHaveBeenCalledTimes(1),
+      {
+        timeout: 5000,
+      }
+    );
+  });
+
   it('When action type is "redirect" and redirectUrl is missing should log an error ', async () => {
     startMock.mockReturnValueOnce(
       generateSdkResponse({


### PR DESCRIPTION
Fix duplicate redirect calls (one is canceled by the browser) caused by "update" event which triggered the callback once again.
Fixed by validating that values (effected the redirect) are really changed
