### PR TITLE
chore: fix release angular RELEASE

### DIFF
--- a/packages/sdks/angular-sdk/package.json
+++ b/packages/sdks/angular-sdk/package.json
@@ -23,6 +23,9 @@
       "default": "./fesm2022/descope-angular-sdk.mjs"
     }
   },
+  "files": [
+    "dist"
+  ],
   "sideEffects": false,
   "scripts": {
     "ng": "ng",
@@ -30,11 +33,12 @@
     "format-lint": "pretty-quick --staged --ignore-path .gitignore && lint-staged",
     "prebuild": "node scripts/setversion/setversion.js",
     "build": "npm run build:lib && rm -rf ./dist/package.json",
-    "build:lib": "cp package.json ./projects/angular-sdk && ng build angular-sdk",
+    "build:lib": "cp package.json ./projects/angular-sdk && ng build angular-sdk && rm -rf ./projects/angular-sdk/package.json",
     "build:app": "ng build demo-app",
-    "pretest": "cp package.json ./projects/angular-sdk",
     "watch": "ng build --watch --configuration development",
+    "pretest": "cp package.json ./projects/angular-sdk",
     "test": "jest --config jest.config.js",
+    "posttest": "rm -rf ./projects/angular-sdk/package.json",
     "lint": "ng lint",
     "format": "prettier . -w --ignore-path .gitignore",
     "format-check": "prettier . --check --ignore-path .gitignore"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -356,6 +356,8 @@ importers:
         specifier: ^4.5.3
         version: 4.9.5
 
+  packages/libs/sdk-helpers/dist/cjs: {}
+
   packages/libs/sdk-mixins:
     dependencies:
       '@descope/sdk-component-drivers':
@@ -633,130 +635,6 @@ importers:
         specifier: ~0.13.0
         version: 0.13.3
 
-  packages/sdks/angular-sdk/projects/angular-sdk:
-    dependencies:
-      '@descope/access-key-management-widget':
-        specifier: workspace:*
-        version: link:../../../../widgets/access-key-management-widget
-      '@descope/audit-management-widget':
-        specifier: workspace:*
-        version: link:../../../../widgets/audit-management-widget
-      '@descope/core-js-sdk':
-        specifier: workspace:*
-        version: link:../../../core-js-sdk
-      '@descope/role-management-widget':
-        specifier: workspace:*
-        version: link:../../../../widgets/role-management-widget
-      '@descope/user-management-widget':
-        specifier: workspace:*
-        version: link:../../../../widgets/user-management-widget
-      '@descope/user-profile-widget':
-        specifier: workspace:*
-        version: link:../../../../widgets/user-profile-widget
-      '@descope/web-component':
-        specifier: workspace:*
-        version: link:../../../web-component
-      '@descope/web-js-sdk':
-        specifier: workspace:*
-        version: link:../../../web-js-sdk
-      tslib:
-        specifier: ^2.3.0
-        version: 2.6.3
-    devDependencies:
-      '@angular-devkit/build-angular':
-        specifier: ^16.2.6
-        version: 16.2.14(@angular/compiler-cli@16.2.12)(@types/node@20.14.9)(jest-environment-jsdom@29.7.0)(jest@29.7.0)(ng-packagr@16.2.3)(typescript@4.9.3)
-      '@angular-eslint/builder':
-        specifier: 16.3.1
-        version: 16.3.1(eslint@8.57.0)(typescript@4.9.3)
-      '@angular-eslint/eslint-plugin':
-        specifier: 16.3.1
-        version: 16.3.1(eslint@8.57.0)(typescript@4.9.3)
-      '@angular-eslint/eslint-plugin-template':
-        specifier: 16.3.1
-        version: 16.3.1(eslint@8.57.0)(typescript@4.9.3)
-      '@angular-eslint/schematics':
-        specifier: 16.3.1
-        version: 16.3.1(@angular/cli@16.2.14)(eslint@8.57.0)(typescript@4.9.3)
-      '@angular-eslint/template-parser':
-        specifier: 16.3.1
-        version: 16.3.1(eslint@8.57.0)(typescript@4.9.3)
-      '@angular/animations':
-        specifier: ^16.2.9
-        version: 16.2.12(@angular/core@16.2.12)
-      '@angular/cli':
-        specifier: ^16.2.6
-        version: 16.2.14
-      '@angular/common':
-        specifier: ^16.2.9
-        version: 16.2.12(@angular/core@16.2.12)(rxjs@7.8.1)
-      '@angular/compiler':
-        specifier: ^16.2.9
-        version: 16.2.12(@angular/core@16.2.12)
-      '@angular/compiler-cli':
-        specifier: ^16.2.9
-        version: 16.2.12(@angular/compiler@16.2.12)(typescript@4.9.3)
-      '@angular/core':
-        specifier: ^16.2.9
-        version: 16.2.12(rxjs@7.8.1)(zone.js@0.13.3)
-      '@angular/forms':
-        specifier: ^16.2.9
-        version: 16.2.12(@angular/common@16.2.12)(@angular/core@16.2.12)(@angular/platform-browser@16.2.12)(rxjs@7.8.1)
-      '@angular/platform-browser':
-        specifier: ^16.2.9
-        version: 16.2.12(@angular/animations@16.2.12)(@angular/common@16.2.12)(@angular/core@16.2.12)
-      '@angular/platform-browser-dynamic':
-        specifier: ^16.2.9
-        version: 16.2.12(@angular/common@16.2.12)(@angular/compiler@16.2.12)(@angular/core@16.2.12)(@angular/platform-browser@16.2.12)
-      '@angular/router':
-        specifier: ^16.2.9
-        version: 16.2.12(@angular/common@16.2.12)(@angular/core@16.2.12)(@angular/platform-browser@16.2.12)(rxjs@7.8.1)
-      '@types/jest':
-        specifier: ^29.5.5
-        version: 29.5.12
-      '@typescript-eslint/eslint-plugin':
-        specifier: 6.12.0
-        version: 6.12.0(@typescript-eslint/parser@6.12.0)(eslint@8.57.0)(typescript@4.9.3)
-      '@typescript-eslint/parser':
-        specifier: 6.12.0
-        version: 6.12.0(eslint@8.57.0)(typescript@4.9.3)
-      eslint:
-        specifier: ^8.51.0
-        version: 8.57.0
-      eslint-plugin-prettier:
-        specifier: ^4.2.1
-        version: 4.2.1(eslint-config-prettier@9.1.0)(eslint@8.57.0)(prettier@2.8.8)
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.14.9)(ts-node@10.9.2)
-      jest-preset-angular:
-        specifier: ^13.1.2
-        version: 13.1.6(@angular-devkit/build-angular@16.2.14)(@angular/compiler-cli@16.2.12)(@angular/core@16.2.12)(@angular/platform-browser-dynamic@16.2.12)(@babel/core@7.24.7)(jest@29.7.0)(typescript@4.9.3)
-      lint-staged:
-        specifier: ^15.2.0
-        version: 15.2.7
-      ng-mocks:
-        specifier: ^14.11.0
-        version: 14.13.0(@angular/common@16.2.12)(@angular/core@16.2.12)(@angular/forms@16.2.12)(@angular/platform-browser@16.2.12)
-      ng-packagr:
-        specifier: ^16.2.3
-        version: 16.2.3(@angular/compiler-cli@16.2.12)(tslib@2.6.3)(typescript@4.9.3)
-      prettier:
-        specifier: 2.8.8
-        version: 2.8.8
-      pretty-quick:
-        specifier: ^3.1.3
-        version: 3.3.1(prettier@2.8.8)
-      rxjs:
-        specifier: ~7.8.1
-        version: 7.8.1
-      typescript:
-        specifier: 4.9.3
-        version: 4.9.3
-      zone.js:
-        specifier: ~0.13.0
-        version: 0.13.3
-
   packages/sdks/core-js-sdk:
     dependencies:
       jwt-decode:
@@ -880,6 +758,8 @@ importers:
       typescript:
         specifier: ^4.5.3
         version: 4.9.5
+
+  packages/sdks/core-js-sdk/dist/cjs: {}
 
   packages/sdks/nextjs-sdk:
     dependencies:


### PR DESCRIPTION
The Angular project structure where we have nested packages is very problematic
It requires many workarounds to make it work in a monorepo
I'm not so familiar with Angular ecosystem but we need to check if there is a way to flatten it and have only one package.json

CC @asafshen 