### PR TITLE
feat: Add support for templateId in LoginOptions and SignUpOptions

### DIFF
--- a/packages/sdks/core-js-sdk/src/sdk/types.ts
+++ b/packages/sdks/core-js-sdk/src/sdk/types.ts
@@ -104,6 +104,7 @@ export type LoginOptions = {
   stepup?: boolean;
   mfa?: boolean;
   customClaims?: Record<string, any>;
+  templateId?: string;
   templateOptions?: TemplateOptions;
 };
 
@@ -115,6 +116,7 @@ export type AccessKeyLoginOptions = {
 /** Sign Up options to be added to the different authentication methods */
 export type SignUpOptions = {
   customClaims?: Record<string, any>;
+  templateId?: string;
   templateOptions?: TemplateOptions;
 };
 

--- a/packages/sdks/core-js-sdk/test/sdk/enchantedLink.test.ts
+++ b/packages/sdks/core-js-sdk/test/sdk/enchantedLink.test.ts
@@ -49,6 +49,7 @@ describe('Enchanted Link', () => {
           name: 'John Doe',
         },
         {
+          templateId: 'bar',
           templateOptions: {
             ble: 'blue',
           },
@@ -61,6 +62,7 @@ describe('Enchanted Link', () => {
           URI: 'http://some.thing.com',
           user: { name: 'John Doe' },
           loginOptions: {
+            templateId: 'bar',
             templateOptions: {
               ble: 'blue',
             },

--- a/packages/sdks/core-js-sdk/test/sdk/otp.test.ts
+++ b/packages/sdks/core-js-sdk/test/sdk/otp.test.ts
@@ -162,6 +162,7 @@ describe('otp', () => {
 
     it('should send the correct request with sign up options', () => {
       sdk.otp.signUpOrIn.email('loginId', {
+        templateId: 'foo',
         templateOptions: {
           ble: 'blue',
         },
@@ -171,6 +172,7 @@ describe('otp', () => {
         {
           loginId: 'loginId',
           loginOptions: {
+            templateId: 'foo',
             templateOptions: {
               ble: 'blue',
             },


### PR DESCRIPTION
## Description
- Add support for `templateId` in `LoginOptions` and `SignUpOptions`

## Must
- [X] Tests
- [X] Documentation (if applicable)
