### PR TITLE
Transform resp hook

### DIFF
--- a/packages/core-js-sdk/src/createSdk.ts
+++ b/packages/core-js-sdk/src/createSdk.ts
@@ -29,6 +29,7 @@ const withMultipleHooks =
       hooks?: {
         beforeRequest?: BeforeRequest | BeforeRequest[];
         afterRequest?: AfterRequest | AfterRequest[];
+        transformResponse?: Hooks['transformResponse'];
       };
     },
   ) => {
@@ -53,7 +54,14 @@ const withMultipleHooks =
       );
     };
 
-    return createSdk({ ...config, hooks: { beforeRequest, afterRequest } });
+    return createSdk({
+      ...config,
+      hooks: {
+        beforeRequest,
+        afterRequest,
+        transformResponse: config.hooks?.transformResponse,
+      },
+    });
   };
 
 /** Descope SDK client */

--- a/packages/core-js-sdk/src/httpClient/helpers/index.ts
+++ b/packages/core-js-sdk/src/httpClient/helpers/index.ts
@@ -1,1 +1,14 @@
 export { default as createFetchLogger } from './createFetchLogger';
+
+export function transformSetCookie(setCookieHeader: string) {
+  // Split the header by semicolons to separate different attributes
+  var cookiesString = setCookieHeader.split(';');
+
+  return cookiesString.reduce((acc, cookie) => {
+    const [key, value] = cookie.split('=');
+    return {
+      ...acc,
+      [key.trim()]: value,
+    };
+  }, {});
+}

