### PR TITLE
feat: get auth claims by current tenant if it matches

### DIFF
--- a/packages/core-js-sdk/src/constants/index.ts
+++ b/packages/core-js-sdk/src/constants/index.ts
@@ -7,5 +7,8 @@ export const MIN_POLLING_INTERVAL_MS = 1000; // 1 second
 /** Default maximum time we are willing to wait for the magic-link/enchanted-link/notp to be clicked */
 export const MAX_POLLING_TIMEOUT_MS = 1000 * 60 * 10; // 10 minutes
 
+/**  Descope current tenant claim */
+export const DESCOPE_CURRENT_TENANT_CLAIM = 'dct';
+
 /** API paths to the Descope service */
 export { default as apiPaths } from './apiPaths';

--- a/packages/core-js-sdk/test/sdk/sdk.test.ts
+++ b/packages/core-js-sdk/test/sdk/sdk.test.ts
@@ -108,6 +108,12 @@ describe('sdk', () => {
       },
     };
 
+    const mockNoTenantsToken = {
+      permissions: ['p1', 'p2'],
+      roles: ['r1', 'r2'],
+      dct: 't1',
+    };
+
     it('should return two permissions', () => {
       (jwtDecode as jest.Mock).mockImplementation(() => mock);
       expect(sdk.getJwtPermissions('jwt')).toStrictEqual(['foo', 'bar']);
@@ -134,6 +140,22 @@ describe('sdk', () => {
         'C2EdY4UXXzKPV0EKdZFJbuKKmvtl',
         'C2EdY4UXXzKPV0EKdZFJbuKKmvtm',
       ]);
+    });
+    it('should return current tenant permissions', () => {
+      (jwtDecode as jest.Mock).mockImplementation(() => mockNoTenantsToken);
+      expect(sdk.getJwtPermissions('jwt', 't1')).toStrictEqual(['p1', 'p2']);
+    });
+    it('should return current tenant roles', () => {
+      (jwtDecode as jest.Mock).mockImplementation(() => mockNoTenantsToken);
+      expect(sdk.getJwtRoles('jwt', 't1')).toStrictEqual(['r1', 'r2']);
+    });
+    it('should return empty tenant permissions if tenant does not match', () => {
+      (jwtDecode as jest.Mock).mockImplementation(() => mockNoTenantsToken);
+      expect(sdk.getJwtPermissions('jwt', 't2')).toStrictEqual([]);
+    });
+    it('should return empty tenant roles if tenant does not match', () => {
+      (jwtDecode as jest.Mock).mockImplementation(() => mockNoTenantsToken);
+      expect(sdk.getJwtRoles('jwt', 't2')).toStrictEqual([]);
     });
   });
 


### PR DESCRIPTION


## Description
get auth claims by current tenant for `getJwtPermissions` and `getJwtRoles`

with the following sample code
<img width="1096" alt="image" src="https://github.com/descope/descope-js/assets/10514677/eb877154-fd80-434c-9981-4637d6e1ef46">



and the following jwt
![image](https://github.com/descope/descope-js/assets/10514677/0d3b947c-98e7-4260-985c-46ec061d379e)


here is the result
<img width="408" alt="Screenshot 2024-05-30 at 17 07 05" src="https://github.com/descope/descope-js/assets/10514677/b83ec25f-3c1a-456e-8225-3bc5fb97e020">
