### PR TITLE
chore: Add WebAuthn failure reason and fix autofill bug in getChromiumVersion

### DIFF
--- a/packages/web-component/src/lib/helpers/helpers.ts
+++ b/packages/web-component/src/lib/helpers/helpers.ts
@@ -344,11 +344,14 @@ export const handleAutoFocus = (
 };
 
 /**
- * With a fallback value in case:
+ * To return a fallback value in case the timeout expires and the promise
+ * isn't fulfilled:
+ *
  *   const promise = loadUserCount();
  *   const count = await timeoutPromise(2000, promise, 0);
  *
- * Or just throw if the timeout expires:
+ * Or without a fallback value to just throw an error if the timeout expires:
+ *
  *   try {
  *     count = await timeoutPromise(2000, promise);
  *   }

--- a/packages/web-component/src/lib/helpers/helpers.ts
+++ b/packages/web-component/src/lib/helpers/helpers.ts
@@ -352,6 +352,9 @@ export const handleAutoFocus = (
  *   try {
  *     count = await timeoutPromise(2000, promise);
  *   }
+ *
+ * Fallback is returned only in case of timeout, so if the passed promise rejects
+ * the fallback value is not used, and the returned promise will throw as well.
  */
 export function timeoutPromise<T>(
   timeout: number,

--- a/packages/web-component/test/descope-wc.test.ts
+++ b/packages/web-component/test/descope-wc.test.ts
@@ -1321,7 +1321,7 @@ describe('web-component', () => {
       'submit',
       {
         transactionId: 't1',
-        cancelWebauthn: true,
+        failure: 'NotAllowedError',
       },
       0
     );


### PR DESCRIPTION
## Description
- Change WebAuthn `...Finish` actions to return the `failure` string instead of `cancelWebauthn` flag.
- Fixed issue where `getChromiumVersion` wasn't actually a function
- This caused Passkey Autofill to sometimes fail initialization in the console runner
- Updated the tests to hopefully cover all scenarios around this

## Must
- [X] Tests
- [X] Documentation (if applicable)
