### PR TITLE
fix: update affected projects check in release workflow

### DIFF
--- a/.github/workflows/release-next-react-sdk.yml
+++ b/.github/workflows/release-next-react-sdk.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Check if should run
         id: 'check'
         run: |
-          if $(npx nx show projects --affected --plain | grep -q "react-sdk\|web-component"); then
+          if $(npx nx show projects --affected --base HEAD~1 --head HEAD | grep -q "react-sdk\|web-component"); then
             echo "run=true" >> $GITHUB_OUTPUT
           else
             echo "run=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Related Issues
Fixes https://github.com/descope/etc/issues/8715

## Description
Updated the condition in the release-next-react-sdk workflow to check for affected projects using the correct base and head references. 
This ensures that the workflow accurately determines if the 'react-sdk' or 'web-component' projects are affected by recent changes.
