### PR TITLE
feat: Add the revokeOtherSessions attribute in LoginOptions RELEASE

### DIFF
--- a/packages/sdks/core-js-sdk/src/sdk/types.ts
+++ b/packages/sdks/core-js-sdk/src/sdk/types.ts
@@ -103,6 +103,7 @@ export type TemplateOptions = Record<string, string>; // for providing messaging
 export type LoginOptions = {
   stepup?: boolean;
   mfa?: boolean;
+  revokeOtherSessions?: boolean;
   customClaims?: Record<string, any>;
   templateId?: string;
   templateOptions?: TemplateOptions;

--- a/packages/sdks/core-js-sdk/test/sdk/otp.test.ts
+++ b/packages/sdks/core-js-sdk/test/sdk/otp.test.ts
@@ -163,6 +163,7 @@ describe('otp', () => {
     it('should send the correct request with sign up options', () => {
       sdk.otp.signUpOrIn.email('loginId', {
         templateId: 'foo',
+        revokeOtherSessions: true,
         templateOptions: {
           ble: 'blue',
         },
@@ -173,6 +174,7 @@ describe('otp', () => {
           loginId: 'loginId',
           loginOptions: {
             templateId: 'foo',
+            revokeOtherSessions: true,
             templateOptions: {
               ble: 'blue',
             },


### PR DESCRIPTION
## Related Issues

https://github.com/descope/etc/issues/8242


## Description

Add the revokeOtherSessions attribute in LoginOptions.

## Must

- [x] Tests
- [ ] Documentation (if applicable)
