### PR TITLE
fix: polling timeout when click is response t triggers another polling

### DIFF
--- a/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
+++ b/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
@@ -535,6 +535,11 @@ class DescopeWc extends BaseDescopeWc {
     componentsVersion,
   ) => {
     if (action === RESPONSE_ACTIONS.poll) {
+      // Reset polling, in case it was already set, this may happen
+      // when the user clicks on a button that triggers a polling action
+      // while the polling timeout is already running
+      this.#resetPollingTimeout();
+
       // schedule next polling request for 2 seconds from now
       this.#pollingTimeout = setTimeout(async () => {
         let sdkResp;


### PR DESCRIPTION


## Description
Fix a case when click is response t triggers another polling

tested ML and EL with short and long polling 