### PR TITLE
fix: Add custom attributes

### DIFF
--- a/packages/core-js-sdk/src/sdk/types.ts
+++ b/packages/core-js-sdk/src/sdk/types.ts
@@ -50,9 +50,9 @@ export type UserResponse = User & {
   roleNames?: string[];
   userTenants?: UserTenant[];
   createTime: number;
-  totp: boolean;
-  saml: boolean;
-  oauth?: Record<string, boolean>;
+  TOTP: boolean;
+  SAML: boolean;
+  OAuth?: Record<string, boolean>;
   customAttributes?: Record<string, any>;
 };
 

--- a/packages/core-js-sdk/src/sdk/types.ts
+++ b/packages/core-js-sdk/src/sdk/types.ts
@@ -53,6 +53,7 @@ export type UserResponse = User & {
   totp: boolean;
   saml: boolean;
   oauth?: Record<string, boolean>;
+  customAttributes?: Record<string, any>;
 };
 
 /** A tenant association mapping  */


### PR DESCRIPTION
## Related Issues
https://github.com/descope/etc/issues/4052


## Description
- add custom attributes field (though Descope support only string | boolean | number, I think `any` will make more sense in the long run)

- fix  totp/smal/oauth(TypeScript definition) to actual values (TOTP/SAML/OAuth)
![image](https://github.com/descope/descope-js/assets/10514677/ab63757a-1ca1-464b-893b-21d34cb82a7d)
 