--- a/packages/core-js-sdk/src/httpClient/index.ts
+++ b/packages/core-js-sdk/src/httpClient/index.ts
@@ -1,3 +1,4 @@
+import { transformSetCookie } from './helpers';
 import createFetchLogger from './helpers/createFetchLogger';
 import {
   CreateHttpClientConfig,
@@ -83,6 +84,19 @@ const createHttpClient = ({
 
     if (hooks?.afterRequest) {
       await hooks.afterRequest(config, res?.clone());
+    }
+
+    if (hooks.transformResponse) {
+      // we want to make sure cloning the response will keep the transformed json data
+      const hookResponse = res?.clone();
+      const json = await res.json();
+      const cookies = transformSetCookie(res.headers.get('set-cookie'));
+      return hooks.transformResponse({
+        ...res,
+        clone: () => hookResponse,
+        json: () => Promise.resolve(json),
+        cookies,
+      });
     }
 
     return res;

--- a/packages/core-js-sdk/src/httpClient/index.ts
+++ b/packages/core-js-sdk/src/httpClient/index.ts
@@ -86,17 +86,17 @@ const createHttpClient = ({
       await hooks.afterRequest(config, res?.clone());
     }
 
-    if (hooks.transformResponse) {
+    if (hooks?.transformResponse) {
       // we want to make sure cloning the response will keep the transformed json data
-      const hookResponse = res?.clone();
       const json = await res.json();
-      const cookies = transformSetCookie(res.headers.get('set-cookie'));
-      return hooks.transformResponse({
+      const cookies = transformSetCookie(res.headers?.get('set-cookie') || '');
+      const mutableResponse = {
         ...res,
-        clone: () => hookResponse,
         json: () => Promise.resolve(json),
         cookies,
-      });
+      };
+      mutableResponse.clone = () => mutableResponse;
+      return hooks.transformResponse(mutableResponse);
     }
 
     return res;

--- a/packages/core-js-sdk/src/httpClient/types.ts
+++ b/packages/core-js-sdk/src/httpClient/types.ts
@@ -7,6 +7,8 @@ type HttpClientReqConfig = {
   token?: string;
 };
 
+export type ExtendedResponse = Response & { cookies: Record<string, string> };
+
 /** HTTP methods we use in the client */
 export enum HTTPMethods {
   get = 'GET',
@@ -56,6 +58,7 @@ export type RequestConfig = {
 };
 
 export type BeforeRequest = (config: RequestConfig) => RequestConfig;
+
 export type AfterRequest = (
   req: RequestConfig,
   res: Response,
@@ -65,4 +68,7 @@ export type AfterRequest = (
 export type Hooks = {
   beforeRequest?: BeforeRequest;
   afterRequest?: AfterRequest;
+  transformResponse?: (
+    mutableResponse: ExtendedResponse,
+  ) => Promise<ExtendedResponse>;
 };

--- a/packages/core-js-sdk/src/httpClient/urlBuilder.ts
+++ b/packages/core-js-sdk/src/httpClient/urlBuilder.ts
@@ -1,7 +1,4 @@
 import { BASE_URL_REGION_PLACEHOLDER } from '../constants';
-import { pathJoin } from '../sdk/helpers';
-
-const schemeSeparator = '://';
 
 /** Build URL with given parts */
 export const urlBuilder = ({
@@ -15,26 +12,19 @@ export const urlBuilder = ({
   queryParams?: { [key: string]: string };
   projectId: string;
 }) => {
-  // NOTE: many URL and URLSearchParams functions and fields are NOT SUPPORTED by the react-native runtime
+  // NOTE: many URL and URLSearchParams functions and fields are NOT SUPPORTED by the react-native runtime.
+  // To add insult to injury - it adds a trailing slash almost no matter what the input is:
+  // https://github.com/facebook/react-native/blob/main/packages/react-native/Libraries/Blob/URL.js#L144
   // Do not replace unless testing with all of the core-dependent projects
   const region = projectId.slice(1, -27);
   baseUrl = baseUrl.replace(
-    BASE_URL_REGION_PLACEHOLDER,
+    BASE_URL_REGION_PLACEHOLDER + '.',
     region ? region + '.' : '',
   );
-  // extract scheme and host from base URL
-  const schemeEndIndex =
-    baseUrl.indexOf(schemeSeparator) + schemeSeparator.length;
-  let firstSlashIndex = baseUrl.substring(schemeEndIndex).indexOf('/');
-  if (firstSlashIndex === -1) firstSlashIndex = baseUrl.length;
-  const schemeAndHost = baseUrl.substring(0, firstSlashIndex);
-
-  // extract a path from the base URL if one exists and append the given path
-  let pathname = baseUrl.substring(firstSlashIndex, baseUrl.length);
-  pathname = pathJoin(pathname, path);
-
-  // join them back together
-  let url = `${schemeAndHost}${pathname}`;
+  // append path to base
+  let url = path
+    ? `${baseUrl.replace(/\/$/, '')}/${path?.replace(/^\//, '')}`
+    : baseUrl;
 
   // add query params if given
   if (queryParams) {
@@ -47,5 +37,5 @@ export const urlBuilder = ({
     });
   }
 
-  return new URL(url);
+  return url;
 };

--- a/packages/core-js-sdk/test/httpClient.test.ts
+++ b/packages/core-js-sdk/test/httpClient.test.ts
@@ -58,7 +58,7 @@ describe('httpClient', () => {
     });
 
     expect(mockFetch).toHaveBeenCalledWith(
-      new URL('http://descope.com/1/2/3?test2=123'),
+      'http://descope.com/1/2/3?test2=123',
       {
         body: undefined,
         credentials: 'include',
@@ -80,7 +80,7 @@ describe('httpClient', () => {
     });
 
     expect(mockFetch).toHaveBeenCalledWith(
-      new URL('http://descope.com/1/2/3?test2=123&test3=456&test4=789'),
+      'http://descope.com/1/2/3?test2=123&test3=456&test4=789',
       {
         body: undefined,
         credentials: 'include',
@@ -129,7 +129,7 @@ describe('httpClient', () => {
     });
 
     expect(mockFetch).toHaveBeenCalledWith(
-      new URL('http://descope.com/1/2/3?test2=123&moshe=yakov'),
+      'http://descope.com/1/2/3?test2=123&moshe=yakov',
       {
         body: undefined,
         credentials: 'include',
@@ -155,11 +155,11 @@ describe('httpClient', () => {
 
     httpClient.get('1/2/3', {
       headers: { test2: '123' },
-      queryParams: { test2: '123' },
+      queryParams: { test2: '123', moshe: 'yakov' },
     });
 
     expect(mockFetch).toHaveBeenCalledWith(
-      new URL('http://descope.com/1/2/3?test2=123&moshe=yakov'),
+      'http://descope.com/1/2/3?test2=123&moshe=yakov',
       {
         body: undefined,
         credentials: 'same-origin',
@@ -188,7 +188,7 @@ describe('httpClient', () => {
     });
 
     expect(mockFetch).toHaveBeenCalledWith(
-      new URL('http://descope.com/1/2/3?test2=123&moshe=yakov'),
+      'http://descope.com/1/2/3?test2=123',
       {
         body: undefined,
         headers: new Headers({
@@ -210,18 +210,15 @@ describe('httpClient', () => {
 
     httpClient.get('1/2/3', { token: null });
 
-    expect(mockFetch).toHaveBeenCalledWith(
-      new URL('http://descope.com/1/2/3'),
-      {
-        body: undefined,
-        credentials: 'include',
-        headers: new Headers({
-          Authorization: 'Bearer 456',
-          ...descopeHeaders,
-        }),
-        method: 'GET',
-      },
-    );
+    expect(mockFetch).toHaveBeenCalledWith('http://descope.com/1/2/3', {
+      body: undefined,
+      credentials: 'include',
+      headers: new Headers({
+        Authorization: 'Bearer 456',
+        ...descopeHeaders,
+      }),
+      method: 'GET',
+    });
   });
 
   it.each(['post', 'put'])(
@@ -234,7 +231,7 @@ describe('httpClient', () => {
       });
 
       expect(mockFetch).toHaveBeenCalledWith(
-        new URL('http://descope.com/1/2/3?test2=123'),
+        'http://descope.com/1/2/3?test2=123',
         {
           body: JSON.stringify('aaa'),
           credentials: 'include',
@@ -258,7 +255,7 @@ describe('httpClient', () => {
     });
 
     expect(mockFetch).toHaveBeenCalledWith(
-      new URL('http://descope.com/1/2/3?test2=123'),
+      'http://descope.com/1/2/3?test2=123',
       {
         body: undefined,
         credentials: 'include',
@@ -288,7 +285,7 @@ describe('httpClient', () => {
     httpClient.get('1/2/3', { token: null });
 
     expect(mockFetch).toHaveBeenCalledWith(
-      new URL('http://api.use1.descope.com/1/2/3'),
+      'http://api.use1.descope.com/1/2/3',
       expect.anything(),
     );
   });
@@ -302,7 +299,7 @@ describe('httpClient', () => {
     httpClient.get('1/2/3', { token: null });
 
     expect(mockFetch).toHaveBeenCalledWith(
-      new URL('http://api.descope.com/1/2/3'),
+      'http://api.descope.com/1/2/3',
       expect.anything(),
     );
   });
@@ -462,7 +459,7 @@ describe('createFetchLogger', () => {
     });
 
     expect(mockFetch).toHaveBeenCalledWith(
-      new URL('http://descope.com/auth/ds/1/2/3?test2=123'),
+      'http://descope.com/auth/ds/1/2/3?test2=123',
       expect.anything(),
     );
   });


### PR DESCRIPTION
## Related Issues

https://github.com/descope/etc/issues/6428
https://github.com/descope/etc/issues/6304

## Description

- Remove `URL` completely as it adds unwanted behavior on react native and gives nothing in return
- Add new hook to allow for global response manipulation. This new hook will be used by the react native SDK

## Must

- [x] Tests
- [x] Documentation (if applicable)
