### PR TITLE
feat: support also custom oauth providers

### DIFF
--- a/packages/core-js-sdk/src/sdk/oauth/index.ts
+++ b/packages/core-js-sdk/src/sdk/oauth/index.ts
@@ -7,24 +7,14 @@ import { stringNonEmpty, withValidations } from '../validations';
 
 const withExchangeValidations = withValidations(stringNonEmpty('code'));
 const withOauth = (httpClient: HttpClient) => ({
-  start: Object.assign((provider: string, redirectUrl?: string, loginOptions?: LoginOptions, token?: string) => {
-    return transformResponse(
-      httpClient.post(apiPaths.oauth.start, loginOptions || {}, {
-        queryParams: {
-          provider,
-          ...(redirectUrl && { redirectURL: redirectUrl }),
-        },
-        token,
-      })
-    );
-  }, Object.keys(OAuthProviders).reduce(
-    (acc, provider) => ({
-      ...acc,
-      [provider]: (
-        redirectUrl?: string,
-        loginOptions?: LoginOptions,
-        token?: string
-      ) => transformResponse(
+  start: Object.assign(
+    (
+      provider: string,
+      redirectUrl?: string,
+      loginOptions?: LoginOptions,
+      token?: string
+    ) => {
+      return transformResponse(
         httpClient.post(apiPaths.oauth.start, loginOptions || {}, {
           queryParams: {
             provider,
@@ -32,12 +22,32 @@ const withOauth = (httpClient: HttpClient) => ({
           },
           token,
         })
-      ),
-    }),
-    {}
-  ) as Oauth['start']),
+      );
+    },
+    Object.keys(OAuthProviders).reduce(
+      (acc, provider) => ({
+        ...acc,
+        [provider]: (
+          redirectUrl?: string,
+          loginOptions?: LoginOptions,
+          token?: string
+        ) =>
+          transformResponse(
+            httpClient.post(apiPaths.oauth.start, loginOptions || {}, {
+              queryParams: {
+                provider,
+                ...(redirectUrl && { redirectURL: redirectUrl }),
+              },
+              token,
+            })
+          ),
+      }),
+      {}
+    ) as Oauth['start']
+  ),
   exchange: withExchangeValidations(
-    (code: string): Promise<SdkResponse<JWTResponse>> => transformResponse(httpClient.post(apiPaths.oauth.exchange, { code }))
+    (code: string): Promise<SdkResponse<JWTResponse>> =>
+      transformResponse(httpClient.post(apiPaths.oauth.exchange, { code }))
   ),
 });
 

--- a/packages/core-js-sdk/src/sdk/oauth/types.ts
+++ b/packages/core-js-sdk/src/sdk/oauth/types.ts
@@ -1,4 +1,4 @@
-import { SdkResponse, URLResponse, JWTResponse } from '../types';
+import { SdkResponse, URLResponse, JWTResponse, LoginOptions } from '../types';
 
 enum OAuthProviders {
   facebook = 'facebook',
@@ -11,13 +11,14 @@ enum OAuthProviders {
   linkedin = 'linkedin',
 }
 
-type StartFn = <B extends { redirect: boolean }>(
-  redirectURL?: string,
-  config?: B
-) => Promise<SdkResponse<URLResponse>>;
 type VerifyFn = (code: string) => Promise<SdkResponse<JWTResponse>>;
+export type StartFn = (
+  redirectURL?: string,
+  loginOptions?: LoginOptions,
+  token?: string
+) => Promise<SdkResponse<URLResponse>>;
 
-type Providers<T> = Record<keyof typeof OAuthProviders, T>;
+export type Providers<T> = Record<keyof typeof OAuthProviders, T>;
 
 export type Oauth = {
   start: Providers<StartFn>;
@@ -25,3 +26,4 @@ export type Oauth = {
 };
 
 export { OAuthProviders };
+

--- a/packages/core-js-sdk/src/sdk/oauth/types.ts
+++ b/packages/core-js-sdk/src/sdk/oauth/types.ts
@@ -9,6 +9,7 @@ enum OAuthProviders {
   apple = 'apple',
   discord = 'discord',
   linkedin = 'linkedin',
+  slack = 'slack',
 }
 
 type VerifyFn = (code: string) => Promise<SdkResponse<JWTResponse>>;
@@ -26,4 +27,3 @@ export type Oauth = {
 };
 
 export { OAuthProviders };
-

--- a/packages/core-js-sdk/test/sdk/oauth.test.ts
+++ b/packages/core-js-sdk/test/sdk/oauth.test.ts
@@ -55,6 +55,20 @@ describe('oauth', () => {
       );
     });
 
+    it('should run start with provider name', () => {
+      sdk.oauth.start('test', 'http://redirecturl.com/');
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        apiPaths.oauth.start,
+        {},
+        {
+          queryParams: {
+            provider: 'test',
+            redirectURL: 'http://redirecturl.com/',
+          },
+        }
+      );
+    });
+
     it('should override the redirect url when provided and login options', () => {
       sdk.oauth.start.facebook(
         'http://redirecturl.com/',


### PR DESCRIPTION
## Related Issues

Related to https://github.com/descope/etc/issues/4097

## Description

Support the ability to set any oauth provider and not only the default ones from a close list. 
This solution supports also backwards for existing usages

## Must

- [x] Tests
- [ ] Documentation (if applicable)
