### PR TITLE
feat: Add nativeResume function and have polling check the current action

### DIFF
--- a/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
+++ b/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
@@ -116,7 +116,7 @@ class DescopeWc extends BaseDescopeWc {
     const response = JSON.parse(payload);
     this.logger.info(`nativeResume received payload of type '${type}'`);
     if (type === 'oauthWeb' || type === 'sso') {
-      let {exchangeCode} = response;
+      let { exchangeCode } = response;
       if (!exchangeCode) {
         const url = new URL(response.url);
         exchangeCode = url.searchParams?.get(URL_CODE_PARAM_NAME);


### PR DESCRIPTION
## Related Issues

https://github.com/descope/etc/issues/5992

## Description

Move native mobile resume logic into web-component sdk, both for Magic Link and OAuth

## Must

- [x] Tests
- [ ] Documentation (if applicable)
