### PR TITLE
feat: add readToken to only read tokens but not persist

### DIFF
--- a/packages/web-js-sdk/README.md
+++ b/packages/web-js-sdk/README.md
@@ -24,6 +24,8 @@ const sdk = descopeSdk({
   sdk.refresh(...), flow.next(...), etc.) in browser storage. In addition, this will
   make `sdk.getSessionToken()` available, see usage bellow bellow */
   persistTokens: true,
+  /* Read Tokens that exist after a succesful authentication, this does not persist incoming tokens and refreshes in browser storage. */
+  readTokens: true,
   /* Pass `sessionTokenViaCookie: true` to store the session token in a cookie when using `persistTokens`. By default, the sdk will set the session token in the browser storage.
   Notes:
     - This option is relevant only when `persistTokens` is true.

--- a/packages/web-js-sdk/src/enhancers/withPersistTokens/index.ts
+++ b/packages/web-js-sdk/src/enhancers/withPersistTokens/index.ts
@@ -18,12 +18,12 @@ import { PersistTokensOptions } from './types';
  */
 export const withPersistTokens =
   <T extends CreateWebSdk>(createSdk: T) =>
-  <A extends boolean>({
+  <A extends boolean, B extends boolean>({
     persistTokens: isPersistTokens,
     readTokens: isReadTokens,
     sessionTokenViaCookie,
     ...config
-  }: Parameters<T>[0] & PersistTokensOptions<A>): A extends true
+  }: Parameters<T>[0] & PersistTokensOptions<A, B>): A extends true
     ? ReturnType<T> & {
         getRefreshToken: typeof getRefreshToken;
         getSessionToken: typeof getSessionToken;

--- a/packages/web-js-sdk/src/enhancers/withPersistTokens/types.ts
+++ b/packages/web-js-sdk/src/enhancers/withPersistTokens/types.ts
@@ -1,9 +1,9 @@
-export type PersistTokensOptions<A extends boolean> = {
+export type PersistTokensOptions<A extends boolean, B extends boolean> = {
   // If true, response's tokens will be persisted (read and write) - session-token in DS cookie, and refresh-token in local storage
   // In addition, the stored refresh-token will be automatically passed to the sdk functions, unless it was provided
   persistTokens?: A;
   // If true, existing tokens such as local storage or cookies will be read - session-token in DS cookie, and refresh-token in local storage.
-  readTokens?: A;
+  readTokens?: B;
   // If true, session token (jwt) will be stored on cookie. Otherwise, the session token will be
   // stored on local storage and can accessed with getSessionToken function
   // Use this option if session token will stay small (less than 1k)

--- a/packages/web-js-sdk/src/enhancers/withPersistTokens/types.ts
+++ b/packages/web-js-sdk/src/enhancers/withPersistTokens/types.ts
@@ -1,7 +1,9 @@
 export type PersistTokensOptions<A extends boolean> = {
-  // If true, response's tokens will be persisted - session-token in DS cookie, and refresh-token in local storage
+  // If true, response's tokens will be persisted (read and write) - session-token in DS cookie, and refresh-token in local storage
   // In addition, the stored refresh-token will be automatically passed to the sdk functions, unless it was provided
   persistTokens?: A;
+  // If true, existing tokens such as local storage or cookies will be read - session-token in DS cookie, and refresh-token in local storage.
+  readTokens?: A;
   // If true, session token (jwt) will be stored on cookie. Otherwise, the session token will be
   // stored on local storage and can accessed with getSessionToken function
   // Use this option if session token will stay small (less than 1k)

--- a/packages/web-js-sdk/test/persistTokens.test.ts
+++ b/packages/web-js-sdk/test/persistTokens.test.ts
@@ -42,6 +42,28 @@ describe('persistTokens', () => {
 
     expect(sdk.getRefreshToken()).toEqual(authInfo.refreshJwt);
   });
+
+  it('should get refresh token from local storage read tokens', () => {
+    const sdk = createSdk({ projectId: 'pid', readTokens: true });
+    localStorage.setItem('DSR', authInfo.refreshJwt);
+    sdk.httpClient.get('1/2/3');
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      new URL(`https://api.descope.com/1/2/3`),
+      {
+        body: undefined,
+        headers: new Headers({
+          Authorization: `Bearer pid:${authInfo.refreshJwt}`,
+          ...descopeHeaders,
+        }),
+        method: 'GET',
+        credentials: 'include',
+      }
+    );
+
+    expect(sdk).not.toHaveProperty('getRefreshToken');
+  });
+
   it('should set session token as cookie and refresh token to local storage when managing session token via cookie', async () => {
     const mockFetch = jest
       .fn()


### PR DESCRIPTION
## Related Issues

related https://github.com/descope/etc/issues/3871

## Related PRs
https://github.com/descope/console-app/pull/1804

## Description
- add readTokens to all only read of auth tokens instead of persist

## Must

- [ ] Tests
- [ ] Documentation (if applicable)
