### PR TITLE
fix: change polling to timeout

### DIFF
--- a/packages/web-component/test/descope-wc.test.ts
+++ b/packages/web-component/test/descope-wc.test.ts
@@ -1599,33 +1599,43 @@ describe('web-component', () => {
       jest.useRealTimers();
     });
 
-    it('When action type is "poll" - check that interval is removed properly', async () => {
-      jest.spyOn(global, 'clearInterval');
+    it('Should clear timeout when user clicks a button', async () => {
+      jest.spyOn(global, 'clearTimeout');
 
-      startMock.mockReturnValueOnce(
-        generateSdkResponse({
-          executionId: 'e1',
-          stepId: 's1',
-          screenId: '1',
-          action: RESPONSE_ACTIONS.poll,
-        }),
-      );
+      startMock.mockReturnValueOnce(generateSdkResponse());
+      nextMock.mockReturnValueOnce(generateSdkResponse({ screenId: '1' }));
 
-      nextMock.mockReturnValueOnce(generateSdkResponse());
-
-      pageContent = '<div>hey</div>';
+      pageContent =
+        '<descope-button id="submitterId">click</descope-button><span>It works!</span>';
 
       document.body.innerHTML = `<h1>Custom element test</h1> <descope-wc flow-id="otpSignInEmail" project-id="1"></descope-wc>`;
 
       jest.runAllTimers();
 
-      await waitFor(() => expect(clearInterval).toHaveBeenCalled(), {
+      await waitFor(() => screen.findByShadowText('It works!'), {
+        timeout: 10000,
+      });
+
+      fireEvent.click(screen.getByShadowText('click'));
+
+      await waitFor(() =>
+        expect(nextMock).toHaveBeenCalledWith(
+          '0',
+          '0',
+          'submitterId',
+          1,
+          '1.2.3',
+          expect.any(Object),
+        ),
+      );
+
+      await waitFor(() => expect(clearTimeout).toHaveBeenCalled(), {
         timeout: 8000,
       });
     });
 
-    it('When has polling element - next with "polling", and check that interval is set properly', async () => {
-      jest.spyOn(global, 'setInterval');
+    it('When has polling element - next with "polling", and check that timeout is set properly', async () => {
+      jest.spyOn(global, 'setTimeout');
 
       startMock.mockReturnValueOnce(generateSdkResponse());
 
@@ -1642,7 +1652,7 @@ describe('web-component', () => {
 
       await waitFor(
         () =>
-          expect(setInterval).toHaveBeenCalledWith(expect.any(Function), 2000),
+          expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 2000),
         {
           timeout: WAIT_TIMEOUT,
         },
@@ -1707,7 +1717,7 @@ describe('web-component', () => {
     });
 
     it('When has polling element, and next poll returns polling response', async () => {
-      jest.spyOn(global, 'setInterval');
+      jest.spyOn(global, 'setTimeout');
 
       startMock.mockReturnValueOnce(generateSdkResponse());
 
@@ -1728,7 +1738,7 @@ describe('web-component', () => {
     });
 
     it('When has polling element, and next poll returns completed response', async () => {
-      jest.spyOn(global, 'setInterval');
+      jest.spyOn(global, 'setTimeout');
 
       startMock.mockReturnValueOnce(generateSdkResponse());
 


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/3844

## Description
(instead of https://github.com/descope/descope-js/pull/257)
changing the mechanism to timeout based rather then interval based

tested "short polling" (screen/end after polling) and "long polling" (connector action with 2 secs timeout) on both EL and ML