### PR TITLE
fix: fix multiple fetch user

### DIFF
--- a/packages/sdks/react-sdk/src/components/AuthProvider/AuthProvider.tsx
+++ b/packages/sdks/react-sdk/src/components/AuthProvider/AuthProvider.tsx
@@ -69,6 +69,7 @@ const AuthProvider: FC<IAuthProviderProps> = ({
   }, [sdk]);
 
   const isSessionFetched = useRef(false);
+  const isUserFetched = useRef(false);
 
   const fetchSession = useCallback(() => {
     // We want that the session will fetched only once
@@ -82,6 +83,10 @@ const AuthProvider: FC<IAuthProviderProps> = ({
   }, [sdk]);
 
   const fetchUser = useCallback(() => {
+    // We want that the user will fetched only once
+    if (isUserFetched.current) return;
+    isUserFetched.current = true;
+
     setIsUserLoading(true);
     withValidation(sdk.me)().then(() => {
       setIsUserLoading(false);
@@ -93,6 +98,7 @@ const AuthProvider: FC<IAuthProviderProps> = ({
       fetchUser,
       user,
       isUserLoading,
+      isUserFetched: isUserFetched.current,
       fetchSession,
       session,
       isSessionLoading,
@@ -110,6 +116,7 @@ const AuthProvider: FC<IAuthProviderProps> = ({
       fetchUser,
       user,
       isUserLoading,
+      isUserFetched.current,
       fetchSession,
       session,
       isSessionLoading,

--- a/packages/sdks/react-sdk/src/hooks/useUser.ts
+++ b/packages/sdks/react-sdk/src/hooks/useUser.ts
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import useContext from './useContext';
 
 const useUser = () => {
-  const { user, fetchUser, isUserLoading, session } = useContext();
+  const { user, fetchUser, isUserLoading, session, isUserFetched } = useContext();
   const [isInit, setIsInit] = useState(false); // we want to get the user only in the first time we got a session
 
   // when session should be received, we want the return value of "isUserLoading" to be true starting from the first call
@@ -21,10 +21,10 @@ const useUser = () => {
 
   // we want this to happen before returning a value so we are using "useMemo" and not "useEffect"
   useMemo(() => {
-    if (shouldFetchUser) {
+    if (shouldFetchUser && !isUserFetched) {
       isLoading.current = true;
     }
-  }, [shouldFetchUser]);
+  }, [shouldFetchUser, isUserFetched]);
 
   useEffect(() => {
     if (shouldFetchUser) {

--- a/packages/sdks/react-sdk/src/types.ts
+++ b/packages/sdks/react-sdk/src/types.ts
@@ -81,6 +81,7 @@ export interface IContext {
   fetchUser: () => void;
   user: User;
   isUserLoading: boolean;
+  isUserFetched: boolean;
   fetchSession: () => void;
   session: string;
   isSessionLoading: boolean;


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/7260


## Description
fix multiple fetch user when `useUser` happen multiple times
1. add ref on auth provider
2. consider that ref in hook


(this is similar to to approach that we have in `useSession`)