### PR TITLE
add getTenants utility function to fetch tenant list from JWT

### DIFF
--- a/packages/core-js-sdk/src/sdk/helpers/index.ts
+++ b/packages/core-js-sdk/src/sdk/helpers/index.ts
@@ -33,6 +33,17 @@ export function isJwtExpired(token: string): boolean {
 }
 
 /**
+ * Returns the list of tenants in the given JWT
+ *
+ * @param token JWT token
+ */
+export function getTenants(token: string): string[] {
+  let claims: any = parseJwt(token);
+  const items = Object.keys(claims?.tenants);
+  return Array.isArray(items) ? items : [];
+}
+
+/**
  * Returns the list of permissions granted in the given JWT but DOES NOT check for signature
  *
  * @param token JWT token

--- a/packages/core-js-sdk/src/sdk/index.ts
+++ b/packages/core-js-sdk/src/sdk/index.ts
@@ -4,6 +4,7 @@ import withAccessKeys from './accesskey';
 import withEnchantedLink from './enchantedLink';
 import withFlow from './flow';
 import {
+  getTenants,
   getJwtPermissions,
   getJwtRoles,
   isJwtExpired,
@@ -46,6 +47,7 @@ export default (httpClient: HttpClient) => ({
   me: (token?: string) =>
     transformResponse<UserResponse>(httpClient.get(apiPaths.me, { token })),
   isJwtExpired: withJwtValidations(isJwtExpired),
+  getTenants: withJwtValidations(getTenants),
   getJwtPermissions: withJwtValidations(getJwtPermissions),
   getJwtRoles: withJwtValidations(getJwtRoles),
   httpClient,

--- a/packages/core-js-sdk/test/sdk/sdk.test.ts
+++ b/packages/core-js-sdk/test/sdk/sdk.test.ts
@@ -66,6 +66,9 @@ describe('sdk', () => {
         C2EdY4UXXzKPV0EKdZFJbuKKmvtl: {
           roles: ['abc', 'xyz'],
         },
+        C2EdY4UXXzKPV0EKdZFJbuKKmvtm: {
+          roles: ['def'],
+        },
       },
     };
 
@@ -88,6 +91,13 @@ describe('sdk', () => {
       expect(
         sdk.getJwtRoles('jwt', 'C2EdY4UXXzKPV0EKdZFJbuKKmvtl')
       ).toStrictEqual(['abc', 'xyz']);
+    });
+    it('should return a list of tenants', () => {
+      (jwtDecode as jest.Mock).mockImplementation(() => mock);
+      expect(sdk.getTenants('jwt')).toStrictEqual([
+        'C2EdY4UXXzKPV0EKdZFJbuKKmvtl',
+        'C2EdY4UXXzKPV0EKdZFJbuKKmvtm',
+      ]);
     });
   });
 


### PR DESCRIPTION
## Description

This commit adds a `getTenants` utility function to fetch the list of tenants from the JWT token.
The JWT token consists of tenants as keys, and in order to fetch roles/permissions for a specific tenant, 
we need to parse the tenant keys ourselves. 
The helper function provides an easier way to get the tenant list, which can then be further used
to fetch roles/permissions in a tenant enabled environment.

## Must

- [x] Tests
- [ ] Documentation (if applicable)
