### PR TITLE
fix: Change persist-tokens hook to always add token (if exists) t http requests

### DIFF
--- a/packages/web-component/src/lib/descope-wc/BaseDescopeWc.ts
+++ b/packages/web-component/src/lib/descope-wc/BaseDescopeWc.ts
@@ -269,8 +269,6 @@ class BaseDescopeWc extends HTMLElement {
 
   #createSdk(projectId: string, baseUrl: string) {
     this.sdk = createSdk({
-      // Use persist tokens options in order to add existing tokens in outgoing requests (if they exists)
-      persistTokens: true,
       preview: this.preview,
       storagePrefix: this.storagePrefix,
       ...BaseDescopeWc.sdkConfigOverrides,

--- a/packages/web-js-sdk/README.md
+++ b/packages/web-js-sdk/README.md
@@ -22,7 +22,9 @@ const sdk = descopeSdk({
   projectId: myProjectId,
   /* Persist tokens that returned after successful authentication (e.g. sdk.otp.verify.email(...),
   sdk.refresh(...), flow.next(...), etc.) in browser storage. In addition, this will
-  make `sdk.getSessionToken()` available, see usage bellow bellow */
+  make `sdk.getSessionToken()` available, see usage bellow bellow.
+  Note: Tokens stored in the browser are automatically added to requests, regardless of the persistTokens value.
+  */
   persistTokens: true,
   /* Pass `sessionTokenViaCookie: true` to store the session token in a cookie when using `persistTokens`. By default, the sdk will set the session token in the browser storage.
   Notes:


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/5319


## Description
change web-js-sdk to always send the token if it exists

like mentioned in the issue, someone may rely on the fact that the token is also in the local storage\
so we should document it clearly in RN that this may break existing code that relies on the previous buggy behavior (I don't want to bump major for this bug though)

