### PR TITLE
chore: trying to improve flow loading time

### DIFF
--- a/packages/libs/sdk-mixins/src/mixins/debuggerMixin/debugger-wc.ts
+++ b/packages/libs/sdk-mixins/src/mixins/debuggerMixin/debugger-wc.ts
@@ -255,5 +255,8 @@ class Debugger extends HTMLElement {
   }
 }
 
-customElements.define('descope-debugger', Debugger);
+if (!customElements.get('descope-debugger')) {
+  customElements.define('descope-debugger', Debugger);
+}
+
 export default Debugger;

--- a/packages/web-component/src/app/index.html
+++ b/packages/web-component/src/app/index.html
@@ -44,6 +44,7 @@
         locale="<locale>"
         debug="true"
       ></descope-wc>
+      <div class="loading">Loading ...</div>
     </div>
     <script>
       // Translate or modify the error as needed
@@ -62,6 +63,12 @@
       descopeWcEle.addEventListener('success', (e) =>
         alert(`Success! - ${JSON.stringify(e.detail)}`),
       );
+      descopeWcEle.addEventListener('ready', () => {
+        // Remove/hide loading
+        document.querySelector('.loading')?.remove();
+        // Alternatively, it can be hidden. For example:
+        // document.querySelector('.loading')?.style.display = 'none';
+      });
     </script>
   </body>
 </html>

--- a/packages/web-component/src/app/index.html
+++ b/packages/web-component/src/app/index.html
@@ -44,7 +44,6 @@
         locale="<locale>"
         debug="true"
       ></descope-wc>
-      <div class="loading">Loading ...</div>
     </div>
     <script>
       // Translate or modify the error as needed
@@ -63,12 +62,6 @@
       descopeWcEle.addEventListener('success', (e) =>
         alert(`Success! - ${JSON.stringify(e.detail)}`),
       );
-      descopeWcEle.addEventListener('ready', () => {
-        // Remove/hide loading
-        document.querySelector('.loading')?.remove();
-        // Alternatively, it can be hidden. For example:
-        // document.querySelector('.loading')?.style.display = 'none';
-      });
     </script>
   </body>
 </html>

--- a/packages/web-component/src/lib/debugger-wc.ts
+++ b/packages/web-component/src/lib/debugger-wc.ts
@@ -253,5 +253,7 @@ class Debugger extends HTMLElement {
   }
 }
 
-customElements.define('descope-debugger', Debugger);
+if (!customElements.get('descope-debugger')) {
+  customElements.define('descope-debugger', Debugger);
+}
 export default Debugger;

--- a/packages/web-component/test/debugger.test.ts
+++ b/packages/web-component/test/debugger.test.ts
@@ -98,8 +98,8 @@ describe('debugger', () => {
       };
 
       switch (true) {
-        case url.endsWith('theme.css'): {
-          return { ...res, text: () => '' };
+        case url.endsWith('theme.json'): {
+          return { ...res, json: () => ({}) };
         }
         case url.endsWith('.html'): {
           return { ...res, text: () => pageContent };


### PR DESCRIPTION
related: https://github.com/descope/etc/issues/5847

I changed the loading order, now the theme is fetched without waiting for the config
should be slightly better but I don't see how we can improve it a lot by changing the code

2 points to take in consideration:
- Their login flow do not have the first page optimization
- We are preventing browser cache for static.descope resources
