### PR TITLE
fix: Add an explicit empty check in after request for old react native

### DIFF
--- a/packages/core-js-sdk/src/createSdk.ts
+++ b/packages/core-js-sdk/src/createSdk.ts
@@ -44,6 +44,8 @@ const withMultipleHooks =
       // get the after hooks from the config while function is running
       // because the hooks might change after sdk creation
       const afterRequestHooks = [].concat(config.hooks?.afterRequest || []);
+      // do not remove this check - on old versions of react-native it is required
+      if (afterRequestHooks.length == 0) return;
       const results = await Promise.allSettled(
         afterRequestHooks?.map((fn) => fn(req, res?.clone())),
       );


### PR DESCRIPTION
## Related Issues

https://github.com/descope/etc/issues/6918

## Description

Added an empty check for after request hooks for old react-native. It will throw otherwise.

## Must

- [x] Tests
- [x] Documentation (if applicable)
