### PR TITLE
feat: Support eager refresh prop

### DIFF
--- a/packages/sdks/react-sdk/README.md
+++ b/packages/sdks/react-sdk/README.md
@@ -30,6 +30,20 @@ const AppRoot = () => {
       // must be configured (e.g., https://auth.app.example.com)
       // and should be set as the baseUrl property.
       // baseUrl = "https://auth.app.example.com"
+      // Allows to override the base URL that is used to fetch static files
+      // baseStaticUrl? = "https://auth.static.app.example.com"
+      // Determines if tokens will be stored on local storage and can accessed with getToken function
+      // persistTokens={false} // Default is true
+      // If true, session token (jwt) will be stored on cookie. Otherwise, the session token will be stored on local storage and can accessed with getSessionToken function.
+      // Use this option if session token will stay small (less than 1k)
+      // NOTE: Session token can grow, especially in cases of using authorization, or adding custom claims
+      // sessionTokenViaCookie={true}
+      // If true, last authenticated user will be stored on local storage and can accessed with getUser function
+      // storeLastAuthenticatedUser={false} // Default is true
+      // If true, last authenticated user will not be removed after logout
+      // keepLastAuthenticatedUserAfterLogout?: boolean;
+      // If true, session will be refreshed on first useSession call, even if the session is never fetched before
+      // eagerRefreshOnFirstUseSession={false} // Default is true
     >
       <App />
     </AuthProvider>
@@ -600,6 +614,18 @@ const handleUpdateUser = useCallback(() => {
     sdk.refresh();
   });
 }, [sdk]);
+```
+
+### I see a `/refresh` API call failure in my logs
+
+By default, the Descope SDK eagerly attempts to refresh the session when the `useSession` hook is first called regardless the previous logged in state. If you want to disable this behavior, you can set the `eagerRefreshOnFirstUseSession={false}` prop on the `AuthProvider` component. With this property set to `false`, the SDK will only attempt to refresh the session if the user has previously logged in.
+
+Example:
+
+```jsx
+<AuthProvider eagerRefreshOnFirstUseSession={false}>
+  <App />
+</AuthProvider>
 ```
 
 ## Learn More

--- a/packages/sdks/react-sdk/examples/app/index.tsx
+++ b/packages/sdks/react-sdk/examples/app/index.tsx
@@ -13,6 +13,7 @@ root.render(
     <AuthProvider
       projectId={process.env.DESCOPE_PROJECT_ID!}
       baseUrl={process.env.DESCOPE_BASE_URL}
+      eagerRefreshOnFirstUseSession={false}
       baseStaticUrl={process.env.DESCOPE_BASE_STATIC_URL}
     >
       <App />


### PR DESCRIPTION
## Related Issues

https://github.com/descope/etc/issues/2862


## Description
support a property for eager refresh (default is true, like today)
if `eagerRefreshOnFirstUseSession` off, sdk only refresh if user was logged in before

few notes
 - keeping the default behavior as `true` even though imho a sane default is `false`, but we don't want to break backwards
 - lets talk about
    (a) usage of this functionality (AuthProvider vs useSession)
    (a) naming of this prop (`callRefreshIfLoggedIn`?)
 - if we agree on the solution - I'll write tests and implement also in other sdks (vue/angular)