### PR TITLE
feat: change polling mechanism to timeout

### DIFF
--- a/packages/web-component/src/lib/descope-wc/DescopeWc.ts
+++ b/packages/web-component/src/lib/descope-wc/DescopeWc.ts
@@ -393,18 +393,22 @@ class DescopeWc extends BaseDescopeWc {
     this.stepState.update(stepStateUpdate);
   }
 
-  #handlePollingResponse = async (executionId, stepId, version, action) => {
+  #handlePollingResponse = (executionId, stepId, version, action) => {
     if (action === RESPONSE_ACTIONS.poll) {
-      const sdkResp = await this.sdk.flow.next(
-        executionId,
-        stepId,
-        CUSTOM_INTERACTIONS.polling,
-        {},
-        version
-      );
-      this.#handleSdkResponse(sdkResp);
-      const { action: nextAction } = sdkResp.data;
-      this.#handlePollingResponse(executionId, stepId, version, nextAction);
+      // schedule next polling request for 2 seconds from now
+      setTimeout(async () => {
+        const sdkResp = await this.sdk.flow.next(
+          executionId,
+          stepId,
+          CUSTOM_INTERACTIONS.polling,
+          {},
+          version
+        );
+        this.#handleSdkResponse(sdkResp);
+        const { action: nextAction } = sdkResp?.data ?? {};
+        // will poll again if needed
+        this.#handlePollingResponse(executionId, stepId, version, nextAction);
+      }, 2000);
     }
   };
 

--- a/packages/web-component/test/descope-wc.test.ts
+++ b/packages/web-component/test/descope-wc.test.ts
@@ -1664,7 +1664,9 @@ describe('web-component', () => {
 
       jest.runAllTimers();
 
-      await screen.findByShadowText('It works!');
+      await waitFor(() => screen.findByShadowText('It works!'), {
+        timeout: 10000,
+      });
 
       fireEvent.click(screen.getByShadowText('click'));
 

--- a/packages/web-component/test/descope-wc.test.ts
+++ b/packages/web-component/test/descope-wc.test.ts
@@ -1651,6 +1651,37 @@ describe('web-component', () => {
       jest.useRealTimers();
     });
 
+    it('Should clear timeout when user clicks a button', async () => {
+      jest.spyOn(global, 'clearTimeout');
+
+      startMock.mockReturnValueOnce(generateSdkResponse());
+      nextMock.mockReturnValueOnce(generateSdkResponse({ screenId: '1' }));
+
+      pageContent =
+        '<button id="submitterId">click</button><span>It works!</span>';
+
+      document.body.innerHTML = `<h1>Custom element test</h1> <descope-wc flow-id="otpSignInEmail" project-id="1"></descope-wc>`;
+
+      jest.runAllTimers();
+
+      await screen.findByShadowText('It works!');
+
+      fireEvent.click(screen.getByShadowText('click'));
+
+      await waitFor(() =>
+        expect(nextMock).toHaveBeenCalledWith(
+          '0',
+          '0',
+          'submitterId',
+          expect.any(Object)
+        )
+      );
+
+      await waitFor(() => expect(clearTimeout).toHaveBeenCalled(), {
+        timeout: 10000,
+      });
+    });
+
     it('When has polling element - next with "polling", and check that timeout is set properly', async () => {
       jest.spyOn(global, 'setTimeout');
 

--- a/packages/web-component/test/descope-wc.test.ts
+++ b/packages/web-component/test/descope-wc.test.ts
@@ -1651,33 +1651,8 @@ describe('web-component', () => {
       jest.useRealTimers();
     });
 
-    it('When action type is "poll" - check that interval is removed properly', async () => {
-      jest.spyOn(global, 'clearInterval');
-
-      startMock.mockReturnValueOnce(
-        generateSdkResponse({
-          executionId: 'e1',
-          stepId: 's1',
-          screenId: '1',
-          action: RESPONSE_ACTIONS.poll,
-        })
-      );
-
-      nextMock.mockReturnValueOnce(generateSdkResponse());
-
-      pageContent = '<div>hey</div>';
-
-      document.body.innerHTML = `<h1>Custom element test</h1> <descope-wc flow-id="otpSignInEmail" project-id="1"></descope-wc>`;
-
-      jest.runAllTimers();
-
-      await waitFor(() => expect(clearInterval).toHaveBeenCalled(), {
-        timeout: 10000,
-      });
-    });
-
-    it('When has polling element - next with "polling", and check that interval is set properly', async () => {
-      jest.spyOn(global, 'setInterval');
+    it('When has polling element - next with "polling", and check that timeout is set properly', async () => {
+      jest.spyOn(global, 'setTimeout');
 
       startMock.mockReturnValueOnce(generateSdkResponse());
 
@@ -1694,7 +1669,7 @@ describe('web-component', () => {
 
       await waitFor(
         () =>
-          expect(setInterval).toHaveBeenCalledWith(expect.any(Function), 2000),
+          expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 2000),
         {
           timeout: 10000,
         }
@@ -1755,7 +1730,7 @@ describe('web-component', () => {
     });
 
     it('When has polling element, and next poll returns polling response', async () => {
-      jest.spyOn(global, 'setInterval');
+      jest.spyOn(global, 'setTimeout');
 
       startMock.mockReturnValueOnce(generateSdkResponse());
 
@@ -1776,7 +1751,7 @@ describe('web-component', () => {
     });
 
     it('When has polling element, and next poll returns completed response', async () => {
-      jest.spyOn(global, 'setInterval');
+      jest.spyOn(global, 'setTimeout');
 
       startMock.mockReturnValueOnce(generateSdkResponse());
 


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/3844

## Description
(instead of https://github.com/descope/descope-js/pull/257) 

changing the mechanism to timeout based rather then interval based

tested "short polling" (screen/end after polling) and "long polling" (connector action with 2 secs timeout) on both EL and ML