### PR TITLE
fix: component context override order

### DIFF
--- a/packages/web-component/src/lib/descope-wc/BaseDescopeWc.ts
+++ b/packages/web-component/src/lib/descope-wc/BaseDescopeWc.ts
@@ -411,7 +411,7 @@ class BaseDescopeWc extends HTMLElement {
   }
 
   #handleComponentsContext(e: CustomEvent) {
-    this.#componentsContext = { ...e.detail, ...this.#componentsContext };
+    this.#componentsContext = { ...this.#componentsContext, ...e.detail };
   }
 
   async #applyTheme() {


### PR DESCRIPTION
Related https://github.com/descope/etc/issues/6490
component context now using the latest values received from the components 