### PR TITLE
fix: Replace URL building with string based operations

### DIFF
--- a/packages/core-js-sdk/src/httpClient/urlBuilder.ts
+++ b/packages/core-js-sdk/src/httpClient/urlBuilder.ts
@@ -1,6 +1,8 @@
 import { BASE_URL_REGION_PLACEHOLDER } from '../constants';
 import { pathJoin } from '../sdk/helpers';
 
+const schemeSeparator = '://';
+
 /** Build URL with given parts */
 export const urlBuilder = ({
   path,
@@ -10,17 +12,40 @@ export const urlBuilder = ({
 }: {
   path: string;
   baseUrl: string;
-  queryParams: ConstructorParameters<typeof URLSearchParams>[0];
+  queryParams?: { [key: string]: string };
   projectId: string;
 }) => {
+  // NOTE: many URL and URLSearchParams functions and fields are NOT SUPPORTED by the react-native runtime
+  // Do not replace unless testing with all of the core-dependent projects
   const region = projectId.slice(1, -27);
   baseUrl = baseUrl.replace(
     BASE_URL_REGION_PLACEHOLDER,
     region ? region + '.' : '',
   );
-  const url = new URL(baseUrl);
-  url.pathname = pathJoin(url.pathname, path);
-  if (queryParams) url.search = new URLSearchParams(queryParams).toString();
+  // extract scheme and host from base URL
+  const schemeEndIndex =
+    baseUrl.indexOf(schemeSeparator) + schemeSeparator.length;
+  let firstSlashIndex = baseUrl.substring(schemeEndIndex).indexOf('/');
+  if (firstSlashIndex === -1) firstSlashIndex = baseUrl.length;
+  const schemeAndHost = baseUrl.substring(0, firstSlashIndex);
 
-  return url;
+  // extract a path from the base URL if one exists and append the given path
+  let pathname = baseUrl.substring(firstSlashIndex, baseUrl.length);
+  pathname = pathJoin(pathname, path);
+
+  // join them back together
+  let url = `${schemeAndHost}${pathname}`;
+
+  // add query params if given
+  if (queryParams) {
+    url = `${url}?`;
+    const keys = Object.keys(queryParams);
+    keys.forEach((key: string, index: number) => {
+      url = `${url}${key}=${queryParams[key]}${
+        index === keys.length - 1 ? '' : '&'
+      }`;
+    });
+  }
+
+  return new URL(url);
 };

--- a/packages/core-js-sdk/test/httpClient.test.ts
+++ b/packages/core-js-sdk/test/httpClient.test.ts
@@ -57,6 +57,28 @@ describe('httpClient', () => {
     );
   });
 
+  it('should call fetch with multiple params when calling "get"', () => {
+    httpClient.get('1/2/3', {
+      headers: { test2: '123' },
+      queryParams: { test2: '123', test3: '456', test4: '789' },
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      new URL('http://descope.com/1/2/3?test2=123&test3=456&test4=789'),
+      {
+        body: undefined,
+        credentials: 'include',
+        headers: new Headers({
+          test2: '123',
+          test: '123',
+          Authorization: 'Bearer 456',
+          ...descopeHeaders,
+        }),
+        method: 'GET',
+      },
+    );
+  });
+
   it('should call the "afterHook"', async () => {
     await hookedHttpClient.post('1/2/3', {
       headers: { test2: '123' },


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/6428

## Description

The React-Native runtime doesn't support most of the `URL` and `URLSearchParams` fields and functionality.
The URL building function was replaced with a string-based approach supported by all.

## Must

- [x] Tests
- [ ] Documentation (if applicable)
