### PR TITLE
feat: Added Private Routes to Next JS SDK

### DIFF
--- a/packages/sdks/nextjs-sdk/README.md
+++ b/packages/sdks/nextjs-sdk/README.md
@@ -140,24 +140,58 @@ import { authMiddleware } from '@descope/nextjs-sdk/server'
 export default authMiddleware({
 	// The Descope project ID to use for authentication
 	// Defaults to process.env.DESCOPE_PROJECT_ID
-	projectId: 'your-descope-project-id'
+	projectId: 'your-descope-project-id',
 
 	// The URL to redirect to if the user is not authenticated
 	// Defaults to process.env.SIGN_IN_ROUTE or '/sign-in' if not provided
 	// NOTE: In case it contains query parameters that exist in the original URL, they will override the original query parameters. e.g. if the original URL is /page?param1=1&param2=2 and the redirect URL is /sign-in?param1=3, the final redirect URL will be /sign-in?param1=3&param2=2
-	redirectUrl?: string
+	redirectUrl?: string,
 
-	// An array of public routes that do not require authentication
-	// In addition to the default public routes:
-	// - process.env.SIGN_IN_ROUTE or /sign-in if not provided
-	// - process.env.SIGN_UP_ROUTE or /sign-up if not provided
-	publicRoutes?: string[]
+	// These are the public and private routes in your app. Read more about how to use these below.
+	publicRoutes?: string[],
+	privateRoutes?: string[]
+	// If you having privateRoutes and publicRoutes defined at the same time, privateRoutes will be ignored.
 })
 
 export const config = {
 	matcher: ['/((?!.+\\.[\\w]+$|_next).*)', '/', '/(api|trpc)(.*)']
 }
 ```
+
+##### Public and Private Route Definitions
+
+- **All routes are private by default.**
+- **`publicRoutes`:** Use this to specify which routes do not require authentication. If specified, only these routes and the default public routes will be public.
+- **`privateRoutes`:** Use this to specify which routes require authentication. If specified, only these routes will be private, and all other routes will be public.
+- **Conflict Handling:** If both `publicRoutes` and `privateRoutes` are provided, `privateRoutes` will be ignored, and a warning will be logged.
+
+This setup ensures that you can clearly define which routes in your application require authentication and which do not, while providing a mechanism to handle potential misconfigurations gracefully.
+
+###### Public Routes
+
+- **Description:** An array of public routes that do not require authentication.
+- **Configuration:** Use `publicRoutes` to specify routes that don't require authentication.
+- **Additional Defaults:** In addition to the routes you specify, the following default public routes are included:
+  - `process.env.SIGN_IN_ROUTE` or `/sign-in` if not provided
+  - `process.env.SIGN_UP_ROUTE` or `/sign-up` if not provided
+- **Example:**
+  ```typescript
+  const options = {
+  	publicRoutes: ['/home', '/about']
+  };
+  ```
+
+###### Private Routes
+
+- **Description:** An array of private routes that require authentication.
+- **Configuration:** Use `privateRoutes` to specify routes that require authentication. All other routes will be considered public.
+- **Conflict Handling:** If both `publicRoutes` and `privateRoutes` are defined at the same time, `privateRoutes` will be ignored, and a warning will be logged.
+- **Example:**
+  ```typescript
+  const options = {
+  	privateRoutes: ['/dashboard', '/profile']
+  };
+  ```
 
 ##### Read session information in server side
 

--- a/packages/sdks/nextjs-sdk/test/server/authMiddleware.test.ts
+++ b/packages/sdks/nextjs-sdk/test/server/authMiddleware.test.ts
@@ -86,9 +86,11 @@ describe('authMiddleware', () => {
 		});
 		const mockReq = createMockNextRequest({ pathname: '/private' });
 
-		await middleware(mockReq);
-		// Expect the middleware not to redirect
-		expect(NextResponse.redirect).not.toHaveBeenCalled();
+		const response = await middleware(mockReq);
+		expect(NextResponse.redirect).toHaveBeenCalledWith(expect.anything());
+		expect(response).toEqual({
+			pathname: DEFAULT_PUBLIC_ROUTES.signIn
+		});
 	});
 
 	it('allows authenticated users for private routes and adds proper headers', async () => {

--- a/packages/sdks/nextjs-sdk/test/server/authMiddleware.test.ts
+++ b/packages/sdks/nextjs-sdk/test/server/authMiddleware.test.ts
@@ -129,11 +129,8 @@ describe('authMiddleware', () => {
 		});
 		const mockReq = createMockNextRequest({ pathname: '/sign-in' });
 
-		const response = await middleware(mockReq);
-		expect(NextResponse.redirect).toHaveBeenCalledWith(expect.anything());
-		expect(response).toEqual({
-			pathname: DEFAULT_PUBLIC_ROUTES.signIn
-		});
+		await middleware(mockReq);
+		expect(NextResponse.redirect).not.toHaveBeenCalled();
 	});
 
 	it('allows unauthenticated users for public routes', async () => {

--- a/packages/sdks/nextjs-sdk/test/server/authMiddleware.test.ts
+++ b/packages/sdks/nextjs-sdk/test/server/authMiddleware.test.ts
@@ -133,15 +133,15 @@ describe('authMiddleware', () => {
 		expect(NextResponse.redirect).not.toHaveBeenCalled();
 	});
 
-	it('allows unauthenticated users for public routes', async () => {
+	it('allows unauthenticated users to hit private route when both public and private routes are defined', async () => {
 		mockValidateJwt.mockRejectedValue(new Error('Invalid JWT'));
 		const middleware = authMiddleware({
-			publicRoutes: ['/sign-in', '/sign-up']
+			publicRoutes: ['/sign-in'],
+			privateRoutes: ['/private']
 		});
-		const mockReq = createMockNextRequest({ pathname: '/sign-in' });
+		const mockReq = createMockNextRequest({ pathname: '/private' });
 
 		await middleware(mockReq);
-		// Expect the middleware not to redirect
 		expect(NextResponse.redirect).not.toHaveBeenCalled();
 	});
 

--- a/packages/sdks/nextjs-sdk/test/server/authMiddleware.test.ts
+++ b/packages/sdks/nextjs-sdk/test/server/authMiddleware.test.ts
@@ -119,13 +119,13 @@ describe('authMiddleware', () => {
 		);
 	});
 
-	it('redirects unauthenticated users for private routes, when public routes and private routes are defined', async () => {
+	it('allows unauthenticated users for public routes when both public and private routes are defined', async () => {
 		mockValidateJwt.mockRejectedValue(new Error('Invalid JWT'));
 		const middleware = authMiddleware({
-			publicRoutes: ['/private'],
+			publicRoutes: ['/sign-in'],
 			privateRoutes: ['/private']
 		});
-		const mockReq = createMockNextRequest({ pathname: '/private' });
+		const mockReq = createMockNextRequest({ pathname: '/sign-in' });
 
 		const response = await middleware(mockReq);
 		expect(NextResponse.redirect).toHaveBeenCalledWith(expect.anything());

--- a/packages/sdks/nextjs-sdk/test/server/authMiddleware.test.ts
+++ b/packages/sdks/nextjs-sdk/test/server/authMiddleware.test.ts
@@ -133,18 +133,6 @@ describe('authMiddleware', () => {
 		expect(NextResponse.redirect).not.toHaveBeenCalled();
 	});
 
-	it('allows unauthenticated users to hit private route when both public and private routes are defined', async () => {
-		mockValidateJwt.mockRejectedValue(new Error('Invalid JWT'));
-		const middleware = authMiddleware({
-			publicRoutes: ['/sign-in'],
-			privateRoutes: ['/private']
-		});
-		const mockReq = createMockNextRequest({ pathname: '/private' });
-
-		await middleware(mockReq);
-		expect(NextResponse.redirect).not.toHaveBeenCalled();
-	});
-
 	it('allows authenticated users for non-public routes and adds proper headers', async () => {
 		// Mock validateJwt to simulate an authenticated user
 		const authInfo = {

--- a/packages/sdks/nextjs-sdk/test/server/authMiddleware.test.ts
+++ b/packages/sdks/nextjs-sdk/test/server/authMiddleware.test.ts
@@ -79,6 +79,73 @@ describe('authMiddleware', () => {
 		expect(NextResponse.redirect).not.toHaveBeenCalled();
 	});
 
+	it('redirects unauthenticated users for private routes', async () => {
+		mockValidateJwt.mockRejectedValue(new Error('Invalid JWT'));
+		const middleware = authMiddleware({
+			privateRoutes: ['/private']
+		});
+		const mockReq = createMockNextRequest({ pathname: '/private' });
+
+		await middleware(mockReq);
+		// Expect the middleware not to redirect
+		expect(NextResponse.redirect).not.toHaveBeenCalled();
+	});
+
+	it('allows authenticated users for private routes and adds proper headers', async () => {
+		// Mock validateJwt to simulate an authenticated user
+		const authInfo = {
+			jwt: 'validJwt',
+			token: { iss: 'project-1', sub: 'user-123' }
+		};
+		mockValidateJwt.mockImplementation(() => authInfo);
+
+		const middleware = authMiddleware({
+			privateRoutes: ['/private']
+		});
+		const mockReq = createMockNextRequest({
+			pathname: '/private',
+			headers: { Authorization: 'Bearer validJwt' }
+		});
+
+		await middleware(mockReq);
+		// Expect no redirect and check if response contains session headers
+		expect(NextResponse.redirect).not.toHaveBeenCalled();
+		expect(NextResponse.next).toHaveBeenCalled();
+
+		const headersArg = (NextResponse.next as any as jest.Mock).mock.lastCall[0]
+			.request.headers;
+		expect(headersArg.get('x-descope-session')).toEqual(
+			Buffer.from(JSON.stringify(authInfo)).toString('base64')
+		);
+	});
+
+	it('redirects unauthenticated users for private routes, when public routes and private routes are defined', async () => {
+		mockValidateJwt.mockRejectedValue(new Error('Invalid JWT'));
+		const middleware = authMiddleware({
+			publicRoutes: ['/private'],
+			privateRoutes: ['/private']
+		});
+		const mockReq = createMockNextRequest({ pathname: '/private' });
+
+		const response = await middleware(mockReq);
+		expect(NextResponse.redirect).toHaveBeenCalledWith(expect.anything());
+		expect(response).toEqual({
+			pathname: DEFAULT_PUBLIC_ROUTES.signIn
+		});
+	});
+
+	it('allows unauthenticated users for public routes', async () => {
+		mockValidateJwt.mockRejectedValue(new Error('Invalid JWT'));
+		const middleware = authMiddleware({
+			publicRoutes: ['/sign-in', '/sign-up']
+		});
+		const mockReq = createMockNextRequest({ pathname: '/sign-in' });
+
+		await middleware(mockReq);
+		// Expect the middleware not to redirect
+		expect(NextResponse.redirect).not.toHaveBeenCalled();
+	});
+
 	it('allows authenticated users for non-public routes and adds proper headers', async () => {
 		// Mock validateJwt to simulate an authenticated user
 		const authInfo = {

--- a/packages/sdks/nextjs-sdk/test/server/authMiddleware.test.ts
+++ b/packages/sdks/nextjs-sdk/test/server/authMiddleware.test.ts
@@ -133,6 +133,21 @@ describe('authMiddleware', () => {
 		expect(NextResponse.redirect).not.toHaveBeenCalled();
 	});
 
+	it('blocks unauthenticated users for private routes when both public and private routes are defined', async () => {
+		mockValidateJwt.mockRejectedValue(new Error('Invalid JWT'));
+		const middleware = authMiddleware({
+			publicRoutes: ['/sign-in'],
+			privateRoutes: ['/private']
+		});
+		const mockReq = createMockNextRequest({ pathname: '/other-route' });
+
+		const response = await middleware(mockReq);
+		expect(NextResponse.redirect).toHaveBeenCalledWith(expect.anything());
+		expect(response).toEqual({
+			pathname: DEFAULT_PUBLIC_ROUTES.signIn
+		});
+	});
+
 	it('allows authenticated users for non-public routes and adds proper headers', async () => {
 		// Mock validateJwt to simulate an authenticated user
 		const authInfo = {


### PR DESCRIPTION
## Related Issues

## Related PRs

| branch       | PR         |
| ------------ | ---------- |
| service a PR | Link to PR |
| service b PR | Link to PR |

## Description

Allow Descoper to define private routes as well as public ones, for sites that are majority public, but have specific private routes.

## Must

- [ ] Tests
- [ ] Documentation (if applicable)
