### PR TITLE
fix: large session expiration consideration 

### DIFF
--- a/packages/web-js-sdk/README.md
+++ b/packages/web-js-sdk/README.md
@@ -31,7 +31,9 @@ const sdk = descopeSdk({
 In addition, some browsers (e.g. Safari) may not store `Secure` cookie if the hosted page is running on an HTTP protocol. */
   */
   sessionTokenViaCookie: false,
-  /* Automatically schedule a call refresh session call after a successful authentication */
+  /* Automatically schedule a call refresh session call after a successful authentication:
+  Note: due to browser limitation, the maximum interval for the refresh has an upper bound of 2^32 - 1 milliseconds (approximately 24.8 days).
+  */
   autoRefresh: true,
 });
 

--- a/packages/web-js-sdk/src/constants.ts
+++ b/packages/web-js-sdk/src/constants.ts
@@ -1,2 +1,6 @@
 // This sdk can be used in SSR apps
 export const IS_BROWSER = typeof window !== 'undefined';
+
+// Maximum timeout value for setTimeout
+// For more information, refer to https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#maximum_delay_value
+export const MAX_TIMEOUT = Math.pow(2, 31) - 1;

--- a/packages/web-js-sdk/src/enhancers/withAutoRefresh/index.ts
+++ b/packages/web-js-sdk/src/enhancers/withAutoRefresh/index.ts
@@ -9,6 +9,7 @@ import {
 } from './helpers';
 import { AutoRefreshOptions } from './types';
 import logger from '../helpers/logger';
+import { MAX_TIMEOUT } from '../../constants';
 
 // The amount of time (ms) to trigger the refresh before session expires
 const REFRESH_THRESHOLD = 20 * 1000; // 20 sec
@@ -51,8 +52,15 @@ export const withAutoRefresh =
       } else if (sessionJwt) {
         sessionExpiration = getTokenExpiration(sessionJwt);
         refreshToken = refreshJwt;
-        const timeout =
+        let timeout =
           millisecondsUntilDate(sessionExpiration) - REFRESH_THRESHOLD;
+
+        if (timeout > MAX_TIMEOUT) {
+          logger.debug(
+            `Timeout is too large (${timeout}ms), setting it to ${MAX_TIMEOUT}ms`
+          );
+          timeout = MAX_TIMEOUT;
+        }
         clearAllTimers();
 
         const refreshTimeStr = new Date(

--- a/packages/web-js-sdk/test/testUtils.ts
+++ b/packages/web-js-sdk/test/testUtils.ts
@@ -19,9 +19,10 @@ export const createMockReturnValue = (data: any) => {
   return ret;
 };
 
-export const getFutureSessionToken = () => {
-  // create a token that expires in 1 hour
+// create a token that expires in the future
+// default is 1 hour
+export const getFutureSessionToken = (seconds = 60 * 60) => {
   return `{}.${window.btoa(
-    JSON.stringify({ exp: Math.floor(Date.now() / 1000) + 60 * 60 })
+    JSON.stringify({ exp: Math.floor(Date.now() / 1000) + seconds })
   )}.`;
 };


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/4292



## Description
when session expiration is above 24.8 days - setTimeout will fire immediately - resulting a loop of refresh where eventually it will result 429

see more details in https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#maximum_delay_value


the solution here is to limit upper session with that upper bound 

here is where session expiration is 30 days
<img width="1887" alt="Descope WC demo app 2023-10-02 19-10-43" src="https://github.com/descope/descope-js/assets/10514677/04ad0405-f174-4327-be93-076bd110d615">
