### PR TITLE
feat: sdk flags for the web-component

### DIFF
--- a/packages/sdks/web-component/src/lib/descope-wc/BaseDescopeWc.ts
+++ b/packages/sdks/web-component/src/lib/descope-wc/BaseDescopeWc.ts
@@ -29,6 +29,7 @@ import {
   DescopeUI,
   ProjectConfiguration,
   FlowConfig,
+  SdkFlags,
 } from '../types';
 import initTemplate from './initTemplate';
 import {
@@ -69,6 +70,8 @@ class BaseDescopeWc extends BaseClass {
       'x-descope-sdk-version': BUILD_VERSION,
     },
   };
+
+  static sdkFlags: SdkFlags = {};
 
   #init = false;
 

--- a/packages/sdks/web-component/src/lib/types.ts
+++ b/packages/sdks/web-component/src/lib/types.ts
@@ -5,6 +5,17 @@ import createSdk from '@descope/web-js-sdk';
 export type SdkConfig = Parameters<typeof createSdk>[0];
 export type Sdk = ReturnType<typeof createSdk>;
 
+// Flags that can be passed to the SDK
+export type SdkFlags = {
+  /**
+   * When enabled, optimizes polling behavior by detecting potential throttling,
+   * especially in iOS browsers when the tab is hidden.
+   * If throttling is detected, the polling timeout is reduced temporarily to maintain responsiveness.
+   * If disabled, polling operates with the default delay without adaptive adjustments.
+   */
+  enablePollingOptimization?: boolean;
+};
+
 export type SdkFlowNext = Sdk['flow']['next'];
 
 export type ComponentsConfig = Record<string, any>;


### PR DESCRIPTION
## Related Issues


## Description
introduce a mechanism to support sdk flags for the web-component

usage:

![image](https://github.com/user-attachments/assets/a63c8bee-7b6d-444a-9804-8fe4cab1f8bd)

for now, I think we can go without adding it to readme, maybe we need to think how to introduce this as a part of each top level package

@shilgapira @nirgur lmk what you think