### PR TITLE
feat: allow caller to omit cookiePolicy

### DIFF
--- a/packages/core-js-sdk/src/createSdk.ts
+++ b/packages/core-js-sdk/src/createSdk.ts
@@ -11,7 +11,7 @@ type SdkConfig = {
   logger?: Logger;
   baseUrl?: string;
   hooks?: Hooks;
-  cookiePolicy?: RequestCredentials;
+  cookiePolicy?: RequestCredentials | null;
   baseHeaders?: HeadersInit;
   fetch?: Fetch;
 };

--- a/packages/core-js-sdk/src/httpClient/types.ts
+++ b/packages/core-js-sdk/src/httpClient/types.ts
@@ -21,12 +21,12 @@ export type HttpClient = {
   post: (
     path: string,
     body?: any,
-    config?: HttpClientReqConfig
+    config?: HttpClientReqConfig,
   ) => Promise<Response>;
   put: (
     path: string,
     body?: any,
-    config?: HttpClientReqConfig
+    config?: HttpClientReqConfig,
   ) => Promise<Response>;
   delete: (path: string, config?: HttpClientReqConfig) => Promise<Response>;
   hooks?: Hooks;
@@ -41,7 +41,7 @@ export type CreateHttpClientConfig = {
   baseConfig?: { baseHeaders: HeadersInit };
   logger?: Logger;
   hooks?: Hooks;
-  cookiePolicy?: RequestCredentials;
+  cookiePolicy?: RequestCredentials | null;
   fetch?: Fetch;
 };
 
@@ -58,7 +58,7 @@ export type RequestConfig = {
 export type BeforeRequest = (config: RequestConfig) => RequestConfig;
 export type AfterRequest = (
   req: RequestConfig,
-  res: Response
+  res: Response,
 ) => void | Promise<void>;
 
 /** Hooks before and after the request is made */

--- a/packages/core-js-sdk/test/httpClient.test.ts
+++ b/packages/core-js-sdk/test/httpClient.test.ts
@@ -53,7 +53,7 @@ describe('httpClient', () => {
           ...descopeHeaders,
         }),
         method: 'GET',
-      }
+      },
     );
   });
 
@@ -69,7 +69,7 @@ describe('httpClient', () => {
         text: expect.any(Function),
         json: expect.any(Function),
         clone: expect.any(Function),
-      })
+      }),
     );
   });
 
@@ -103,7 +103,7 @@ describe('httpClient', () => {
           'x-descope-sdk-version': globalThis.BUILD_VERSION,
         }),
         method: 'GET',
-      }
+      },
     );
   });
 
@@ -132,7 +132,35 @@ describe('httpClient', () => {
           ...descopeHeaders,
         }),
         method: 'GET',
-      }
+      },
+    );
+  });
+
+  it('should omit cookiePolicy when null is provided', () => {
+    const httpClient = createHttpClient({
+      baseUrl: 'http://descope.com',
+      projectId: '456',
+      baseConfig: { baseHeaders: { test: '123' } },
+      cookiePolicy: null,
+    });
+
+    httpClient.get('1/2/3', {
+      headers: { test2: '123' },
+      queryParams: { test2: '123' },
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      new URL('http://descope.com/1/2/3?test2=123&moshe=yakov'),
+      {
+        body: undefined,
+        headers: new Headers({
+          test2: '123',
+          test: '123',
+          Authorization: 'Bearer 456',
+          ...descopeHeaders,
+        }),
+        method: 'GET',
+      },
     );
   });
 
@@ -154,7 +182,7 @@ describe('httpClient', () => {
           ...descopeHeaders,
         }),
         method: 'GET',
-      }
+      },
     );
   });
 
@@ -179,9 +207,9 @@ describe('httpClient', () => {
             ...descopeHeaders,
           }),
           method: method.toUpperCase(),
-        }
+        },
       );
-    }
+    },
   );
 
   it('http delete called with correct parameters', () => {
@@ -203,13 +231,13 @@ describe('httpClient', () => {
           ...descopeHeaders,
         }),
         method: 'delete'.toUpperCase(),
-      }
+      },
     );
   });
 
   it('should not throw when not providing config or logger', () => {
     expect(
-      createHttpClient({ baseUrl: 'http://descope.com', projectId: '456' }).get
+      createHttpClient({ baseUrl: 'http://descope.com', projectId: '456' }).get,
     ).not.toThrow();
   });
 });
@@ -247,7 +275,7 @@ describe('createFetchLogger', () => {
         'Method: POST',
         'Headers: {"test":"123"}',
         'Body: reqBody',
-      ].join('\n')
+      ].join('\n'),
     );
   });
 
@@ -285,7 +313,7 @@ describe('createFetchLogger', () => {
         'Status: 200 OK',
         'Headers: {"header":"header"}',
         'Body: resBody',
-      ].join('\n')
+      ].join('\n'),
     );
   });
 
@@ -323,7 +351,7 @@ describe('createFetchLogger', () => {
         'Status: 200 OK',
         'Headers: {"header":"header"}',
         'Body: resBody',
-      ].join('\n')
+      ].join('\n'),
     );
   });
 


### PR DESCRIPTION
## Description

* On Cloudflare, the `fetch` implementation does not support `credentials`. In this library, we create an http client using a `cookiePolicy` option that is then passed to `fetch`.
* This change allows the caller to pass `cookiePolicy: null` to `createHttpClient`, which will omit the `credentials` option when calling `fetch`. If null is not passed, the previous behavior is preserved.
* See https://github.com/cloudflare/workerd/blob/main/src/workerd/api/http.h#L591 for details on why Cloudflare will not implement `credentials` in their version of `fetch`.

Fixes #338 

## Must

- [x] Tests
