### PR TITLE
fix: handle close timeouts

### DIFF
--- a/packages/sdks/web-js-sdk/src/constants.ts
+++ b/packages/sdks/web-js-sdk/src/constants.ts
@@ -4,3 +4,6 @@ export const IS_BROWSER = typeof window !== 'undefined';
 // Maximum timeout value for setTimeout
 // For more information, refer to https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#maximum_delay_value
 export const MAX_TIMEOUT = Math.pow(2, 31) - 1;
+
+// The amount of time (ms) to trigger the refresh before session expires
+export const REFRESH_THRESHOLD = 20 * 1000; // 20 sec

--- a/packages/sdks/web-js-sdk/src/enhancers/withAutoRefresh/helpers.ts
+++ b/packages/sdks/web-js-sdk/src/enhancers/withAutoRefresh/helpers.ts
@@ -1,9 +1,6 @@
 import { jwtDecode, JwtPayload } from 'jwt-decode';
 import logger from '../helpers/logger';
-import { MAX_TIMEOUT } from '../../constants';
-
-// The amount of time (ms) to trigger the refresh before session expires
-const REFRESH_THRESHOLD = 20 * 1000; // 20 sec
+import { MAX_TIMEOUT, REFRESH_THRESHOLD } from '../../constants';
 
 /**
  * Get the JWT expiration WITHOUT VALIDATING the JWT

--- a/packages/sdks/web-js-sdk/src/enhancers/withAutoRefresh/helpers.ts
+++ b/packages/sdks/web-js-sdk/src/enhancers/withAutoRefresh/helpers.ts
@@ -1,4 +1,9 @@
 import { jwtDecode, JwtPayload } from 'jwt-decode';
+import logger from '../helpers/logger';
+import { MAX_TIMEOUT } from '../../constants';
+
+// The amount of time (ms) to trigger the refresh before session expires
+const REFRESH_THRESHOLD = 20 * 1000; // 20 sec
 
 /**
  * Get the JWT expiration WITHOUT VALIDATING the JWT
@@ -33,4 +38,17 @@ export const createTimerFunctions = () => {
   };
 
   return { clearAllTimers, setTimer };
+};
+
+export const getAutoRefreshTimeout = (sessionExpiration: Date) => {
+  let timeout = millisecondsUntilDate(sessionExpiration) - REFRESH_THRESHOLD;
+
+  if (timeout > MAX_TIMEOUT) {
+    logger.debug(
+      `Timeout is too large (${timeout}ms), setting it to ${MAX_TIMEOUT}ms`,
+    );
+    timeout = MAX_TIMEOUT;
+  }
+
+  return timeout;
 };

--- a/packages/sdks/web-js-sdk/src/enhancers/withAutoRefresh/index.ts
+++ b/packages/sdks/web-js-sdk/src/enhancers/withAutoRefresh/index.ts
@@ -35,7 +35,6 @@ export const withAutoRefresh =
         // tab becomes visible and the session is expired, do a refresh
         if (
           document.visibilityState === 'visible' &&
-          millisecondsUntilDate(sessionExpiration) > REFRESH_THRESHOLD &&
           new Date() > sessionExpiration
         ) {
           logger.debug('Expiration time passed, refreshing session');

--- a/packages/sdks/web-js-sdk/src/enhancers/withAutoRefresh/index.ts
+++ b/packages/sdks/web-js-sdk/src/enhancers/withAutoRefresh/index.ts
@@ -5,15 +5,12 @@ import { addHooks, getAuthInfoFromResponse } from '../helpers';
 import {
   createTimerFunctions,
   getTokenExpiration,
-  millisecondsUntilDate,
+  getAutoRefreshTimeout,
 } from './helpers';
 import { AutoRefreshOptions } from './types';
 import logger from '../helpers/logger';
-import { IS_BROWSER, MAX_TIMEOUT } from '../../constants';
+import { IS_BROWSER } from '../../constants';
 import { getRefreshToken } from '../withPersistTokens/helpers';
-
-// The amount of time (ms) to trigger the refresh before session expires
-const REFRESH_THRESHOLD = 20 * 1000; // 20 sec
 
 /**
  * Automatically refresh the session token before it expires
@@ -62,15 +59,8 @@ export const withAutoRefresh =
           return;
         }
         refreshToken = refreshJwt;
-        let timeout =
-          millisecondsUntilDate(sessionExpiration) - REFRESH_THRESHOLD;
+        const timeout = getAutoRefreshTimeout(sessionExpiration);
 
-        if (timeout > MAX_TIMEOUT) {
-          logger.debug(
-            `Timeout is too large (${timeout}ms), setting it to ${MAX_TIMEOUT}ms`,
-          );
-          timeout = MAX_TIMEOUT;
-        }
         clearAllTimers();
 
         const refreshTimeStr = new Date(

--- a/packages/sdks/web-js-sdk/src/enhancers/withAutoRefresh/index.ts
+++ b/packages/sdks/web-js-sdk/src/enhancers/withAutoRefresh/index.ts
@@ -6,7 +6,6 @@ import {
   createTimerFunctions,
   getTokenExpiration,
   getAutoRefreshTimeout,
-  millisecondsUntilDate,
 } from './helpers';
 import { AutoRefreshOptions } from './types';
 import logger from '../helpers/logger';

--- a/packages/sdks/web-js-sdk/src/enhancers/withAutoRefresh/index.ts
+++ b/packages/sdks/web-js-sdk/src/enhancers/withAutoRefresh/index.ts
@@ -34,6 +34,7 @@ export const withAutoRefresh =
         // tab becomes visible and the session is expired, do a refresh
         if (
           document.visibilityState === 'visible' &&
+          sessionExpiration &&
           new Date() > sessionExpiration
         ) {
           logger.debug('Expiration time passed, refreshing session');
@@ -51,6 +52,7 @@ export const withAutoRefresh =
       // if we got 401 we want to cancel all timers
       if (res?.status === 401) {
         logger.debug('Received 401, canceling all timers');
+        sessionExpiration = null;
         clearAllTimers();
       } else if (sessionJwt) {
         sessionExpiration = getTokenExpiration(sessionJwt);


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/8912
Fixes https://github.com/descope/etc/issues/7424

## Description

handle too close timeouts in the following ways
 - after auth request - if calculated timeout is less than 20 seconds - do not set refresh timeout
 - when window becomes visible - do not refresh if refresh failed  