### PR TITLE
feat: http session cookie

### DIFF
--- a/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/access-key-management/access-key-management.component.spec.ts
+++ b/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/access-key-management/access-key-management.component.spec.ts
@@ -18,8 +18,6 @@ describe('DescopeAccessKeyManagementComponent', () => {
   let component: AccessKeyManagementComponent;
   let fixture: ComponentFixture<AccessKeyManagementComponent>;
   let mockedCreateSdk: jest.Mock;
-  const onSessionTokenChangeSpy = jest.fn();
-  const onIsAuthenticatedChangeSpy = jest.fn();
   const onAccessKeyChangeSpy = jest.fn();
   const afterRequestHooksSpy = jest.fn();
   const mockConfig: DescopeAuthConfig = {
@@ -30,8 +28,6 @@ describe('DescopeAccessKeyManagementComponent', () => {
     mockedCreateSdk = mocked(createSdk);
 
     mockedCreateSdk.mockReturnValue({
-      onSessionTokenChange: onSessionTokenChangeSpy,
-      onIsAuthenticatedChange: onIsAuthenticatedChangeSpy,
       onAccessKeyChange: onAccessKeyChangeSpy,
       httpClient: {
         hooks: {

--- a/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/access-key-management/access-key-management.component.spec.ts
+++ b/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/access-key-management/access-key-management.component.spec.ts
@@ -19,6 +19,7 @@ describe('DescopeAccessKeyManagementComponent', () => {
   let fixture: ComponentFixture<AccessKeyManagementComponent>;
   let mockedCreateSdk: jest.Mock;
   const onSessionTokenChangeSpy = jest.fn();
+  const onIsAuthenticatedChangeSpy = jest.fn();
   const onAccessKeyChangeSpy = jest.fn();
   const afterRequestHooksSpy = jest.fn();
   const mockConfig: DescopeAuthConfig = {
@@ -30,6 +31,7 @@ describe('DescopeAccessKeyManagementComponent', () => {
 
     mockedCreateSdk.mockReturnValue({
       onSessionTokenChange: onSessionTokenChangeSpy,
+      onIsAuthenticatedChange: onIsAuthenticatedChangeSpy,
       onAccessKeyChange: onAccessKeyChangeSpy,
       httpClient: {
         hooks: {

--- a/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/applications-portal/applications-portal.component.spec.ts
+++ b/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/applications-portal/applications-portal.component.spec.ts
@@ -19,6 +19,7 @@ describe('DescopeApplicationsPortalComponent', () => {
   let fixture: ComponentFixture<ApplicationsPortalComponent>;
   let mockedCreateSdk: jest.Mock;
   const onSessionTokenChangeSpy = jest.fn();
+  const onIsAuthenticatedChangeSpy = jest.fn();
   const onAuditChangeSpy = jest.fn();
   const afterRequestHooksSpy = jest.fn();
   const mockConfig: DescopeAuthConfig = {
@@ -30,6 +31,7 @@ describe('DescopeApplicationsPortalComponent', () => {
 
     mockedCreateSdk.mockReturnValue({
       onSessionTokenChange: onSessionTokenChangeSpy,
+      onIsAuthenticatedChange: onIsAuthenticatedChangeSpy,
       onAuditChange: onAuditChangeSpy,
       httpClient: {
         hooks: {

--- a/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/applications-portal/applications-portal.component.spec.ts
+++ b/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/applications-portal/applications-portal.component.spec.ts
@@ -18,9 +18,6 @@ describe('DescopeApplicationsPortalComponent', () => {
   let component: ApplicationsPortalComponent;
   let fixture: ComponentFixture<ApplicationsPortalComponent>;
   let mockedCreateSdk: jest.Mock;
-  const onSessionTokenChangeSpy = jest.fn();
-  const onIsAuthenticatedChangeSpy = jest.fn();
-  const onAuditChangeSpy = jest.fn();
   const afterRequestHooksSpy = jest.fn();
   const mockConfig: DescopeAuthConfig = {
     projectId: 'someProject'
@@ -30,9 +27,6 @@ describe('DescopeApplicationsPortalComponent', () => {
     mockedCreateSdk = mocked(createSdk);
 
     mockedCreateSdk.mockReturnValue({
-      onSessionTokenChange: onSessionTokenChangeSpy,
-      onIsAuthenticatedChange: onIsAuthenticatedChangeSpy,
-      onAuditChange: onAuditChangeSpy,
       httpClient: {
         hooks: {
           afterRequest: afterRequestHooksSpy

--- a/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/audit-management/audit-management.component.spec.ts
+++ b/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/audit-management/audit-management.component.spec.ts
@@ -19,6 +19,7 @@ describe('DescopeAuditManagementComponent', () => {
   let fixture: ComponentFixture<AuditManagementComponent>;
   let mockedCreateSdk: jest.Mock;
   const onSessionTokenChangeSpy = jest.fn();
+  const onIsAuthenticatedChangeSpy = jest.fn();
   const onAuditChangeSpy = jest.fn();
   const afterRequestHooksSpy = jest.fn();
   const mockConfig: DescopeAuthConfig = {
@@ -30,6 +31,7 @@ describe('DescopeAuditManagementComponent', () => {
 
     mockedCreateSdk.mockReturnValue({
       onSessionTokenChange: onSessionTokenChangeSpy,
+      onIsAuthenticatedChange: onIsAuthenticatedChangeSpy,
       onAuditChange: onAuditChangeSpy,
       httpClient: {
         hooks: {

--- a/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/audit-management/audit-management.component.spec.ts
+++ b/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/audit-management/audit-management.component.spec.ts
@@ -18,9 +18,6 @@ describe('DescopeAuditManagementComponent', () => {
   let component: AuditManagementComponent;
   let fixture: ComponentFixture<AuditManagementComponent>;
   let mockedCreateSdk: jest.Mock;
-  const onSessionTokenChangeSpy = jest.fn();
-  const onIsAuthenticatedChangeSpy = jest.fn();
-  const onAuditChangeSpy = jest.fn();
   const afterRequestHooksSpy = jest.fn();
   const mockConfig: DescopeAuthConfig = {
     projectId: 'someProject'
@@ -30,9 +27,6 @@ describe('DescopeAuditManagementComponent', () => {
     mockedCreateSdk = mocked(createSdk);
 
     mockedCreateSdk.mockReturnValue({
-      onSessionTokenChange: onSessionTokenChangeSpy,
-      onIsAuthenticatedChange: onIsAuthenticatedChangeSpy,
-      onAuditChange: onAuditChangeSpy,
       httpClient: {
         hooks: {
           afterRequest: afterRequestHooksSpy

--- a/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/descope/descope.component.spec.ts
+++ b/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/descope/descope.component.spec.ts
@@ -20,6 +20,7 @@ describe('DescopeComponent', () => {
   let fixture: ComponentFixture<DescopeComponent>;
   let mockedCreateSdk: jest.Mock;
   const onSessionTokenChangeSpy = jest.fn();
+  const onIsAuthenticatedChangeSpy = jest.fn();
   const onUserChangeSpy = jest.fn();
   const afterRequestHooksSpy = jest.fn();
   const mockConfig: DescopeAuthConfig = {
@@ -31,6 +32,7 @@ describe('DescopeComponent', () => {
 
     mockedCreateSdk.mockReturnValue({
       onSessionTokenChange: onSessionTokenChangeSpy,
+      onIsAuthenticatedChange: onIsAuthenticatedChangeSpy,
       onUserChange: onUserChangeSpy,
       httpClient: {
         hooks: {

--- a/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/role-management/role-management.component.spec.ts
+++ b/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/role-management/role-management.component.spec.ts
@@ -18,8 +18,6 @@ describe('DescopeRoleManagementComponent', () => {
   let component: RoleManagementComponent;
   let fixture: ComponentFixture<RoleManagementComponent>;
   let mockedCreateSdk: jest.Mock;
-  const onSessionTokenChangeSpy = jest.fn();
-  const onIsAuthenticatedChangeSpy = jest.fn();
   const onRoleChangeSpy = jest.fn();
   const afterRequestHooksSpy = jest.fn();
   const mockConfig: DescopeAuthConfig = {
@@ -30,8 +28,6 @@ describe('DescopeRoleManagementComponent', () => {
     mockedCreateSdk = mocked(createSdk);
 
     mockedCreateSdk.mockReturnValue({
-      onSessionTokenChange: onSessionTokenChangeSpy,
-      onIsAuthenticatedChange: onIsAuthenticatedChangeSpy,
       onRoleChange: onRoleChangeSpy,
       httpClient: {
         hooks: {

--- a/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/role-management/role-management.component.spec.ts
+++ b/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/role-management/role-management.component.spec.ts
@@ -19,6 +19,7 @@ describe('DescopeRoleManagementComponent', () => {
   let fixture: ComponentFixture<RoleManagementComponent>;
   let mockedCreateSdk: jest.Mock;
   const onSessionTokenChangeSpy = jest.fn();
+  const onIsAuthenticatedChangeSpy = jest.fn();
   const onRoleChangeSpy = jest.fn();
   const afterRequestHooksSpy = jest.fn();
   const mockConfig: DescopeAuthConfig = {
@@ -30,6 +31,7 @@ describe('DescopeRoleManagementComponent', () => {
 
     mockedCreateSdk.mockReturnValue({
       onSessionTokenChange: onSessionTokenChangeSpy,
+      onIsAuthenticatedChange: onIsAuthenticatedChangeSpy,
       onRoleChange: onRoleChangeSpy,
       httpClient: {
         hooks: {

--- a/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/sign-in-flow/sign-in-flow.component.spec.ts
+++ b/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/sign-in-flow/sign-in-flow.component.spec.ts
@@ -24,6 +24,7 @@ describe('SignInFlowComponent', () => {
 
     mockedCreateSdk.mockReturnValue({
       onSessionTokenChange: jest.fn(),
+      onIsAuthenticatedChange: jest.fn(),
       onUserChange: jest.fn()
     });
 

--- a/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/sign-up-flow/sign-up-flow.component.spec.ts
+++ b/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/sign-up-flow/sign-up-flow.component.spec.ts
@@ -23,6 +23,7 @@ describe('SignUpFlowComponent', () => {
 
     mockedCreateSdk.mockReturnValue({
       onSessionTokenChange: jest.fn(),
+      onIsAuthenticatedChange: jest.fn(),
       onUserChange: jest.fn()
     });
 

--- a/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/sign-up-or-in-flow/sign-up-or-in-flow.component.spec.ts
+++ b/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/sign-up-or-in-flow/sign-up-or-in-flow.component.spec.ts
@@ -23,6 +23,7 @@ describe('SignUpOrInFlowComponent', () => {
 
     mockedCreateSdk.mockReturnValue({
       onSessionTokenChange: jest.fn(),
+      onIsAuthenticatedChange: jest.fn(),
       onUserChange: jest.fn()
     });
 

--- a/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/user-management/user-management.component.spec.ts
+++ b/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/user-management/user-management.component.spec.ts
@@ -18,8 +18,6 @@ describe('DescopeUserManagementComponent', () => {
   let component: UserManagementComponent;
   let fixture: ComponentFixture<UserManagementComponent>;
   let mockedCreateSdk: jest.Mock;
-  const onSessionTokenChangeSpy = jest.fn();
-  const onIsAuthenticatedChangeSpy = jest.fn();
   const onUserChangeSpy = jest.fn();
   const afterRequestHooksSpy = jest.fn();
   const mockConfig: DescopeAuthConfig = {
@@ -30,8 +28,6 @@ describe('DescopeUserManagementComponent', () => {
     mockedCreateSdk = mocked(createSdk);
 
     mockedCreateSdk.mockReturnValue({
-      onSessionTokenChange: onSessionTokenChangeSpy,
-      onIsAuthenticatedChange: onIsAuthenticatedChangeSpy,
       onUserChange: onUserChangeSpy,
       httpClient: {
         hooks: {

--- a/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/user-management/user-management.component.spec.ts
+++ b/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/user-management/user-management.component.spec.ts
@@ -19,6 +19,7 @@ describe('DescopeUserManagementComponent', () => {
   let fixture: ComponentFixture<UserManagementComponent>;
   let mockedCreateSdk: jest.Mock;
   const onSessionTokenChangeSpy = jest.fn();
+  const onIsAuthenticatedChangeSpy = jest.fn();
   const onUserChangeSpy = jest.fn();
   const afterRequestHooksSpy = jest.fn();
   const mockConfig: DescopeAuthConfig = {
@@ -30,6 +31,7 @@ describe('DescopeUserManagementComponent', () => {
 
     mockedCreateSdk.mockReturnValue({
       onSessionTokenChange: onSessionTokenChangeSpy,
+      onIsAuthenticatedChange: onIsAuthenticatedChangeSpy,
       onUserChange: onUserChangeSpy,
       httpClient: {
         hooks: {

--- a/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/user-profile/user-profile.component.spec.ts
+++ b/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/user-profile/user-profile.component.spec.ts
@@ -19,6 +19,7 @@ describe('DescopeUserProfileComponent', () => {
   let fixture: ComponentFixture<UserProfileComponent>;
   let mockedCreateSdk: jest.Mock;
   const onSessionTokenChangeSpy = jest.fn();
+  const onIsAuthenticatedChangeSpy = jest.fn();
   const onAuditChangeSpy = jest.fn();
   const afterRequestHooksSpy = jest.fn();
   const mockConfig: DescopeAuthConfig = {
@@ -30,6 +31,7 @@ describe('DescopeUserProfileComponent', () => {
 
     mockedCreateSdk.mockReturnValue({
       onSessionTokenChange: onSessionTokenChangeSpy,
+      onIsAuthenticatedChange: onIsAuthenticatedChangeSpy,
       onAuditChange: onAuditChangeSpy,
       httpClient: {
         hooks: {

--- a/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/user-profile/user-profile.component.spec.ts
+++ b/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/user-profile/user-profile.component.spec.ts
@@ -18,9 +18,6 @@ describe('DescopeUserProfileComponent', () => {
   let component: UserProfileComponent;
   let fixture: ComponentFixture<UserProfileComponent>;
   let mockedCreateSdk: jest.Mock;
-  const onSessionTokenChangeSpy = jest.fn();
-  const onIsAuthenticatedChangeSpy = jest.fn();
-  const onAuditChangeSpy = jest.fn();
   const afterRequestHooksSpy = jest.fn();
   const mockConfig: DescopeAuthConfig = {
     projectId: 'someProject'
@@ -30,9 +27,6 @@ describe('DescopeUserProfileComponent', () => {
     mockedCreateSdk = mocked(createSdk);
 
     mockedCreateSdk.mockReturnValue({
-      onSessionTokenChange: onSessionTokenChangeSpy,
-      onIsAuthenticatedChange: onIsAuthenticatedChangeSpy,
-      onAuditChange: onAuditChangeSpy,
       httpClient: {
         hooks: {
           afterRequest: afterRequestHooksSpy

--- a/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/services/descope-auth.service.ts
+++ b/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/services/descope-auth.service.ts
@@ -53,8 +53,8 @@ export class DescopeAuthService {
     });
     this.user$ = this.userSubject.asObservable();
     this.descopeSdk.onSessionTokenChange(this.setSession.bind(this));
-    this.descopeSdk.onUserChange(this.setUser.bind(this));
     this.descopeSdk.onIsAuthenticatedChange(this.setIsAuthenticated.bind(this));
+    this.descopeSdk.onUserChange(this.setUser.bind(this));
   }
 
   refreshSession() {
@@ -64,22 +64,6 @@ export class DescopeAuthService {
       isSessionLoading: true
     });
     return this.descopeSdk.refresh().pipe(
-      tap((data) => {
-        const afterRequestSession = this.sessionSubject.value;
-        if (data.ok && data.data) {
-          this.sessionSubject.next({
-            ...afterRequestSession,
-            sessionToken: data.data.sessionJwt,
-            isAuthenticated: !!data.data.sessionJwt
-          });
-        } else {
-          this.sessionSubject.next({
-            ...afterRequestSession,
-            sessionToken: '',
-            isAuthenticated: false
-          });
-        }
-      }),
       finalize(() => {
         const afterRefreshSession = this.sessionSubject.value;
         this.sessionSubject.next({
@@ -186,18 +170,16 @@ export class DescopeAuthService {
   private setSession(sessionToken: string | null) {
     const currentSession = this.sessionSubject.value;
     this.sessionSubject.next({
-      sessionToken,
-      isAuthenticated: currentSession.isAuthenticated,
-      isSessionLoading: currentSession.isSessionLoading
+      ...currentSession,
+      sessionToken
     });
   }
 
   private setIsAuthenticated(isAuthenticated: boolean) {
     const currentSession = this.sessionSubject.value;
     this.sessionSubject.next({
-      sessionToken: currentSession.sessionToken,
-      isAuthenticated,
-      isSessionLoading: currentSession.isSessionLoading
+      ...currentSession,
+      isAuthenticated
     });
   }
 

--- a/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/services/descope-auth.service.ts
+++ b/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/services/descope-auth.service.ts
@@ -54,6 +54,7 @@ export class DescopeAuthService {
     this.user$ = this.userSubject.asObservable();
     this.descopeSdk.onSessionTokenChange(this.setSession.bind(this));
     this.descopeSdk.onUserChange(this.setUser.bind(this));
+    this.descopeSdk.onIsAuthenticatedChange(this.setIsAuthenticated.bind(this));
   }
 
   refreshSession() {
@@ -186,7 +187,16 @@ export class DescopeAuthService {
     const currentSession = this.sessionSubject.value;
     this.sessionSubject.next({
       sessionToken,
-      isAuthenticated: !!sessionToken,
+      isAuthenticated: currentSession.isAuthenticated,
+      isSessionLoading: currentSession.isSessionLoading
+    });
+  }
+
+  private setIsAuthenticated(isAuthenticated: boolean) {
+    const currentSession = this.sessionSubject.value;
+    this.sessionSubject.next({
+      sessionToken: currentSession.sessionToken,
+      isAuthenticated,
       isSessionLoading: currentSession.isSessionLoading
     });
   }

--- a/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/services/descope.interceptor.spec.ts
+++ b/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/services/descope.interceptor.spec.ts
@@ -27,6 +27,7 @@ describe('DescopeInterceptor', () => {
     mockedCreateSdk = mocked(createSdk);
     mockedCreateSdk.mockReturnValue({
       onSessionTokenChange: jest.fn(),
+      onIsAuthenticatedChange: jest.fn(),
       onUserChange: jest.fn()
     });
 
@@ -72,7 +73,12 @@ describe('DescopeInterceptor', () => {
     jest.spyOn(authService, 'getSessionToken').mockReturnValue(null);
     const refreshSessionSpy = jest
       .spyOn(authService, 'refreshSession')
-      .mockReturnValue(of({ ok: true, data: { sessionJwt: 'newToken' } }));
+      .mockReturnValue(
+        of({
+          ok: true,
+          data: { sessionJwt: 'newToken', sessionExpiration: 1663190468 }
+        })
+      );
 
     httpClient.get('/api/data').subscribe();
 

--- a/packages/sdks/angular-sdk/projects/demo-app/src/app/app.component.spec.ts
+++ b/packages/sdks/angular-sdk/projects/demo-app/src/app/app.component.spec.ts
@@ -10,12 +10,14 @@ jest.mock('@descope/web-js-sdk');
 describe('AppComponent', () => {
   let mockedCreateSdk: jest.Mock;
   const onSessionTokenChangeSpy = jest.fn();
+  const onIsAuthenticatedChangeSpy = jest.fn();
   const onUserChangeSpy = jest.fn();
 
   beforeEach(async () => {
     mockedCreateSdk = mocked(createSdk);
     mockedCreateSdk.mockReturnValue({
       onSessionTokenChange: onSessionTokenChangeSpy,
+      onIsAuthenticatedChange: onIsAuthenticatedChangeSpy,
       onUserChange: onUserChangeSpy
     });
 

--- a/packages/sdks/angular-sdk/projects/demo-app/src/app/home/home.component.spec.ts
+++ b/packages/sdks/angular-sdk/projects/demo-app/src/app/home/home.component.spec.ts
@@ -15,12 +15,14 @@ describe('HomeComponent', () => {
 
   let mockedCreateSdk: jest.Mock;
   const onSessionTokenChangeSpy = jest.fn();
+  const onIsAuthenticatedChangeSpy = jest.fn();
   const onUserChangeSpy = jest.fn();
 
   beforeEach(async () => {
     mockedCreateSdk = mocked(createSdk);
     mockedCreateSdk.mockReturnValue({
       onSessionTokenChange: onSessionTokenChangeSpy,
+      onIsAuthenticatedChange: onIsAuthenticatedChangeSpy,
       onUserChange: onUserChangeSpy
     });
 

--- a/packages/sdks/angular-sdk/projects/demo-app/src/app/login/login.component.spec.ts
+++ b/packages/sdks/angular-sdk/projects/demo-app/src/app/login/login.component.spec.ts
@@ -14,12 +14,14 @@ describe('LoginComponent', () => {
 
   let mockedCreateSdk: jest.Mock;
   const onSessionTokenChangeSpy = jest.fn();
+  const onIsAuthenticatedChangeSpy = jest.fn();
   const onUserChangeSpy = jest.fn();
 
   beforeEach(async () => {
     mockedCreateSdk = mocked(createSdk);
     mockedCreateSdk.mockReturnValue({
       onSessionTokenChange: onSessionTokenChangeSpy,
+      onIsAuthenticatedChange: onIsAuthenticatedChangeSpy,
       onUserChange: onUserChangeSpy
     });
 

--- a/packages/sdks/angular-sdk/projects/demo-app/src/app/protected/protected.component.spec.ts
+++ b/packages/sdks/angular-sdk/projects/demo-app/src/app/protected/protected.component.spec.ts
@@ -14,12 +14,14 @@ describe('ProtectedComponent', () => {
 
   let mockedCreateSdk: jest.Mock;
   const onSessionTokenChangeSpy = jest.fn();
+  const onIsAuthenticatedChangeSpy = jest.fn();
   const onUserChangeSpy = jest.fn();
 
   beforeEach(async () => {
     mockedCreateSdk = mocked(createSdk);
     mockedCreateSdk.mockReturnValue({
       onSessionTokenChange: onSessionTokenChangeSpy,
+      onIsAuthenticatedChange: onIsAuthenticatedChangeSpy,
       onUserChange: onUserChangeSpy
     });
 

--- a/packages/sdks/core-js-sdk/src/sdk/types.ts
+++ b/packages/sdks/core-js-sdk/src/sdk/types.ts
@@ -132,6 +132,7 @@ export type JWTResponse = {
   cookieExpiration?: number;
   user?: UserResponse;
   firstSeen?: boolean;
+  sessionExpiration: number;
 };
 
 /** Authentication info result from exchanging access keys for a session */

--- a/packages/sdks/react-sdk/README.md
+++ b/packages/sdks/react-sdk/README.md
@@ -251,6 +251,7 @@ const App = () => {
   // NOTE - `useDescope`, `useSession`, `useUser` should be used inside `AuthProvider` context,
   // and will throw an exception if this requirement is not met
   // useSession retrieves authentication state, session loading status, and session token
+  // If the session token is managed in cookies in project settings, sessionToken will be empty.
   const { isAuthenticated, isSessionLoading, sessionToken } = useSession();
   // useUser retrieves the logged in user information
   const { user, isUserLoading } = useUser();
@@ -344,6 +345,8 @@ const Component = () => {
 }
 ```
 
+Note that ff Descope project settings are configured to manage session token in cookies, the `getSessionToken` function will return an empty string.
+
 #### 2. Passing `sessionTokenViaCookie` boolean prop to the `AuthProvider`
 
 Passing `sessionTokenViaCookie` prop to `AuthProvider` component. Descope SDK will automatically store session token on the `DS` cookie.
@@ -373,6 +376,11 @@ In addition, some browsers (e.g. Safari) may not store `Secure` cookie if the ho
 The session token cookie is set to [`SameSite=Strict`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#samesitesamesite-value) by default.
 If you need to customize this, you can set `sessionTokenViaCookie={sameSite: 'Lax'}`
 
+#### 3. Configure Descope project to manage session token in cookies
+
+If project settings are configured to manage session token in cookies, Descope services will automatically set the session token in the `DS` cookie as a `Secure` and `HttpOnly` cookie. In this case, the session token will not be stored in the browser's and will not be accessible to the client-side code using `useSession` or `getSessionToken`.
+
+````js
 ### Helper Functions
 
 You can also use the following functions to assist with various actions managing your JWT.
@@ -425,7 +433,7 @@ const AppRoot = () => {
     </AuthProvider>
   );
 };
-```
+````
 
 ### Last User Persistence
 

--- a/packages/sdks/react-sdk/src/components/AuthProvider/AuthProvider.tsx
+++ b/packages/sdks/react-sdk/src/components/AuthProvider/AuthProvider.tsx
@@ -47,6 +47,7 @@ const AuthProvider: FC<IAuthProviderProps> = ({
 }) => {
   const [user, setUser] = useState<User>();
   const [session, setSession] = useState<string>();
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
 
   const [isUserLoading, setIsUserLoading] = useState(false);
   const [isSessionLoading, setIsSessionLoading] = useState(false);
@@ -65,10 +66,13 @@ const AuthProvider: FC<IAuthProviderProps> = ({
     if (sdk) {
       const unsubscribeSessionToken = sdk.onSessionTokenChange(setSession);
       const unsubscribeUser = sdk.onUserChange(setUser);
+      const unsubscribeIsAuthenticated =
+        sdk.onIsAuthenticatedChange(setIsAuthenticated);
 
       return () => {
         unsubscribeSessionToken();
         unsubscribeUser();
+        unsubscribeIsAuthenticated();
       };
     }
     return undefined;
@@ -107,6 +111,7 @@ const AuthProvider: FC<IAuthProviderProps> = ({
       isUserFetched: isUserFetched.current,
       fetchSession,
       session,
+      isAuthenticated,
       isSessionLoading,
       isSessionFetched: isSessionFetched.current,
       projectId,
@@ -126,6 +131,7 @@ const AuthProvider: FC<IAuthProviderProps> = ({
       isUserFetched.current,
       fetchSession,
       session,
+      isAuthenticated,
       isSessionLoading,
       isSessionFetched.current,
       projectId,

--- a/packages/sdks/react-sdk/src/hooks/useSession.ts
+++ b/packages/sdks/react-sdk/src/hooks/useSession.ts
@@ -2,8 +2,13 @@ import { useEffect, useMemo, useRef } from 'react';
 import useContext from './useContext';
 
 const useSession = () => {
-  const { session, isSessionLoading, fetchSession, isSessionFetched } =
-    useContext();
+  const {
+    session,
+    isSessionLoading,
+    fetchSession,
+    isSessionFetched,
+    isAuthenticated,
+  } = useContext();
 
   // when session should be received, we want the return value of "isSessionLoading" to be true starting from the first call
   // (and not only when receiving an update from the context)
@@ -14,7 +19,7 @@ const useSession = () => {
     isLoading.current = isSessionLoading;
   }, [isSessionLoading]);
 
-  const shouldFetchSession = !session && !isSessionLoading;
+  const shouldFetchSession = !isAuthenticated && !isSessionLoading;
 
   // we want this to happen before returning a value so we are using "useMemo" and not "useEffect"
   useMemo(() => {
@@ -33,7 +38,7 @@ const useSession = () => {
   return {
     isSessionLoading: isLoading.current,
     sessionToken: session,
-    isAuthenticated: !!session,
+    isAuthenticated,
   };
 };
 

--- a/packages/sdks/react-sdk/src/hooks/useUser.ts
+++ b/packages/sdks/react-sdk/src/hooks/useUser.ts
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import useContext from './useContext';
 
 const useUser = () => {
-  const { user, fetchUser, isUserLoading, session, isUserFetched } =
+  const { user, fetchUser, isUserLoading, isAuthenticated, isUserFetched } =
     useContext();
   const [isInit, setIsInit] = useState(false); // we want to get the user only in the first time we got a session
 
@@ -11,8 +11,8 @@ const useUser = () => {
   const isLoading = useRef(isUserLoading);
 
   const shouldFetchUser = useMemo(
-    () => !user && !isUserLoading && session && !isInit,
-    [fetchUser, session, isInit],
+    () => !user && !isUserLoading && isAuthenticated && !isInit,
+    [fetchUser, isAuthenticated, isInit],
   );
 
   // we want this to happen before returning a value so we are using "useMemo" and not "useEffect"

--- a/packages/sdks/react-sdk/src/types.ts
+++ b/packages/sdks/react-sdk/src/types.ts
@@ -91,6 +91,7 @@ export interface IContext {
   isUserFetched: boolean;
   fetchSession: () => void;
   session: string;
+  isAuthenticated: boolean;
   isSessionLoading: boolean;
   isSessionFetched: boolean;
   projectId: string;

--- a/packages/sdks/react-sdk/test/components/App.test.tsx
+++ b/packages/sdks/react-sdk/test/components/App.test.tsx
@@ -38,7 +38,14 @@ jest.mock('@descope/web-js-sdk', () => {
 const renderWithRouter = (ui: React.ReactElement) =>
   render(<MemoryRouter>{ui}</MemoryRouter>);
 
-const { logout, onSessionTokenChange, onIsAuthenticatedChange, onUserChange, refresh, me } = createSdk({
+const {
+  logout,
+  onSessionTokenChange,
+  onIsAuthenticatedChange,
+  onUserChange,
+  refresh,
+  me,
+} = createSdk({
   projectId: '',
 });
 
@@ -56,7 +63,6 @@ describe('App', () => {
       cb(true);
       return () => {};
     });
-
 
     (onUserChange as jest.Mock).mockImplementation((cb) => {
       expect(cb).toBeTruthy();

--- a/packages/sdks/react-sdk/test/components/App.test.tsx
+++ b/packages/sdks/react-sdk/test/components/App.test.tsx
@@ -137,7 +137,7 @@ describe('App', () => {
     );
 
     // ensure refresh called only once
-    expect(refresh).toBeCalledTimes(1);
+    expect(refresh).toHaveBeenCalledTimes(1);
   });
 
   it('should call me only once when useUser used twice', async () => {
@@ -176,7 +176,7 @@ describe('App', () => {
     );
 
     // ensure refresh called only once
-    expect(refresh).toBeCalledTimes(1);
+    expect(refresh).toHaveBeenCalledTimes(1);
 
     const loginButton = await screen.findByText('Login');
     fireEvent.click(loginButton);
@@ -187,6 +187,6 @@ describe('App', () => {
     );
 
     // ensure refresh called only once
-    expect(refresh).toBeCalledTimes(1);
+    expect(refresh).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/sdks/react-sdk/test/components/App.test.tsx
+++ b/packages/sdks/react-sdk/test/components/App.test.tsx
@@ -20,6 +20,7 @@ jest.mock('@descope/web-js-sdk', () => {
   const sdk = {
     logout: jest.fn().mockName('logout'),
     onSessionTokenChange: jest.fn().mockName('onSessionTokenChange'),
+    onIsAuthenticatedChange: jest.fn().mockName('onIsAuthenticatedChange'),
     onUserChange: jest.fn().mockName('onUserChange'),
     getSessionToken: jest.fn().mockName('getSessionToken'),
     getJwtRoles: jest.fn().mockName('getJwtRoles'),
@@ -37,7 +38,7 @@ jest.mock('@descope/web-js-sdk', () => {
 const renderWithRouter = (ui: React.ReactElement) =>
   render(<MemoryRouter>{ui}</MemoryRouter>);
 
-const { logout, onSessionTokenChange, onUserChange, refresh, me } = createSdk({
+const { logout, onSessionTokenChange, onIsAuthenticatedChange, onUserChange, refresh, me } = createSdk({
   projectId: '',
 });
 
@@ -45,15 +46,17 @@ describe('App', () => {
   beforeEach(() => {
     // reset mock functions that may be override
     (onSessionTokenChange as jest.Mock).mockImplementation(() => () => {});
+    (onIsAuthenticatedChange as jest.Mock).mockImplementation(() => () => {});
     (onUserChange as jest.Mock).mockImplementation(() => () => {});
   });
 
   it('should subscribe to user and session token', async () => {
-    (onSessionTokenChange as jest.Mock).mockImplementation((cb) => {
+    (onIsAuthenticatedChange as jest.Mock).mockImplementation((cb) => {
       expect(cb).toBeTruthy();
-      cb('token1');
+      cb(true);
       return () => {};
     });
+
 
     (onUserChange as jest.Mock).mockImplementation((cb) => {
       expect(cb).toBeTruthy();
@@ -100,8 +103,8 @@ describe('App', () => {
   });
 
   it('should render logout button and and call sdk logout', async () => {
-    (onSessionTokenChange as jest.Mock).mockImplementation((cb) => {
-      cb('token1');
+    (onIsAuthenticatedChange as jest.Mock).mockImplementation((cb) => {
+      cb(true);
       return () => {};
     });
     (onUserChange as jest.Mock).mockImplementation((cb) => {
@@ -139,13 +142,13 @@ describe('App', () => {
 
   it('should call me only once when useUser used twice', async () => {
     // rendering App twice which uses useUser
-    (onSessionTokenChange as jest.Mock).mockImplementation((cb) => {
-      cb('token1');
+    (onIsAuthenticatedChange as jest.Mock).mockImplementation((cb) => {
+      cb(true);
       return () => {};
     });
 
     const MyComponent = () => {
-      // Calling useSession to trigger onSessionTokenChange (because having a session token is required to fetch user)
+      // Calling useSession to trigger onIsAuthenticated (because having a session token is required to fetch user)
       useSession();
       // Using useUser to fetch user
       useUser();

--- a/packages/sdks/react-sdk/test/components/DefaultFlows.test.tsx
+++ b/packages/sdks/react-sdk/test/components/DefaultFlows.test.tsx
@@ -14,6 +14,9 @@ jest.mock('@descope/web-js-sdk', () => {
     onSessionTokenChange: jest
       .fn(() => () => {})
       .mockName('onSessionTokenChange'),
+    onIsAuthenticatedChange: jest
+      .fn(() => () => {})
+      .mockName('onIsAuthenticatedChange'),
     onUserChange: jest.fn(() => () => {}).mockName('onUserChange'),
     refresh: jest.fn(),
     httpClient: {

--- a/packages/sdks/react-sdk/test/components/Descope.test.tsx
+++ b/packages/sdks/react-sdk/test/components/Descope.test.tsx
@@ -23,6 +23,9 @@ jest.mock('@descope/web-js-sdk', () => {
     onSessionTokenChange: jest
       .fn(() => () => {})
       .mockName('onSessionTokenChange'),
+    onIsAuthenticatedChange: jest
+      .fn(() => () => {})
+      .mockName('onIsAuthenticatedChange'),
     onUserChange: jest.fn(() => () => {}).mockName('onUserChange'),
     refresh: jest.fn(),
     httpClient: {

--- a/packages/sdks/react-sdk/test/components/DescopeWidgets.test.tsx
+++ b/packages/sdks/react-sdk/test/components/DescopeWidgets.test.tsx
@@ -31,6 +31,9 @@ jest.mock('@descope/web-js-sdk', () => {
     onSessionTokenChange: jest
       .fn(() => () => {})
       .mockName('onSessionTokenChange'),
+    onIsAuthenticatedChange: jest
+      .fn(() => () => {})
+      .mockName('onIsAuthenticatedChange'),
     onUserChange: jest.fn(() => () => {}).mockName('onUserChange'),
     refresh: jest.fn(),
     httpClient: {

--- a/packages/sdks/react-sdk/test/hooks/useAuth.test.tsx
+++ b/packages/sdks/react-sdk/test/hooks/useAuth.test.tsx
@@ -23,6 +23,9 @@ jest.mock('@descope/web-js-sdk', () => {
     onSessionTokenChange: jest
       .fn(() => () => {})
       .mockName('onSessionTokenChange'),
+    onIsAuthenticatedChange: jest
+      .fn(() => () => {})
+      .mockName('onIsAuthenticatedChange'),
     onUserChange: jest.fn(() => () => {}).mockName('onUserChange'),
     refresh: jest.fn(() => Promise.resolve()),
     httpClient: {

--- a/packages/sdks/react-sdk/test/hooks/useAuth.test.tsx
+++ b/packages/sdks/react-sdk/test/hooks/useAuth.test.tsx
@@ -90,7 +90,7 @@ describe('hooks', () => {
     });
 
     result.current.logout();
-    expect(logout).toBeCalled();
+    expect(logout).toHaveBeenCalled();
   });
 
   it('should throw an error when trying to access attribute and sdk is not initialized', () => {
@@ -98,7 +98,7 @@ describe('hooks', () => {
       wrapper: authProviderWrapper(''),
     });
 
-    expect(() => get(result.current, 'dummyKey')).toThrowError(
+    expect(() => get(result.current, 'dummyKey')).toThrow(
       expect.objectContaining({
         message: expect.stringContaining(
           'You can only use this attribute after sdk initialization',
@@ -132,13 +132,13 @@ describe('hooks', () => {
     expect(result.current.isSessionLoading).toEqual(true);
 
     await waitFor(() => {
-      expect(refresh).toBeCalled();
+      expect(refresh).toHaveBeenCalled();
     });
 
     // render again
     rerender();
 
     expect(result.current.isSessionLoading).toEqual(false);
-    expect(refresh).toBeCalledTimes(1);
+    expect(refresh).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/sdks/react-sdk/test/hooks/useSession.test.tsx
+++ b/packages/sdks/react-sdk/test/hooks/useSession.test.tsx
@@ -26,6 +26,7 @@ describe('useSession', () => {
       isSessionLoading: false,
       fetchSession,
       isSessionFetched: false,
+      isAuthenticated: true,
     } as any as IContext);
 
     expect(result.current.isSessionLoading).toBe(false);

--- a/packages/sdks/vue-sdk/README.md
+++ b/packages/sdks/vue-sdk/README.md
@@ -233,7 +233,12 @@ app.use(descope, {
 const sdk = getSdk();
 
 sdk?.onSessionTokenChange((newSession) => {
-  // here you can implement custom logic when the session is changing
+  // here you can implement custom logic when the session is changing,
+  // note that the session may be not available if it is managed in cookies
+});
+
+sdk?.onIsAuthenticatedChange((isAuthenticated) => {
+  // here you can implement custom logic when the authentication state is changing
 });
 ```
 

--- a/packages/sdks/vue-sdk/src/hooks.ts
+++ b/packages/sdks/vue-sdk/src/hooks.ts
@@ -29,7 +29,7 @@ export const useSession = () => {
         session.isLoading.value || session.isFetchSessionWasNeverCalled.value,
     ),
     sessionToken: session.session,
-    isAuthenticated: computed(() => !!session.session.value),
+    isAuthenticated: session.isAuthenticated,
   };
 };
 

--- a/packages/sdks/vue-sdk/src/plugin.ts
+++ b/packages/sdks/vue-sdk/src/plugin.ts
@@ -29,12 +29,17 @@ export default {
 
     const isSessionLoading = ref<boolean | null>(null);
     const sessionToken = ref('');
+    const isAuthenticated = ref(false);
 
     const isUserLoading = ref<boolean | null>(null);
     const user = ref<UserData>(null);
 
     sdk.onSessionTokenChange((s) => {
       sessionToken.value = s;
+    });
+
+    sdk.onIsAuthenticatedChange((a) => {
+      isAuthenticated.value = a;
     });
 
     sdk.onUserChange((u) => {
@@ -65,6 +70,7 @@ export default {
     // maybe there is a better way to do it
     routeGuardInternal.value = () =>
       new Promise((resolve, reject) => {
+        // Asaf - I think we need to change this to isAuthenticated.value
         if (!sessionToken.value && isFetchSessionWasNeverCalled.value) {
           fetchSession().catch(reject);
         }
@@ -72,6 +78,7 @@ export default {
         // if the session is loading we want to wait for it to finish before resolving
         watch(
           () => isSessionLoading.value,
+          // Asaf - I think we need to change this to unref(isAuthenticated)
           () => !isSessionLoading.value && resolve(!!unref(sessionToken)),
           { immediate: true },
         );
@@ -82,6 +89,7 @@ export default {
         fetchSession,
         isLoading: readonly(isSessionLoading),
         session: readonly(sessionToken),
+        isAuthenticated: readonly(isAuthenticated),
         isFetchSessionWasNeverCalled,
       },
       user: {

--- a/packages/sdks/vue-sdk/src/plugin.ts
+++ b/packages/sdks/vue-sdk/src/plugin.ts
@@ -70,16 +70,14 @@ export default {
     // maybe there is a better way to do it
     routeGuardInternal.value = () =>
       new Promise((resolve, reject) => {
-        // Asaf - I think we need to change this to isAuthenticated.value
-        if (!sessionToken.value && isFetchSessionWasNeverCalled.value) {
+        if (!isAuthenticated.value && isFetchSessionWasNeverCalled.value) {
           fetchSession().catch(reject);
         }
 
         // if the session is loading we want to wait for it to finish before resolving
         watch(
           () => isSessionLoading.value,
-          // Asaf - I think we need to change this to unref(isAuthenticated)
-          () => !isSessionLoading.value && resolve(!!unref(sessionToken)),
+          () => !isSessionLoading.value && resolve(!!unref(isAuthenticated)),
           { immediate: true },
         );
       });

--- a/packages/sdks/vue-sdk/src/types.ts
+++ b/packages/sdks/vue-sdk/src/types.ts
@@ -30,6 +30,7 @@ type Session = {
   fetchSession: () => Promise<void>;
   isLoading: Ref<boolean | null>;
   session: Ref<string>;
+  isAuthenticated: Ref<boolean>;
   isFetchSessionWasNeverCalled: Ref<boolean>;
 };
 

--- a/packages/sdks/vue-sdk/tests/hooks.test.ts
+++ b/packages/sdks/vue-sdk/tests/hooks.test.ts
@@ -26,6 +26,7 @@ describe('hooks', () => {
         session: { value: 'session' },
         isLoading: { value: true },
         isFetchSessionWasNeverCalled: true,
+        isAuthenticated: { value: true },
       },
     });
   });
@@ -53,7 +54,7 @@ describe('hooks', () => {
       expect(useSession()).toEqual({
         isLoading: true,
         sessionToken: { value: 'session' },
-        isAuthenticated: true,
+        isAuthenticated: { value: true },
       });
     });
 

--- a/packages/sdks/vue-sdk/tests/plugin.test.ts
+++ b/packages/sdks/vue-sdk/tests/plugin.test.ts
@@ -5,6 +5,7 @@ jest.mock('@descope/web-js-sdk');
 const mockCreateSdk = createSdk as jest.Mock;
 const mockSdk = {
   onSessionTokenChange: jest.fn(),
+  onIsAuthenticatedChange: jest.fn(),
   onUserChange: jest.fn(),
   refresh: jest.fn(),
   me: jest.fn(),

--- a/packages/sdks/vue-sdk/tests/plugin.test.ts
+++ b/packages/sdks/vue-sdk/tests/plugin.test.ts
@@ -143,33 +143,33 @@ describe('plugin', () => {
       expect(mockSdk.refresh).toBeCalledTimes(1);
     });
 
-    it('should return true if there is a session', async () => {
+    it('should return true when is authenticated notifies true', async () => {
       const provide = jest.fn();
       const app = { provide } as any;
 
       plugin.install(app, {} as any);
 
-      const onSessionTokenChange =
-        mockSdk.onSessionTokenChange.mock.calls[0][0];
-      onSessionTokenChange('newSession');
+      const onIsAuthenticatedChange =
+        mockSdk.onIsAuthenticatedChange.mock.calls[0][0];
+      onIsAuthenticatedChange(true);
 
       expect(await routeGuard()).toBe(true);
     });
 
-    it('should return false if there is no session', async () => {
+    it('should return false if is', async () => {
       const provide = jest.fn();
       const app = { provide } as any;
 
       plugin.install(app, {} as any);
 
-      const onSessionTokenChange =
-        mockSdk.onSessionTokenChange.mock.calls[0][0];
-      onSessionTokenChange('');
+      const onIsAuthenticatedChange =
+        mockSdk.onIsAuthenticatedChange.mock.calls[0][0];
+      onIsAuthenticatedChange(false);
 
       expect(await routeGuard()).toBe(false);
     });
 
-    it('should resolve only when the session is not loading', async () => {
+    it('should resolve only when the is authenticated is not loading', async () => {
       const provide = jest.fn();
       const app = { provide } as any;
 
@@ -185,9 +185,9 @@ describe('plugin', () => {
       routeGuard();
       const isAuthenticatedPromise = routeGuard();
 
-      const onSessionTokenChange =
-        mockSdk.onSessionTokenChange.mock.calls[0][0];
-      onSessionTokenChange('session');
+      const onIsAuthenticatedChange =
+        mockSdk.onIsAuthenticatedChange.mock.calls[0][0];
+      onIsAuthenticatedChange(true);
 
       resolve();
 

--- a/packages/sdks/web-component/src/app-web-sample/index.js
+++ b/packages/sdks/web-component/src/app-web-sample/index.js
@@ -53,10 +53,10 @@ async function addUserToPage(user) {
     window.location.reload();
   };
 
-  // in case of session token is missing, reload the page
+  // in case the user is not authenticated, reload the page
   // this may happen if the user logs out from another tab or the refresh token is revoked/expired
-  sdk.onSessionTokenChange = async (token) => {
-    if (!token) {
+  sdk.onIsAuthenticatedChange = async (isAuthenticated) => {
+    if (!isAuthenticated) {
       // reload the page
       window.location.reload();
     }

--- a/packages/sdks/web-js-sdk/README.md
+++ b/packages/sdks/web-js-sdk/README.md
@@ -57,6 +57,11 @@ If you need to customize this, you can set `sessionTokenViaCookie={sameSite: 'La
 
 sdk.onSessionTokenChange((newSession, oldSession) => {
   // handle session token change...
+  // Note that if Descope project settings are configured to manage session token in cookies, the session token will not be available in the browser.
+});
+
+sdk.onIsAuthenticatedChange((isAuthenticated) => {
+  // handle authentication change...
 });
 
 sdk.onUserChange((newUser, oldUser) => {

--- a/packages/sdks/web-js-sdk/src/enhancers/withAutoRefresh/helpers.ts
+++ b/packages/sdks/web-js-sdk/src/enhancers/withAutoRefresh/helpers.ts
@@ -1,11 +1,22 @@
 import { jwtDecode, JwtPayload } from 'jwt-decode';
+import logger from '../helpers/logger';
 
 /**
  * Get the JWT expiration WITHOUT VALIDATING the JWT
  * @param token The JWT to extract expiration from
  * @returns The Date for when the JWT expires or null if there is an issue
  */
-export const getTokenExpiration = (token: string) => {
+export const getTokenExpiration = (
+  token: string,
+  sessionExpiration: number,
+) => {
+  if (sessionExpiration) {
+    return new Date(sessionExpiration * 1000);
+  }
+
+  logger.debug(
+    'Could not extract expiration time from session token, trying to decode the token',
+  );
   try {
     const claims = jwtDecode<JwtPayload>(token);
     if (claims.exp) {

--- a/packages/sdks/web-js-sdk/src/enhancers/withNotifications/index.ts
+++ b/packages/sdks/web-js-sdk/src/enhancers/withNotifications/index.ts
@@ -61,7 +61,7 @@ export const withNotifications =
       onUserChange: userPS.sub,
       onIsAuthenticatedChange: (cb: (isAuthenticated: boolean) => void) => {
         // If and only if there is a session expiration, then the user is authenticated
-        sessionExpirationPS.sub((exp) => {
+        return sessionExpirationPS.sub((exp) => {
           cb(!!exp);
         });
       },

--- a/packages/sdks/web-js-sdk/test/autoRefresh.test.ts
+++ b/packages/sdks/web-js-sdk/test/autoRefresh.test.ts
@@ -324,6 +324,7 @@ describe('autoRefresh', () => {
 
     const authInfoWith1MonthExpiration = {
       ...authInfo,
+      sessionExpiration: undefined,
       sessionJwt: getFutureSessionToken(30 * 24 * 60 * 60 * 1000),
     };
     const mockFetch = jest

--- a/packages/sdks/web-js-sdk/test/autoRefresh.test.ts
+++ b/packages/sdks/web-js-sdk/test/autoRefresh.test.ts
@@ -39,7 +39,6 @@ describe('autoRefresh', () => {
       createMockReturnValue({
         ...authInfo,
         sessionJwt: undefined,
-        sessionExpiration: 1663190468,
       }),
     );
     global.fetch = mockFetch;
@@ -94,7 +93,9 @@ describe('autoRefresh', () => {
 
     const mockFetch = jest
       .fn()
-      .mockReturnValue(createMockReturnValue(authInfo));
+      .mockReturnValue(
+        createMockReturnValue({ ...authInfo, sessionExpiration: undefined }),
+      );
     global.fetch = mockFetch;
 
     const sdk = createSdk({ projectId: 'pid', autoRefresh: true });

--- a/packages/sdks/web-js-sdk/test/autoRefresh.test.ts
+++ b/packages/sdks/web-js-sdk/test/autoRefresh.test.ts
@@ -263,7 +263,9 @@ describe('autoRefresh', () => {
 
     const mockFetch = jest
       .fn()
-      .mockReturnValue(createMockReturnValue(authInfo));
+      .mockReturnValue(
+        createMockReturnValue({ ...authInfo, sessionExpiration: undefined }),
+      );
     global.fetch = mockFetch;
 
     const sdk = createSdk({ projectId: 'pid', autoRefresh: true });
@@ -297,6 +299,7 @@ describe('autoRefresh', () => {
     const mockFetch = jest.fn().mockReturnValue(
       createMockReturnValue({
         ...authInfo,
+        sessionExpiration: undefined,
         sessionJwt: getFutureSessionToken(),
       }),
     );

--- a/packages/sdks/web-js-sdk/test/mocks.ts
+++ b/packages/sdks/web-js-sdk/test/mocks.ts
@@ -7,6 +7,7 @@ export const authInfo = {
   cookiePath: '/path1',
   cookieExpiration: 1665576720,
   user: { name: 'john', loginIds: ['js@hotmail.com'] },
+  sessionExpiration: 1663190468,
 };
 
 export const flowResponse = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,7 +146,7 @@ importers:
         version: 6.6.0(eslint@8.57.1)
       jest:
         specifier: ^29.0.0
-        version: 29.7.0(@types/node@22.13.5)(ts-node@10.9.2)
+        version: 29.7.0(@types/node@22.13.8)(ts-node@10.9.2)
       jest-environment-jsdom:
         specifier: ^29.0.0
         version: 29.7.0
@@ -173,7 +173,7 @@ importers:
         version: 29.1.5(@babel/core@7.26.9)(jest@29.7.0)(typescript@5.6.3)
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@types/node@22.13.5)(typescript@5.6.3)
+        version: 10.9.2(@types/node@22.13.8)(typescript@5.6.3)
       typescript:
         specifier: ^5.0.2
         version: 5.6.3
@@ -641,19 +641,19 @@ importers:
     devDependencies:
       '@angular-devkit/build-angular':
         specifier: ^19.0.0
-        version: 19.1.6(@angular/compiler-cli@19.1.4)(@angular/compiler@19.1.4)(@types/node@22.13.5)(jest-environment-jsdom@29.7.0)(jest@29.7.0)(ng-packagr@16.2.3)(typescript@5.7.3)(vite@6.1.1)
+        version: 19.1.6(@angular/compiler-cli@19.1.4)(@angular/compiler@19.1.4)(@types/node@22.13.8)(jest-environment-jsdom@29.7.0)(jest@29.7.0)(ng-packagr@16.2.3)(typescript@5.7.3)(vite@6.2.0)
       '@angular-eslint/builder':
         specifier: 19.0.2
         version: 19.0.2(eslint@8.57.0)(typescript@5.7.3)
       '@angular-eslint/eslint-plugin':
         specifier: 19.0.2
-        version: 19.0.2(@typescript-eslint/utils@8.24.1)(eslint@8.57.0)(typescript@5.7.3)
+        version: 19.0.2(@typescript-eslint/utils@8.25.0)(eslint@8.57.0)(typescript@5.7.3)
       '@angular-eslint/eslint-plugin-template':
         specifier: 19.0.2
-        version: 19.0.2(@typescript-eslint/types@8.24.1)(@typescript-eslint/utils@8.24.1)(eslint@8.57.0)(typescript@5.7.3)
+        version: 19.0.2(@typescript-eslint/types@8.25.0)(@typescript-eslint/utils@8.25.0)(eslint@8.57.0)(typescript@5.7.3)
       '@angular-eslint/schematics':
         specifier: 19.0.2
-        version: 19.0.2(@typescript-eslint/types@8.24.1)(@typescript-eslint/utils@8.24.1)(eslint@8.57.0)(typescript@5.7.3)
+        version: 19.0.2(@typescript-eslint/types@8.25.0)(@typescript-eslint/utils@8.25.0)(eslint@8.57.0)(typescript@5.7.3)
       '@angular-eslint/template-parser':
         specifier: 19.0.2
         version: 19.0.2(eslint@8.57.0)(typescript@5.7.3)
@@ -662,7 +662,7 @@ importers:
         version: 19.1.4(@angular/core@19.1.4)
       '@angular/cli':
         specifier: ^19.0.0
-        version: 19.1.6(@types/node@22.13.5)
+        version: 19.1.6(@types/node@22.13.8)
       '@angular/common':
         specifier: ^19.0.0
         version: 19.1.4(@angular/core@19.1.4)(rxjs@7.8.1)
@@ -704,7 +704,7 @@ importers:
         version: 4.2.1(eslint-config-prettier@9.1.0)(eslint@8.57.0)(prettier@2.8.8)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.13.5)(ts-node@10.9.2)
+        version: 29.7.0(@types/node@22.13.8)(ts-node@10.9.2)
       jest-preset-angular:
         specifier: ^13.1.2
         version: 13.1.6(@angular-devkit/build-angular@19.1.6)(@angular/compiler-cli@19.1.4)(@angular/core@19.1.4)(@angular/platform-browser-dynamic@19.1.4)(@babel/core@7.26.9)(jest@29.7.0)(typescript@5.7.3)
@@ -717,133 +717,6 @@ importers:
       ng-packagr:
         specifier: ^16.2.3
         version: 16.2.3(@angular/compiler-cli@19.1.4)(tslib@2.6.3)(typescript@5.7.3)
-      prettier:
-        specifier: 2.8.8
-        version: 2.8.8
-      pretty-quick:
-        specifier: ^3.1.3
-        version: 3.3.1(prettier@2.8.8)
-      rxjs:
-        specifier: ~7.8.1
-        version: 7.8.1
-      typescript:
-        specifier: ^5.5.0
-        version: 5.7.3
-      zone.js:
-        specifier: ~0.15.0
-        version: 0.15.0
-
-  packages/sdks/angular-sdk/projects/angular-sdk:
-    dependencies:
-      '@descope/access-key-management-widget':
-        specifier: workspace:*
-        version: link:../../../../widgets/access-key-management-widget
-      '@descope/applications-portal-widget':
-        specifier: workspace:*
-        version: link:../../../../widgets/applications-portal-widget
-      '@descope/audit-management-widget':
-        specifier: workspace:*
-        version: link:../../../../widgets/audit-management-widget
-      '@descope/core-js-sdk':
-        specifier: workspace:*
-        version: link:../../../core-js-sdk
-      '@descope/role-management-widget':
-        specifier: workspace:*
-        version: link:../../../../widgets/role-management-widget
-      '@descope/user-management-widget':
-        specifier: workspace:*
-        version: link:../../../../widgets/user-management-widget
-      '@descope/user-profile-widget':
-        specifier: workspace:*
-        version: link:../../../../widgets/user-profile-widget
-      '@descope/web-component':
-        specifier: workspace:*
-        version: link:../../../web-component
-      '@descope/web-js-sdk':
-        specifier: workspace:*
-        version: link:../../../web-js-sdk
-      tslib:
-        specifier: ^2.3.0
-        version: 2.8.1
-    devDependencies:
-      '@angular-devkit/build-angular':
-        specifier: ^19.0.0
-        version: 19.1.6(@angular/compiler-cli@19.1.4)(@angular/compiler@19.1.4)(@types/node@22.13.5)(jest-environment-jsdom@29.7.0)(jest@29.7.0)(ng-packagr@16.2.3)(typescript@5.7.3)(vite@6.1.1)
-      '@angular-eslint/builder':
-        specifier: 19.0.2
-        version: 19.0.2(eslint@8.57.1)(typescript@5.7.3)
-      '@angular-eslint/eslint-plugin':
-        specifier: 19.0.2
-        version: 19.0.2(@typescript-eslint/utils@8.24.1)(eslint@8.57.1)(typescript@5.7.3)
-      '@angular-eslint/eslint-plugin-template':
-        specifier: 19.0.2
-        version: 19.0.2(@typescript-eslint/types@8.24.1)(@typescript-eslint/utils@8.24.1)(eslint@8.57.1)(typescript@5.7.3)
-      '@angular-eslint/schematics':
-        specifier: 19.0.2
-        version: 19.0.2(@typescript-eslint/types@8.24.1)(@typescript-eslint/utils@8.24.1)(eslint@8.57.1)(typescript@5.7.3)
-      '@angular-eslint/template-parser':
-        specifier: 19.0.2
-        version: 19.0.2(eslint@8.57.1)(typescript@5.7.3)
-      '@angular/animations':
-        specifier: ^19.0.0
-        version: 19.1.4(@angular/core@19.1.4)
-      '@angular/cli':
-        specifier: ^19.0.0
-        version: 19.1.6(@types/node@22.13.5)
-      '@angular/common':
-        specifier: ^19.0.0
-        version: 19.1.4(@angular/core@19.1.4)(rxjs@7.8.1)
-      '@angular/compiler':
-        specifier: ^19.0.0
-        version: 19.1.4(@angular/core@19.1.4)
-      '@angular/compiler-cli':
-        specifier: ^19.0.0
-        version: 19.1.4(@angular/compiler@19.1.4)(typescript@5.7.3)
-      '@angular/core':
-        specifier: ^19.0.0
-        version: 19.1.4(rxjs@7.8.1)(zone.js@0.15.0)
-      '@angular/forms':
-        specifier: ^19.0.0
-        version: 19.1.4(@angular/common@19.1.4)(@angular/core@19.1.4)(@angular/platform-browser@19.1.4)(rxjs@7.8.1)
-      '@angular/platform-browser':
-        specifier: ^19.0.0
-        version: 19.1.4(@angular/animations@19.1.4)(@angular/common@19.1.4)(@angular/core@19.1.4)
-      '@angular/platform-browser-dynamic':
-        specifier: ^19.0.0
-        version: 19.1.4(@angular/common@19.1.4)(@angular/compiler@19.1.4)(@angular/core@19.1.4)(@angular/platform-browser@19.1.4)
-      '@angular/router':
-        specifier: ^19.0.0
-        version: 19.1.4(@angular/common@19.1.4)(@angular/core@19.1.4)(@angular/platform-browser@19.1.4)(rxjs@7.8.1)
-      '@types/jest':
-        specifier: ^29.5.5
-        version: 29.5.14
-      '@typescript-eslint/eslint-plugin':
-        specifier: 6.21.0
-        version: 6.21.0(@typescript-eslint/parser@6.21.0)(eslint@8.57.1)(typescript@5.7.3)
-      '@typescript-eslint/parser':
-        specifier: 6.21.0
-        version: 6.21.0(eslint@8.57.1)(typescript@5.7.3)
-      eslint:
-        specifier: ^8.51.0
-        version: 8.57.1
-      eslint-plugin-prettier:
-        specifier: ^4.2.1
-        version: 4.2.1(eslint-config-prettier@9.1.0)(eslint@8.57.1)(prettier@2.8.8)
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.13.5)(ts-node@10.9.2)
-      jest-preset-angular:
-        specifier: ^13.1.2
-        version: 13.1.6(@angular-devkit/build-angular@19.1.6)(@angular/compiler-cli@19.1.4)(@angular/core@19.1.4)(@angular/platform-browser-dynamic@19.1.4)(@babel/core@7.26.9)(jest@29.7.0)(typescript@5.7.3)
-      lint-staged:
-        specifier: ^15.2.0
-        version: 15.2.7
-      ng-mocks:
-        specifier: ^14.11.0
-        version: 14.13.0(@angular/common@19.1.4)(@angular/core@19.1.4)(@angular/forms@19.1.4)(@angular/platform-browser@19.1.4)
-      ng-packagr:
-        specifier: ^16.2.3
-        version: 16.2.3(@angular/compiler-cli@19.1.4)(tslib@2.8.1)(typescript@5.7.3)
       prettier:
         specifier: 2.8.8
         version: 2.8.8
@@ -1012,7 +885,7 @@ importers:
     optionalDependencies:
       '@descope/web-js-sdk':
         specifier: '>=1'
-        version: 1.24.1
+        version: link:../web-js-sdk
     devDependencies:
       '@babel/core':
         specifier: 7.26.0
@@ -1124,10 +997,10 @@ importers:
         version: 3.1.1
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.13.5)(ts-node@10.9.2)
+        version: 29.7.0(@types/node@22.13.8)(ts-node@10.9.2)
       jest-config:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.13.5)(ts-node@10.9.2)
+        version: 29.7.0(@types/node@22.13.8)(ts-node@10.9.2)
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -1187,7 +1060,7 @@ importers:
         version: 0.7.0(rollup@4.22.4)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.7.1)(@types/node@22.13.5)(typescript@5.4.5)
+        version: 10.9.2(@swc/core@1.7.1)(@types/node@22.13.8)(typescript@5.4.5)
       typescript:
         specifier: ^5.0.2
         version: 5.4.5
@@ -3014,7 +2887,7 @@ packages:
       - chokidar
     dev: true
 
-  /@angular-devkit/build-angular@19.1.6(@angular/compiler-cli@19.1.4)(@angular/compiler@19.1.4)(@types/node@22.13.5)(jest-environment-jsdom@29.7.0)(jest@29.7.0)(ng-packagr@16.2.3)(typescript@5.7.3)(vite@6.1.1):
+  /@angular-devkit/build-angular@19.1.6(@angular/compiler-cli@19.1.4)(@angular/compiler@19.1.4)(@types/node@22.13.8)(jest-environment-jsdom@29.7.0)(jest@29.7.0)(ng-packagr@16.2.3)(typescript@5.7.3)(vite@6.2.0):
     resolution: {integrity: sha512-QZtzkD0PQnBMpIwXyFTa9ZqN2wIEssh8V2VBRXzp0GXOZYvU18ICdZwJCXbRU2Bixwk8mrDALfMfryDWovJkGQ==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
     peerDependencies:
@@ -3062,7 +2935,7 @@ packages:
       '@angular-devkit/architect': 0.1901.6
       '@angular-devkit/build-webpack': 0.1901.6(webpack-dev-server@5.2.0)(webpack@5.97.1)
       '@angular-devkit/core': 19.1.6
-      '@angular/build': 19.1.6(@angular/compiler-cli@19.1.4)(@angular/compiler@19.1.4)(@types/node@22.13.5)(less@4.2.1)(ng-packagr@16.2.3)(postcss@8.4.49)(terser@5.37.0)(typescript@5.7.3)
+      '@angular/build': 19.1.6(@angular/compiler-cli@19.1.4)(@angular/compiler@19.1.4)(@types/node@22.13.8)(less@4.2.1)(ng-packagr@16.2.3)(postcss@8.4.49)(terser@5.37.0)(typescript@5.7.3)
       '@angular/compiler-cli': 19.1.4(@angular/compiler@19.1.4)(typescript@5.7.3)
       '@babel/core': 7.26.0
       '@babel/generator': 7.26.3
@@ -3075,7 +2948,7 @@ packages:
       '@babel/runtime': 7.26.0
       '@discoveryjs/json-ext': 0.6.3
       '@ngtools/webpack': 19.1.6(@angular/compiler-cli@19.1.4)(typescript@5.7.3)(webpack@5.97.1)
-      '@vitejs/plugin-basic-ssl': 1.2.0(vite@6.1.1)
+      '@vitejs/plugin-basic-ssl': 1.2.0(vite@6.2.0)
       ansi-colors: 4.1.3
       autoprefixer: 10.4.20(postcss@8.4.49)
       babel-loader: 9.2.1(@babel/core@7.26.0)(webpack@5.97.1)
@@ -3086,7 +2959,7 @@ packages:
       fast-glob: 3.3.3
       http-proxy-middleware: 3.0.3
       istanbul-lib-instrument: 6.0.3
-      jest: 29.7.0(@types/node@22.13.5)(ts-node@10.9.2)
+      jest: 29.7.0(@types/node@22.13.8)(ts-node@10.9.2)
       jest-environment-jsdom: 29.7.0
       jsonc-parser: 3.3.1
       karma-source-map-support: 1.4.0
@@ -3203,25 +3076,11 @@ packages:
       - chokidar
     dev: true
 
-  /@angular-eslint/builder@19.0.2(eslint@8.57.1)(typescript@5.7.3):
-    resolution: {integrity: sha512-BdmMSndQt2fSBiTVniskUcUpQaeweUapbsL0IDfQ7a13vL0NVXpc3K89YXuVE/xsb08uHtqphuwxPAAj6kX3OA==}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '*'
-    dependencies:
-      '@angular-devkit/architect': 0.1901.6
-      '@angular-devkit/core': 19.1.6
-      eslint: 8.57.1
-      typescript: 5.7.3
-    transitivePeerDependencies:
-      - chokidar
-    dev: true
-
   /@angular-eslint/bundled-angular-compiler@19.0.2:
     resolution: {integrity: sha512-HPmp92r70SNO/0NdIaIhxrgVSpomqryuUk7jszvNRtu+OzYCJGcbLhQD38T3dbBWT/AV0QXzyzExn6/2ai9fEw==}
     dev: true
 
-  /@angular-eslint/eslint-plugin-template@19.0.2(@typescript-eslint/types@8.24.1)(@typescript-eslint/utils@8.24.1)(eslint@8.57.0)(typescript@5.7.3):
+  /@angular-eslint/eslint-plugin-template@19.0.2(@typescript-eslint/types@8.25.0)(@typescript-eslint/utils@8.25.0)(eslint@8.57.0)(typescript@5.7.3):
     resolution: {integrity: sha512-f/OCF9ThnxQ8m0eNYPwnCrySQPhYfCOF6STL7F9LnS8Bs3ZeW3/oT1yLaMIZ1Eg0ogIkgxksMAJZjrJPUPBD1Q==}
     peerDependencies:
       '@typescript-eslint/types': ^7.11.0 || ^8.0.0
@@ -3230,34 +3089,16 @@ packages:
       typescript: '*'
     dependencies:
       '@angular-eslint/bundled-angular-compiler': 19.0.2
-      '@angular-eslint/utils': 19.0.2(@typescript-eslint/utils@8.24.1)(eslint@8.57.0)(typescript@5.7.3)
-      '@typescript-eslint/types': 8.24.1
-      '@typescript-eslint/utils': 8.24.1(eslint@8.57.0)(typescript@5.7.3)
+      '@angular-eslint/utils': 19.0.2(@typescript-eslint/utils@8.25.0)(eslint@8.57.0)(typescript@5.7.3)
+      '@typescript-eslint/types': 8.25.0
+      '@typescript-eslint/utils': 8.25.0(eslint@8.57.0)(typescript@5.7.3)
       aria-query: 5.3.2
       axobject-query: 4.1.0
       eslint: 8.57.0
       typescript: 5.7.3
     dev: true
 
-  /@angular-eslint/eslint-plugin-template@19.0.2(@typescript-eslint/types@8.24.1)(@typescript-eslint/utils@8.24.1)(eslint@8.57.1)(typescript@5.7.3):
-    resolution: {integrity: sha512-f/OCF9ThnxQ8m0eNYPwnCrySQPhYfCOF6STL7F9LnS8Bs3ZeW3/oT1yLaMIZ1Eg0ogIkgxksMAJZjrJPUPBD1Q==}
-    peerDependencies:
-      '@typescript-eslint/types': ^7.11.0 || ^8.0.0
-      '@typescript-eslint/utils': ^7.11.0 || ^8.0.0
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '*'
-    dependencies:
-      '@angular-eslint/bundled-angular-compiler': 19.0.2
-      '@angular-eslint/utils': 19.0.2(@typescript-eslint/utils@8.24.1)(eslint@8.57.1)(typescript@5.7.3)
-      '@typescript-eslint/types': 8.24.1
-      '@typescript-eslint/utils': 8.24.1(eslint@8.57.1)(typescript@5.7.3)
-      aria-query: 5.3.2
-      axobject-query: 4.1.0
-      eslint: 8.57.1
-      typescript: 5.7.3
-    dev: true
-
-  /@angular-eslint/eslint-plugin@19.0.2(@typescript-eslint/utils@8.24.1)(eslint@8.57.0)(typescript@5.7.3):
+  /@angular-eslint/eslint-plugin@19.0.2(@typescript-eslint/utils@8.25.0)(eslint@8.57.0)(typescript@5.7.3):
     resolution: {integrity: sha512-DLuNVVGGFicSThOcMSJyNje+FZSPdG0B3lCBRiqcgKH/16kfM4pV8MobPM7RGK2NhaOmmZ4zzJNwpwWPSgi+Lw==}
     peerDependencies:
       '@typescript-eslint/utils': ^7.11.0 || ^8.0.0
@@ -3265,51 +3106,19 @@ packages:
       typescript: '*'
     dependencies:
       '@angular-eslint/bundled-angular-compiler': 19.0.2
-      '@angular-eslint/utils': 19.0.2(@typescript-eslint/utils@8.24.1)(eslint@8.57.0)(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.24.1(eslint@8.57.0)(typescript@5.7.3)
+      '@angular-eslint/utils': 19.0.2(@typescript-eslint/utils@8.25.0)(eslint@8.57.0)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.25.0(eslint@8.57.0)(typescript@5.7.3)
       eslint: 8.57.0
       typescript: 5.7.3
     dev: true
 
-  /@angular-eslint/eslint-plugin@19.0.2(@typescript-eslint/utils@8.24.1)(eslint@8.57.1)(typescript@5.7.3):
-    resolution: {integrity: sha512-DLuNVVGGFicSThOcMSJyNje+FZSPdG0B3lCBRiqcgKH/16kfM4pV8MobPM7RGK2NhaOmmZ4zzJNwpwWPSgi+Lw==}
-    peerDependencies:
-      '@typescript-eslint/utils': ^7.11.0 || ^8.0.0
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '*'
-    dependencies:
-      '@angular-eslint/bundled-angular-compiler': 19.0.2
-      '@angular-eslint/utils': 19.0.2(@typescript-eslint/utils@8.24.1)(eslint@8.57.1)(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.24.1(eslint@8.57.1)(typescript@5.7.3)
-      eslint: 8.57.1
-      typescript: 5.7.3
-    dev: true
-
-  /@angular-eslint/schematics@19.0.2(@typescript-eslint/types@8.24.1)(@typescript-eslint/utils@8.24.1)(eslint@8.57.0)(typescript@5.7.3):
+  /@angular-eslint/schematics@19.0.2(@typescript-eslint/types@8.25.0)(@typescript-eslint/utils@8.25.0)(eslint@8.57.0)(typescript@5.7.3):
     resolution: {integrity: sha512-wI4SyiAnUCrpigtK6PHRlVWMC9vWljqmlLhbsJV5O5yDajlmRdvgXvSHDefhJm0hSfvZYRXuiAARYv2+QVfnGA==}
     dependencies:
       '@angular-devkit/core': 19.1.6
       '@angular-devkit/schematics': 19.1.6
-      '@angular-eslint/eslint-plugin': 19.0.2(@typescript-eslint/utils@8.24.1)(eslint@8.57.0)(typescript@5.7.3)
-      '@angular-eslint/eslint-plugin-template': 19.0.2(@typescript-eslint/types@8.24.1)(@typescript-eslint/utils@8.24.1)(eslint@8.57.0)(typescript@5.7.3)
-      ignore: 6.0.2
-      semver: 7.6.3
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - '@typescript-eslint/types'
-      - '@typescript-eslint/utils'
-      - chokidar
-      - eslint
-      - typescript
-    dev: true
-
-  /@angular-eslint/schematics@19.0.2(@typescript-eslint/types@8.24.1)(@typescript-eslint/utils@8.24.1)(eslint@8.57.1)(typescript@5.7.3):
-    resolution: {integrity: sha512-wI4SyiAnUCrpigtK6PHRlVWMC9vWljqmlLhbsJV5O5yDajlmRdvgXvSHDefhJm0hSfvZYRXuiAARYv2+QVfnGA==}
-    dependencies:
-      '@angular-devkit/core': 19.1.6
-      '@angular-devkit/schematics': 19.1.6
-      '@angular-eslint/eslint-plugin': 19.0.2(@typescript-eslint/utils@8.24.1)(eslint@8.57.1)(typescript@5.7.3)
-      '@angular-eslint/eslint-plugin-template': 19.0.2(@typescript-eslint/types@8.24.1)(@typescript-eslint/utils@8.24.1)(eslint@8.57.1)(typescript@5.7.3)
+      '@angular-eslint/eslint-plugin': 19.0.2(@typescript-eslint/utils@8.25.0)(eslint@8.57.0)(typescript@5.7.3)
+      '@angular-eslint/eslint-plugin-template': 19.0.2(@typescript-eslint/types@8.25.0)(@typescript-eslint/utils@8.25.0)(eslint@8.57.0)(typescript@5.7.3)
       ignore: 6.0.2
       semver: 7.6.3
       strip-json-comments: 3.1.1
@@ -3333,19 +3142,7 @@ packages:
       typescript: 5.7.3
     dev: true
 
-  /@angular-eslint/template-parser@19.0.2(eslint@8.57.1)(typescript@5.7.3):
-    resolution: {integrity: sha512-z3rZd2sBfuYcFf9rGDsB2zz2fbGX8kkF+0ftg9eocyQmzWrlZHFmuw9ha7oP/Mz8gpblyCS/aa1U/Srs6gz0UQ==}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '*'
-    dependencies:
-      '@angular-eslint/bundled-angular-compiler': 19.0.2
-      eslint: 8.57.1
-      eslint-scope: 8.2.0
-      typescript: 5.7.3
-    dev: true
-
-  /@angular-eslint/utils@19.0.2(@typescript-eslint/utils@8.24.1)(eslint@8.57.0)(typescript@5.7.3):
+  /@angular-eslint/utils@19.0.2(@typescript-eslint/utils@8.25.0)(eslint@8.57.0)(typescript@5.7.3):
     resolution: {integrity: sha512-HotBT8OKr7zCaX1S9k27JuhRiTVIbbYVl6whlb3uwdMIPIWY8iOcEh1tjI4qDPUafpLfR72Dhwi5bO1E17F3/Q==}
     peerDependencies:
       '@typescript-eslint/utils': ^7.11.0 || ^8.0.0
@@ -3353,21 +3150,8 @@ packages:
       typescript: '*'
     dependencies:
       '@angular-eslint/bundled-angular-compiler': 19.0.2
-      '@typescript-eslint/utils': 8.24.1(eslint@8.57.0)(typescript@5.7.3)
+      '@typescript-eslint/utils': 8.25.0(eslint@8.57.0)(typescript@5.7.3)
       eslint: 8.57.0
-      typescript: 5.7.3
-    dev: true
-
-  /@angular-eslint/utils@19.0.2(@typescript-eslint/utils@8.24.1)(eslint@8.57.1)(typescript@5.7.3):
-    resolution: {integrity: sha512-HotBT8OKr7zCaX1S9k27JuhRiTVIbbYVl6whlb3uwdMIPIWY8iOcEh1tjI4qDPUafpLfR72Dhwi5bO1E17F3/Q==}
-    peerDependencies:
-      '@typescript-eslint/utils': ^7.11.0 || ^8.0.0
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '*'
-    dependencies:
-      '@angular-eslint/bundled-angular-compiler': 19.0.2
-      '@typescript-eslint/utils': 8.24.1(eslint@8.57.1)(typescript@5.7.3)
-      eslint: 8.57.1
       typescript: 5.7.3
     dev: true
 
@@ -3381,7 +3165,7 @@ packages:
       tslib: 2.8.1
     dev: true
 
-  /@angular/build@19.1.6(@angular/compiler-cli@19.1.4)(@angular/compiler@19.1.4)(@types/node@22.13.5)(less@4.2.1)(ng-packagr@16.2.3)(postcss@8.4.49)(terser@5.37.0)(typescript@5.7.3):
+  /@angular/build@19.1.6(@angular/compiler-cli@19.1.4)(@angular/compiler@19.1.4)(@types/node@22.13.8)(less@4.2.1)(ng-packagr@16.2.3)(postcss@8.4.49)(terser@5.37.0)(typescript@5.7.3):
     resolution: {integrity: sha512-6zGdMxMITBj5oVRDKcOL+ufrCSsPLPd5AeRcGkaCYQDshaOmn0UXL4HQylU3nswhVT0dtCd4eDA7fh2dlyVF6A==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
     peerDependencies:
@@ -3423,7 +3207,7 @@ packages:
       '@babel/helper-annotate-as-pure': 7.25.9
       '@babel/helper-split-export-declaration': 7.24.7
       '@babel/plugin-syntax-import-attributes': 7.26.0(@babel/core@7.26.0)
-      '@inquirer/confirm': 5.1.1(@types/node@22.13.5)
+      '@inquirer/confirm': 5.1.1(@types/node@22.13.8)
       '@vitejs/plugin-basic-ssl': 1.2.0(vite@6.0.11)
       beasties: 0.2.0
       browserslist: 4.24.4
@@ -3444,7 +3228,7 @@ packages:
       sass: 1.83.1
       semver: 7.6.3
       typescript: 5.7.3
-      vite: 6.0.11(@types/node@22.13.5)(less@4.2.1)(sass@1.83.1)(terser@5.37.0)
+      vite: 6.0.11(@types/node@22.13.8)(less@4.2.1)(sass@1.83.1)(terser@5.37.0)
       watchpack: 2.4.2
     optionalDependencies:
       lmdb: 3.2.2
@@ -3462,7 +3246,7 @@ packages:
       - yaml
     dev: true
 
-  /@angular/cli@19.1.6(@types/node@22.13.5):
+  /@angular/cli@19.1.6(@types/node@22.13.8):
     resolution: {integrity: sha512-5H9Ri+YNPBnac/h1wTPQ+9mLSXfT1n99FwCtMVy6YnG+akRqOKFmPWB29hkFQAgfXi/MYIj+rQKv+d/9yWJibQ==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
     hasBin: true
@@ -3470,7 +3254,7 @@ packages:
       '@angular-devkit/architect': 0.1901.6
       '@angular-devkit/core': 19.1.6
       '@angular-devkit/schematics': 19.1.6
-      '@inquirer/prompts': 7.2.1(@types/node@22.13.5)
+      '@inquirer/prompts': 7.2.1(@types/node@22.13.8)
       '@listr2/prompt-adapter-inquirer': 2.0.18(@inquirer/prompts@7.2.1)
       '@schematics/angular': 19.1.6
       '@yarnpkg/lockfile': 1.1.0
@@ -5698,8 +5482,8 @@ packages:
       jwt-decode: 4.0.0
     dev: false
 
-  /@descope/core-js-sdk@2.35.0:
-    resolution: {integrity: sha512-0nWjqgAVR8Pi3VAUjDgzc+ltp+NhgN0nTAbGMbxfEM8d9OTmu9dfnEfvAJCouP45uMuCE0XXiOGgWBsCYlbHOw==}
+  /@descope/core-js-sdk@2.36.0:
+    resolution: {integrity: sha512-FB99bAJml//Dm/QtX7KCjpK+/1FkZDUN3ZNqCsirxt+mKYaIC6CoI6xibYFgIPA4AhrM15cFb3hP5Nzo0YQVNA==}
     requiresBuild: true
     dependencies:
       jwt-decode: 4.0.0
@@ -5751,11 +5535,11 @@ packages:
       - supports-color
     dev: true
 
-  /@descope/web-js-sdk@1.24.1:
-    resolution: {integrity: sha512-b08ctr532mSb8yzCmidO53FnThEtn9sUWnf9q0LiQ7b0L7Kh7GfhgyH1jB9DTMLKJe0lQwdeZDLAjCTR7T55eA==}
+  /@descope/web-js-sdk@1.25.0:
+    resolution: {integrity: sha512-Fx5Tyrf6cxse5qUdaFBAk3aDT6LZooMcu1rhp6XTT3ZuBeKHnJRrI3E8FDSBdqGIPF/0G3uW4dq2QX+h6vUj2Q==}
     requiresBuild: true
     dependencies:
-      '@descope/core-js-sdk': 2.35.0
+      '@descope/core-js-sdk': 2.36.0
       '@fingerprintjs/fingerprintjs-pro': 3.11.6
       js-cookie: 3.0.5
       jwt-decode: 4.0.0
@@ -6511,16 +6295,6 @@ packages:
       eslint-visitor-keys: 3.4.3
     dev: true
 
-  /@eslint-community/eslint-utils@4.4.1(eslint@8.57.1):
-    resolution: {integrity: sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-    dependencies:
-      eslint: 8.57.1
-      eslint-visitor-keys: 3.4.3
-    dev: true
-
   /@eslint-community/eslint-utils@4.4.1(eslint@9.18.0):
     resolution: {integrity: sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -6934,7 +6708,7 @@ packages:
     dev: true
     optional: true
 
-  /@inquirer/checkbox@4.1.1(@types/node@22.13.5):
+  /@inquirer/checkbox@4.1.1(@types/node@22.13.8):
     resolution: {integrity: sha512-os5kFd/52gZTl/W6xqMfhaKVJHQM8V/U1P8jcSaQJ/C4Qhdrf2jEXdA/HaxfQs9iiUA/0yzYhk5d3oRHTxGDDQ==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -6943,10 +6717,10 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@inquirer/core': 10.1.6(@types/node@22.13.5)
+      '@inquirer/core': 10.1.6(@types/node@22.13.8)
       '@inquirer/figures': 1.0.10
-      '@inquirer/type': 3.0.4(@types/node@22.13.5)
-      '@types/node': 22.13.5
+      '@inquirer/type': 3.0.4(@types/node@22.13.8)
+      '@types/node': 22.13.8
       ansi-escapes: 4.3.2
       yoctocolors-cjs: 2.1.2
     dev: true
@@ -6959,18 +6733,18 @@ packages:
       '@inquirer/type': 1.5.1
     dev: true
 
-  /@inquirer/confirm@5.1.1(@types/node@22.13.5):
+  /@inquirer/confirm@5.1.1(@types/node@22.13.8):
     resolution: {integrity: sha512-vVLSbGci+IKQvDOtzpPTCOiEJCNidHcAq9JYVoWTW0svb5FiwSLotkM+JXNXejfjnzVYV9n0DTBythl9+XgTxg==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
     dependencies:
-      '@inquirer/core': 10.1.6(@types/node@22.13.5)
-      '@inquirer/type': 3.0.4(@types/node@22.13.5)
-      '@types/node': 22.13.5
+      '@inquirer/core': 10.1.6(@types/node@22.13.8)
+      '@inquirer/type': 3.0.4(@types/node@22.13.8)
+      '@types/node': 22.13.8
     dev: true
 
-  /@inquirer/confirm@5.1.5(@types/node@22.13.5):
+  /@inquirer/confirm@5.1.5(@types/node@22.13.8):
     resolution: {integrity: sha512-ZB2Cz8KeMINUvoeDi7IrvghaVkYT2RB0Zb31EaLWOE87u276w4wnApv0SH2qWaJ3r0VSUa3BIuz7qAV2ZvsZlg==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -6979,12 +6753,12 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@inquirer/core': 10.1.6(@types/node@22.13.5)
-      '@inquirer/type': 3.0.4(@types/node@22.13.5)
-      '@types/node': 22.13.5
+      '@inquirer/core': 10.1.6(@types/node@22.13.8)
+      '@inquirer/type': 3.0.4(@types/node@22.13.8)
+      '@types/node': 22.13.8
     dev: true
 
-  /@inquirer/core@10.1.6(@types/node@22.13.5):
+  /@inquirer/core@10.1.6(@types/node@22.13.8):
     resolution: {integrity: sha512-Bwh/Zk6URrHwZnSSzAZAKH7YgGYi0xICIBDFOqBQoXNNAzBHw/bgXgLmChfp+GyR3PnChcTbiCTZGC6YJNJkMA==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -6994,8 +6768,8 @@ packages:
         optional: true
     dependencies:
       '@inquirer/figures': 1.0.10
-      '@inquirer/type': 3.0.4(@types/node@22.13.5)
-      '@types/node': 22.13.5
+      '@inquirer/type': 3.0.4(@types/node@22.13.8)
+      '@types/node': 22.13.8
       ansi-escapes: 4.3.2
       cli-width: 4.1.0
       mute-stream: 2.0.0
@@ -7023,7 +6797,7 @@ packages:
       yoctocolors-cjs: 2.1.2
     dev: true
 
-  /@inquirer/editor@4.2.6(@types/node@22.13.5):
+  /@inquirer/editor@4.2.6(@types/node@22.13.8):
     resolution: {integrity: sha512-l0smvr8g/KAVdXx4I92sFxZiaTG4kFc06cFZw+qqwTirwdUHMFLnouXBB9OafWhpO3cfEkEz2CdPoCmor3059A==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -7032,13 +6806,13 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@inquirer/core': 10.1.6(@types/node@22.13.5)
-      '@inquirer/type': 3.0.4(@types/node@22.13.5)
-      '@types/node': 22.13.5
+      '@inquirer/core': 10.1.6(@types/node@22.13.8)
+      '@inquirer/type': 3.0.4(@types/node@22.13.8)
+      '@types/node': 22.13.8
       external-editor: 3.1.0
     dev: true
 
-  /@inquirer/expand@4.0.8(@types/node@22.13.5):
+  /@inquirer/expand@4.0.8(@types/node@22.13.8):
     resolution: {integrity: sha512-k0ouAC6L+0Yoj/j0ys2bat0fYcyFVtItDB7h+pDFKaDDSFJey/C/YY1rmIOqkmFVZ5rZySeAQuS8zLcKkKRLmg==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -7047,9 +6821,9 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@inquirer/core': 10.1.6(@types/node@22.13.5)
-      '@inquirer/type': 3.0.4(@types/node@22.13.5)
-      '@types/node': 22.13.5
+      '@inquirer/core': 10.1.6(@types/node@22.13.8)
+      '@inquirer/type': 3.0.4(@types/node@22.13.8)
+      '@types/node': 22.13.8
       yoctocolors-cjs: 2.1.2
     dev: true
 
@@ -7063,7 +6837,7 @@ packages:
     engines: {node: '>=18'}
     dev: true
 
-  /@inquirer/input@4.1.5(@types/node@22.13.5):
+  /@inquirer/input@4.1.5(@types/node@22.13.8):
     resolution: {integrity: sha512-bB6wR5wBCz5zbIVBPnhp94BHv/G4eKbUEjlpCw676pI2chcvzTx1MuwZSCZ/fgNOdqDlAxkhQ4wagL8BI1D3Zg==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -7072,12 +6846,12 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@inquirer/core': 10.1.6(@types/node@22.13.5)
-      '@inquirer/type': 3.0.4(@types/node@22.13.5)
-      '@types/node': 22.13.5
+      '@inquirer/core': 10.1.6(@types/node@22.13.8)
+      '@inquirer/type': 3.0.4(@types/node@22.13.8)
+      '@types/node': 22.13.8
     dev: true
 
-  /@inquirer/number@3.0.8(@types/node@22.13.5):
+  /@inquirer/number@3.0.8(@types/node@22.13.8):
     resolution: {integrity: sha512-CTKs+dT1gw8dILVWATn8Ugik1OHLkkfY82J+Musb57KpmF6EKyskv8zmMiEJPzOnLTZLo05X/QdMd8VH9oulXw==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -7086,12 +6860,12 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@inquirer/core': 10.1.6(@types/node@22.13.5)
-      '@inquirer/type': 3.0.4(@types/node@22.13.5)
-      '@types/node': 22.13.5
+      '@inquirer/core': 10.1.6(@types/node@22.13.8)
+      '@inquirer/type': 3.0.4(@types/node@22.13.8)
+      '@types/node': 22.13.8
     dev: true
 
-  /@inquirer/password@4.0.8(@types/node@22.13.5):
+  /@inquirer/password@4.0.8(@types/node@22.13.8):
     resolution: {integrity: sha512-MgA+Z7o3K1df2lGY649fyOBowHGfrKRz64dx3+b6c1w+h2W7AwBoOkHhhF/vfhbs5S4vsKNCuDzS3s9r5DpK1g==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -7100,32 +6874,32 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@inquirer/core': 10.1.6(@types/node@22.13.5)
-      '@inquirer/type': 3.0.4(@types/node@22.13.5)
-      '@types/node': 22.13.5
+      '@inquirer/core': 10.1.6(@types/node@22.13.8)
+      '@inquirer/type': 3.0.4(@types/node@22.13.8)
+      '@types/node': 22.13.8
       ansi-escapes: 4.3.2
     dev: true
 
-  /@inquirer/prompts@7.2.1(@types/node@22.13.5):
+  /@inquirer/prompts@7.2.1(@types/node@22.13.8):
     resolution: {integrity: sha512-v2JSGri6/HXSfoGIwuKEn8sNCQK6nsB2BNpy2lSX6QH9bsECrMv93QHnj5+f+1ZWpF/VNioIV2B/PDox8EvGuQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
     dependencies:
-      '@inquirer/checkbox': 4.1.1(@types/node@22.13.5)
-      '@inquirer/confirm': 5.1.5(@types/node@22.13.5)
-      '@inquirer/editor': 4.2.6(@types/node@22.13.5)
-      '@inquirer/expand': 4.0.8(@types/node@22.13.5)
-      '@inquirer/input': 4.1.5(@types/node@22.13.5)
-      '@inquirer/number': 3.0.8(@types/node@22.13.5)
-      '@inquirer/password': 4.0.8(@types/node@22.13.5)
-      '@inquirer/rawlist': 4.0.8(@types/node@22.13.5)
-      '@inquirer/search': 3.0.8(@types/node@22.13.5)
-      '@inquirer/select': 4.0.8(@types/node@22.13.5)
-      '@types/node': 22.13.5
+      '@inquirer/checkbox': 4.1.1(@types/node@22.13.8)
+      '@inquirer/confirm': 5.1.5(@types/node@22.13.8)
+      '@inquirer/editor': 4.2.6(@types/node@22.13.8)
+      '@inquirer/expand': 4.0.8(@types/node@22.13.8)
+      '@inquirer/input': 4.1.5(@types/node@22.13.8)
+      '@inquirer/number': 3.0.8(@types/node@22.13.8)
+      '@inquirer/password': 4.0.8(@types/node@22.13.8)
+      '@inquirer/rawlist': 4.0.8(@types/node@22.13.8)
+      '@inquirer/search': 3.0.8(@types/node@22.13.8)
+      '@inquirer/select': 4.0.8(@types/node@22.13.8)
+      '@types/node': 22.13.8
     dev: true
 
-  /@inquirer/rawlist@4.0.8(@types/node@22.13.5):
+  /@inquirer/rawlist@4.0.8(@types/node@22.13.8):
     resolution: {integrity: sha512-hl7rvYW7Xl4un8uohQRUgO6uc2hpn7PKqfcGkCOWC0AA4waBxAv6MpGOFCEDrUaBCP+pXPVqp4LmnpWmn1E1+g==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -7134,13 +6908,13 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@inquirer/core': 10.1.6(@types/node@22.13.5)
-      '@inquirer/type': 3.0.4(@types/node@22.13.5)
-      '@types/node': 22.13.5
+      '@inquirer/core': 10.1.6(@types/node@22.13.8)
+      '@inquirer/type': 3.0.4(@types/node@22.13.8)
+      '@types/node': 22.13.8
       yoctocolors-cjs: 2.1.2
     dev: true
 
-  /@inquirer/search@3.0.8(@types/node@22.13.5):
+  /@inquirer/search@3.0.8(@types/node@22.13.8):
     resolution: {integrity: sha512-ihSE9D3xQAupNg/aGDZaukqoUSXG2KfstWosVmFCG7jbMQPaj2ivxWtsB+CnYY/T4D6LX1GHKixwJLunNCffww==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -7149,14 +6923,14 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@inquirer/core': 10.1.6(@types/node@22.13.5)
+      '@inquirer/core': 10.1.6(@types/node@22.13.8)
       '@inquirer/figures': 1.0.10
-      '@inquirer/type': 3.0.4(@types/node@22.13.5)
-      '@types/node': 22.13.5
+      '@inquirer/type': 3.0.4(@types/node@22.13.8)
+      '@types/node': 22.13.8
       yoctocolors-cjs: 2.1.2
     dev: true
 
-  /@inquirer/select@4.0.8(@types/node@22.13.5):
+  /@inquirer/select@4.0.8(@types/node@22.13.8):
     resolution: {integrity: sha512-Io2prxFyN2jOCcu4qJbVoilo19caiD3kqkD3WR0q3yDA5HUCo83v4LrRtg55ZwniYACW64z36eV7gyVbOfORjA==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -7165,10 +6939,10 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@inquirer/core': 10.1.6(@types/node@22.13.5)
+      '@inquirer/core': 10.1.6(@types/node@22.13.8)
       '@inquirer/figures': 1.0.10
-      '@inquirer/type': 3.0.4(@types/node@22.13.5)
-      '@types/node': 22.13.5
+      '@inquirer/type': 3.0.4(@types/node@22.13.8)
+      '@types/node': 22.13.8
       ansi-escapes: 4.3.2
       yoctocolors-cjs: 2.1.2
     dev: true
@@ -7187,7 +6961,7 @@ packages:
       mute-stream: 1.0.0
     dev: true
 
-  /@inquirer/type@3.0.4(@types/node@22.13.5):
+  /@inquirer/type@3.0.4(@types/node@22.13.8):
     resolution: {integrity: sha512-2MNFrDY8jkFYc9Il9DgLsHhMzuHnOYM1+CUYVWbzu9oT0hC7V7EcYvdCKeoll/Fcci04A+ERZ9wcc7cQ8lTkIA==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -7196,7 +6970,7 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@types/node': 22.13.5
+      '@types/node': 22.13.8
     dev: true
 
   /@isaacs/cliui@8.0.2:
@@ -7683,7 +7457,7 @@ packages:
     peerDependencies:
       '@inquirer/prompts': '>= 3 < 8'
     dependencies:
-      '@inquirer/prompts': 7.2.1(@types/node@22.13.5)
+      '@inquirer/prompts': 7.2.1(@types/node@22.13.8)
       '@inquirer/type': 1.5.5
     dev: true
 
@@ -8528,14 +8302,6 @@ packages:
       - nx
     dev: true
 
-  /@nrwl/devkit@19.8.4(nx@19.8.4):
-    resolution: {integrity: sha512-OoIqDjj2mWzLs3aSF6w5OiC2xywYi/jBxHc7t7Lyi56Vc4dQq8vJMELa9WtG6qH0k05fF7N+jAoKlfvLgbbEFA==}
-    dependencies:
-      '@nx/devkit': 19.8.4(nx@19.8.4)
-    transitivePeerDependencies:
-      - nx
-    dev: true
-
   /@nrwl/eslint-plugin-nx@19.8.4(@types/node@20.17.13)(@typescript-eslint/parser@7.2.0)(eslint-config-prettier@9.1.0)(eslint@9.18.0)(nx@19.8.14)(typescript@5.7.3):
     resolution: {integrity: sha512-D2RsuKOwuF3SO9/tA2R93zL2ixampDlQC8+6E7wfcU+KdfMhhGFG2+r53F98Q8cZKMt5Wls2nGSGpj2CWxCk5A==}
     dependencies:
@@ -8717,7 +8483,7 @@ packages:
     peerDependencies:
       nx: '>= 17 <= 20'
     dependencies:
-      '@nrwl/devkit': 19.8.4(nx@19.8.4)
+      '@nrwl/devkit': 19.8.4(nx@19.8.14)
       ejs: 3.1.10
       enquirer: 2.3.6
       ignore: 5.3.2
@@ -9778,8 +9544,8 @@ packages:
     dev: true
     optional: true
 
-  /@rollup/rollup-android-arm-eabi@4.34.8:
-    resolution: {integrity: sha512-q217OSE8DTp8AFHuNHXo0Y86e1wtlfVrXiAlwkIvGRQv9zbc6mE3sjIVfwI8sYUyNxwOg0j/Vm1RKM04JcWLJw==}
+  /@rollup/rollup-android-arm-eabi@4.34.9:
+    resolution: {integrity: sha512-qZdlImWXur0CFakn2BJ2znJOdqYZKiedEPEVNTBrpfPjc/YuTGcaYZcdmNFTkUj3DU0ZM/AElcM8Ybww3xVLzA==}
     cpu: [arm]
     os: [android]
     requiresBuild: true
@@ -9810,8 +9576,8 @@ packages:
     dev: true
     optional: true
 
-  /@rollup/rollup-android-arm64@4.34.8:
-    resolution: {integrity: sha512-Gigjz7mNWaOL9wCggvoK3jEIUUbGul656opstjaUSGC3eT0BM7PofdAJaBfPFWWkXNVAXbaQtC99OCg4sJv70Q==}
+  /@rollup/rollup-android-arm64@4.34.9:
+    resolution: {integrity: sha512-4KW7P53h6HtJf5Y608T1ISKvNIYLWRKMvfnG0c44M6In4DQVU58HZFEVhWINDZKp7FZps98G3gxwC1sb0wXUUg==}
     cpu: [arm64]
     os: [android]
     requiresBuild: true
@@ -9842,8 +9608,8 @@ packages:
     dev: true
     optional: true
 
-  /@rollup/rollup-darwin-arm64@4.34.8:
-    resolution: {integrity: sha512-02rVdZ5tgdUNRxIUrFdcMBZQoaPMrxtwSb+/hOfBdqkatYHR3lZ2A2EGyHq2sGOd0Owk80oV3snlDASC24He3Q==}
+  /@rollup/rollup-darwin-arm64@4.34.9:
+    resolution: {integrity: sha512-0CY3/K54slrzLDjOA7TOjN1NuLKERBgk9nY5V34mhmuu673YNb+7ghaDUs6N0ujXR7fz5XaS5Aa6d2TNxZd0OQ==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
@@ -9874,8 +9640,8 @@ packages:
     dev: true
     optional: true
 
-  /@rollup/rollup-darwin-x64@4.34.8:
-    resolution: {integrity: sha512-qIP/elwR/tq/dYRx3lgwK31jkZvMiD6qUtOycLhTzCvrjbZ3LjQnEM9rNhSGpbLXVJYQ3rq39A6Re0h9tU2ynw==}
+  /@rollup/rollup-darwin-x64@4.34.9:
+    resolution: {integrity: sha512-eOojSEAi/acnsJVYRxnMkPFqcxSMFfrw7r2iD9Q32SGkb/Q9FpUY1UlAu1DH9T7j++gZ0lHjnm4OyH2vCI7l7Q==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
@@ -9898,8 +9664,8 @@ packages:
     dev: true
     optional: true
 
-  /@rollup/rollup-freebsd-arm64@4.34.8:
-    resolution: {integrity: sha512-IQNVXL9iY6NniYbTaOKdrlVP3XIqazBgJOVkddzJlqnCpRi/yAeSOa8PLcECFSQochzqApIOE1GHNu3pCz+BDA==}
+  /@rollup/rollup-freebsd-arm64@4.34.9:
+    resolution: {integrity: sha512-2lzjQPJbN5UnHm7bHIUKFMulGTQwdvOkouJDpPysJS+QFBGDJqcfh+CxxtG23Ik/9tEvnebQiylYoazFMAgrYw==}
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
@@ -9922,8 +9688,8 @@ packages:
     dev: true
     optional: true
 
-  /@rollup/rollup-freebsd-x64@4.34.8:
-    resolution: {integrity: sha512-TYXcHghgnCqYFiE3FT5QwXtOZqDj5GmaFNTNt3jNC+vh22dc/ukG2cG+pi75QO4kACohZzidsq7yKTKwq/Jq7Q==}
+  /@rollup/rollup-freebsd-x64@4.34.9:
+    resolution: {integrity: sha512-SLl0hi2Ah2H7xQYd6Qaiu01kFPzQ+hqvdYSoOtHYg/zCIFs6t8sV95kaoqjzjFwuYQLtOI0RZre/Ke0nPaQV+g==}
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
@@ -9954,8 +9720,8 @@ packages:
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-arm-gnueabihf@4.34.8:
-    resolution: {integrity: sha512-A4iphFGNkWRd+5m3VIGuqHnG3MVnqKe7Al57u9mwgbyZ2/xF9Jio72MaY7xxh+Y87VAHmGQr73qoKL9HPbXj1g==}
+  /@rollup/rollup-linux-arm-gnueabihf@4.34.9:
+    resolution: {integrity: sha512-88I+D3TeKItrw+Y/2ud4Tw0+3CxQ2kLgu3QvrogZ0OfkmX/DEppehus7L3TS2Q4lpB+hYyxhkQiYPJ6Mf5/dPg==}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
@@ -9986,8 +9752,8 @@ packages:
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-arm-musleabihf@4.34.8:
-    resolution: {integrity: sha512-S0lqKLfTm5u+QTxlFiAnb2J/2dgQqRy/XvziPtDd1rKZFXHTyYLoVL58M/XFwDI01AQCDIevGLbQrMAtdyanpA==}
+  /@rollup/rollup-linux-arm-musleabihf@4.34.9:
+    resolution: {integrity: sha512-3qyfWljSFHi9zH0KgtEPG4cBXHDFhwD8kwg6xLfHQ0IWuH9crp005GfoUUh/6w9/FWGBwEHg3lxK1iHRN1MFlA==}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
@@ -10018,8 +9784,8 @@ packages:
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-arm64-gnu@4.34.8:
-    resolution: {integrity: sha512-jpz9YOuPiSkL4G4pqKrus0pn9aYwpImGkosRKwNi+sJSkz+WU3anZe6hi73StLOQdfXYXC7hUfsQlTnjMd3s1A==}
+  /@rollup/rollup-linux-arm64-gnu@4.34.9:
+    resolution: {integrity: sha512-6TZjPHjKZUQKmVKMUowF3ewHxctrRR09eYyvT5eFv8w/fXarEra83A2mHTVJLA5xU91aCNOUnM+DWFMSbQ0Nxw==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
@@ -10050,8 +9816,8 @@ packages:
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-arm64-musl@4.34.8:
-    resolution: {integrity: sha512-KdSfaROOUJXgTVxJNAZ3KwkRc5nggDk+06P6lgi1HLv1hskgvxHUKZ4xtwHkVYJ1Rep4GNo+uEfycCRRxht7+Q==}
+  /@rollup/rollup-linux-arm64-musl@4.34.9:
+    resolution: {integrity: sha512-LD2fytxZJZ6xzOKnMbIpgzFOuIKlxVOpiMAXawsAZ2mHBPEYOnLRK5TTEsID6z4eM23DuO88X0Tq1mErHMVq0A==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
@@ -10074,8 +9840,8 @@ packages:
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-loongarch64-gnu@4.34.8:
-    resolution: {integrity: sha512-NyF4gcxwkMFRjgXBM6g2lkT58OWztZvw5KkV2K0qqSnUEqCVcqdh2jN4gQrTn/YUpAcNKyFHfoOZEer9nwo6uQ==}
+  /@rollup/rollup-linux-loongarch64-gnu@4.34.9:
+    resolution: {integrity: sha512-dRAgTfDsn0TE0HI6cmo13hemKpVHOEyeciGtvlBTkpx/F65kTvShtY/EVyZEIfxFkV5JJTuQ9tP5HGBS0hfxIg==}
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
@@ -10106,8 +9872,8 @@ packages:
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-powerpc64le-gnu@4.34.8:
-    resolution: {integrity: sha512-LMJc999GkhGvktHU85zNTDImZVUCJ1z/MbAJTnviiWmmjyckP5aQsHtcujMjpNdMZPT2rQEDBlJfubhs3jsMfw==}
+  /@rollup/rollup-linux-powerpc64le-gnu@4.34.9:
+    resolution: {integrity: sha512-PHcNOAEhkoMSQtMf+rJofwisZqaU8iQ8EaSps58f5HYll9EAY5BSErCZ8qBDMVbq88h4UxaNPlbrKqfWP8RfJA==}
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
@@ -10138,8 +9904,8 @@ packages:
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-riscv64-gnu@4.34.8:
-    resolution: {integrity: sha512-xAQCAHPj8nJq1PI3z8CIZzXuXCstquz7cIOL73HHdXiRcKk8Ywwqtx2wrIy23EcTn4aZ2fLJNBB8d0tQENPCmw==}
+  /@rollup/rollup-linux-riscv64-gnu@4.34.9:
+    resolution: {integrity: sha512-Z2i0Uy5G96KBYKjeQFKbbsB54xFOL5/y1P5wNBsbXB8yE+At3oh0DVMjQVzCJRJSfReiB2tX8T6HUFZ2k8iaKg==}
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
@@ -10170,8 +9936,8 @@ packages:
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-s390x-gnu@4.34.8:
-    resolution: {integrity: sha512-DdePVk1NDEuc3fOe3dPPTb+rjMtuFw89gw6gVWxQFAuEqqSdDKnrwzZHrUYdac7A7dXl9Q2Vflxpme15gUWQFA==}
+  /@rollup/rollup-linux-s390x-gnu@4.34.9:
+    resolution: {integrity: sha512-U+5SwTMoeYXoDzJX5dhDTxRltSrIax8KWwfaaYcynuJw8mT33W7oOgz0a+AaXtGuvhzTr2tVKh5UO8GVANTxyQ==}
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
@@ -10202,8 +9968,8 @@ packages:
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-x64-gnu@4.34.8:
-    resolution: {integrity: sha512-8y7ED8gjxITUltTUEJLQdgpbPh1sUQ0kMTmufRF/Ns5tI9TNMNlhWtmPKKHCU0SilX+3MJkZ0zERYYGIVBYHIA==}
+  /@rollup/rollup-linux-x64-gnu@4.34.9:
+    resolution: {integrity: sha512-FwBHNSOjUTQLP4MG7y6rR6qbGw4MFeQnIBrMe161QGaQoBQLqSUEKlHIiVgF3g/mb3lxlxzJOpIBhaP+C+KP2A==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
@@ -10234,8 +10000,8 @@ packages:
     dev: true
     optional: true
 
-  /@rollup/rollup-linux-x64-musl@4.34.8:
-    resolution: {integrity: sha512-SCXcP0ZpGFIe7Ge+McxY5zKxiEI5ra+GT3QRxL0pMMtxPfpyLAKleZODi1zdRHkz5/BhueUrYtYVgubqe9JBNQ==}
+  /@rollup/rollup-linux-x64-musl@4.34.9:
+    resolution: {integrity: sha512-cYRpV4650z2I3/s6+5/LONkjIz8MBeqrk+vPXV10ORBnshpn8S32bPqQ2Utv39jCiDcO2eJTuSlPXpnvmaIgRA==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
@@ -10266,8 +10032,8 @@ packages:
     dev: true
     optional: true
 
-  /@rollup/rollup-win32-arm64-msvc@4.34.8:
-    resolution: {integrity: sha512-YHYsgzZgFJzTRbth4h7Or0m5O74Yda+hLin0irAIobkLQFRQd1qWmnoVfwmKm9TXIZVAD0nZ+GEb2ICicLyCnQ==}
+  /@rollup/rollup-win32-arm64-msvc@4.34.9:
+    resolution: {integrity: sha512-z4mQK9dAN6byRA/vsSgQiPeuO63wdiDxZ9yg9iyX2QTzKuQM7T4xlBoeUP/J8uiFkqxkcWndWi+W7bXdPbt27Q==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
@@ -10298,8 +10064,8 @@ packages:
     dev: true
     optional: true
 
-  /@rollup/rollup-win32-ia32-msvc@4.34.8:
-    resolution: {integrity: sha512-r3NRQrXkHr4uWy5TOjTpTYojR9XmF0j/RYgKCef+Ag46FWUTltm5ziticv8LdNsDMehjJ543x/+TJAek/xBA2w==}
+  /@rollup/rollup-win32-ia32-msvc@4.34.9:
+    resolution: {integrity: sha512-KB48mPtaoHy1AwDNkAJfHXvHp24H0ryZog28spEs0V48l3H1fr4i37tiyHsgKZJnCmvxsbATdZGBpbmxTE3a9w==}
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
@@ -10330,8 +10096,8 @@ packages:
     dev: true
     optional: true
 
-  /@rollup/rollup-win32-x64-msvc@4.34.8:
-    resolution: {integrity: sha512-U0FaE5O1BCpZSeE6gBl3c5ObhePQSfk9vDRToMmTkbhCOgW4jqvtS5LGyQ76L1fH8sM0keRp4uDTsbjiUyjk0g==}
+  /@rollup/rollup-win32-x64-msvc@4.34.9:
+    resolution: {integrity: sha512-AyleYRPU7+rgkMWbEh71fQlrzRfeP6SyMnRf9XX4fCdDPAJumdSBqYEcWPMzVQ4ScAl7E4oFfK0GUVn77xSwbw==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
@@ -10699,7 +10465,7 @@ packages:
       chalk: 3.0.0
       css.escape: 1.5.1
       dom-accessibility-api: 0.6.3
-      jest: 29.7.0(@types/node@22.13.5)(ts-node@10.9.2)
+      jest: 29.7.0(@types/node@22.13.8)(ts-node@10.9.2)
       lodash: 4.17.21
       redent: 3.0.0
     dev: true
@@ -11097,8 +10863,8 @@ packages:
       undici-types: 6.19.8
     dev: true
 
-  /@types/node@22.13.5:
-    resolution: {integrity: sha512-+lTU0PxZXn0Dr1NBtC7Y8cR21AJr87dLLU953CWA6pMxxv/UDc7jYAY90upcrie1nRcD6XNG5HOYEDtgW5TxAg==}
+  /@types/node@22.13.8:
+    resolution: {integrity: sha512-G3EfaZS+iOGYWLLRCEAXdWK9my08oHNZ+FHluRiggIYJPOXzhOiDgpVCUHaUvyIC5/fj7C/p637jdzC666AOKQ==}
     dependencies:
       undici-types: 6.20.0
     dev: true
@@ -11374,35 +11140,6 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0)(eslint@8.57.1)(typescript@5.7.3):
-    resolution: {integrity: sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==}
-    engines: {node: ^16.0.0 || >=18.0.0}
-    peerDependencies:
-      '@typescript-eslint/parser': ^6.0.0 || ^6.0.0-alpha
-      eslint: ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@5.7.3)
-      '@typescript-eslint/scope-manager': 6.21.0
-      '@typescript-eslint/type-utils': 6.21.0(eslint@8.57.1)(typescript@5.7.3)
-      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@5.7.3)
-      '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.0
-      eslint: 8.57.1
-      graphemer: 1.4.0
-      ignore: 5.3.2
-      natural-compare: 1.4.0
-      semver: 7.7.1
-      ts-api-utils: 1.3.0(typescript@5.7.3)
-      typescript: 5.7.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0)(eslint@8.57.1)(typescript@5.5.4):
     resolution: {integrity: sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==}
     engines: {node: ^18.18.0 || >=20.0.0}
@@ -11573,27 +11310,6 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.3):
-    resolution: {integrity: sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==}
-    engines: {node: ^16.0.0 || >=18.0.0}
-    peerDependencies:
-      eslint: ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/scope-manager': 6.21.0
-      '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.7.3)
-      '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.0
-      eslint: 8.57.1
-      typescript: 5.7.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.5.4):
     resolution: {integrity: sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==}
     engines: {node: ^18.18.0 || >=20.0.0}
@@ -11718,12 +11434,12 @@ packages:
       '@typescript-eslint/visitor-keys': 8.23.0
     dev: true
 
-  /@typescript-eslint/scope-manager@8.24.1:
-    resolution: {integrity: sha512-OdQr6BNBzwRjNEXMQyaGyZzgg7wzjYKfX2ZBV3E04hUCBDv3GQCHiz9RpqdUIiVrMgJGkXm3tcEh4vFSHreS2Q==}
+  /@typescript-eslint/scope-manager@8.25.0:
+    resolution: {integrity: sha512-6PPeiKIGbgStEyt4NNXa2ru5pMzQ8OYKO1hX1z53HMomrmiSB+R5FmChgQAP1ro8jMtNawz+TRQo/cSXrauTpg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dependencies:
-      '@typescript-eslint/types': 8.24.1
-      '@typescript-eslint/visitor-keys': 8.24.1
+      '@typescript-eslint/types': 8.25.0
+      '@typescript-eslint/visitor-keys': 8.25.0
     dev: true
 
   /@typescript-eslint/type-utils@5.62.0(eslint@7.32.0)(typescript@5.4.5):
@@ -11782,26 +11498,6 @@ packages:
       eslint: 8.57.1
       ts-api-utils: 1.3.0(typescript@5.4.5)
       typescript: 5.4.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/type-utils@6.21.0(eslint@8.57.1)(typescript@5.7.3):
-    resolution: {integrity: sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==}
-    engines: {node: ^16.0.0 || >=18.0.0}
-    peerDependencies:
-      eslint: ^7.0.0 || ^8.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.7.3)
-      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@5.7.3)
-      debug: 4.4.0
-      eslint: 8.57.1
-      ts-api-utils: 1.3.0(typescript@5.7.3)
-      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -11928,8 +11624,8 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dev: true
 
-  /@typescript-eslint/types@8.24.1:
-    resolution: {integrity: sha512-9kqJ+2DkUXiuhoiYIUvIYjGcwle8pcPpdlfkemGvTObzgmYfJ5d0Qm6jwb4NBXP9W1I5tss0VIAnWFumz3mC5A==}
+  /@typescript-eslint/types@8.25.0:
+    resolution: {integrity: sha512-+vUe0Zb4tkNgznQwicsvLUJgZIRs6ITeWSCclX1q85pR1iOiaj+4uZJIUp//Z27QWu5Cseiw3O3AR8hVpax7Aw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dev: true
 
@@ -12149,14 +11845,14 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree@8.24.1(typescript@5.7.3):
-    resolution: {integrity: sha512-UPyy4MJ/0RE648DSKQe9g0VDSehPINiejjA6ElqnFaFIhI6ZEiZAkUI0D5MCk0bQcTf/LVqZStvQ6K4lPn/BRg==}
+  /@typescript-eslint/typescript-estree@8.25.0(typescript@5.7.3):
+    resolution: {integrity: sha512-ZPaiAKEZ6Blt/TPAx5Ot0EIB/yGtLI2EsGoY6F7XKklfMxYQyvtL+gT/UCqkMzO0BVFHLDlzvFqQzurYahxv9Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <5.8.0'
     dependencies:
-      '@typescript-eslint/types': 8.24.1
-      '@typescript-eslint/visitor-keys': 8.24.1
+      '@typescript-eslint/types': 8.25.0
+      '@typescript-eslint/visitor-keys': 8.25.0
       debug: 4.4.0
       fast-glob: 3.3.3
       is-glob: 4.0.3
@@ -12246,25 +11942,6 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/utils@6.21.0(eslint@8.57.1)(typescript@5.7.3):
-    resolution: {integrity: sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==}
-    engines: {node: ^16.0.0 || >=18.0.0}
-    peerDependencies:
-      eslint: ^7.0.0 || ^8.0.0
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.1)
-      '@types/json-schema': 7.0.15
-      '@types/semver': 7.5.8
-      '@typescript-eslint/scope-manager': 6.21.0
-      '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.7.3)
-      eslint: 8.57.1
-      semver: 7.7.1
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: true
-
   /@typescript-eslint/utils@7.18.0(eslint@8.57.1)(typescript@5.4.5):
     resolution: {integrity: sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==}
     engines: {node: ^18.18.0 || >=20.0.0}
@@ -12346,35 +12023,18 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@8.24.1(eslint@8.57.0)(typescript@5.7.3):
-    resolution: {integrity: sha512-OOcg3PMMQx9EXspId5iktsI3eMaXVwlhC8BvNnX6B5w9a4dVgpkQZuU8Hy67TolKcl+iFWq0XX+jbDGN4xWxjQ==}
+  /@typescript-eslint/utils@8.25.0(eslint@8.57.0)(typescript@5.7.3):
+    resolution: {integrity: sha512-syqRbrEv0J1wywiLsK60XzHnQe/kRViI3zwFALrNEgnntn1l24Ra2KvOAWwWbWZ1lBZxZljPDGOq967dsl6fkA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <5.8.0'
     dependencies:
       '@eslint-community/eslint-utils': 4.4.1(eslint@8.57.0)
-      '@typescript-eslint/scope-manager': 8.24.1
-      '@typescript-eslint/types': 8.24.1
-      '@typescript-eslint/typescript-estree': 8.24.1(typescript@5.7.3)
+      '@typescript-eslint/scope-manager': 8.25.0
+      '@typescript-eslint/types': 8.25.0
+      '@typescript-eslint/typescript-estree': 8.25.0(typescript@5.7.3)
       eslint: 8.57.0
-      typescript: 5.7.3
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@typescript-eslint/utils@8.24.1(eslint@8.57.1)(typescript@5.7.3):
-    resolution: {integrity: sha512-OOcg3PMMQx9EXspId5iktsI3eMaXVwlhC8BvNnX6B5w9a4dVgpkQZuU8Hy67TolKcl+iFWq0XX+jbDGN4xWxjQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <5.8.0'
-    dependencies:
-      '@eslint-community/eslint-utils': 4.4.1(eslint@8.57.1)
-      '@typescript-eslint/scope-manager': 8.24.1
-      '@typescript-eslint/types': 8.24.1
-      '@typescript-eslint/typescript-estree': 8.24.1(typescript@5.7.3)
-      eslint: 8.57.1
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
@@ -12420,11 +12080,11 @@ packages:
       eslint-visitor-keys: 4.2.0
     dev: true
 
-  /@typescript-eslint/visitor-keys@8.24.1:
-    resolution: {integrity: sha512-EwVHlp5l+2vp8CoqJm9KikPZgi3gbdZAtabKT9KPShGeOcJhsv4Zdo3oc8T8I0uKEmYoU4ItyxbptjF08enaxg==}
+  /@typescript-eslint/visitor-keys@8.25.0:
+    resolution: {integrity: sha512-kCYXKAum9CecGVHGij7muybDfTS2sD3t0L4bJsEZLkyrXUImiCTq1M3LG2SRtOhiHFwMR9wAFplpT6XHYjTkwQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dependencies:
-      '@typescript-eslint/types': 8.24.1
+      '@typescript-eslint/types': 8.25.0
       eslint-visitor-keys: 4.2.0
     dev: true
 
@@ -12815,16 +12475,16 @@ packages:
     peerDependencies:
       vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
     dependencies:
-      vite: 6.0.11(@types/node@22.13.5)(less@4.2.1)(sass@1.83.1)(terser@5.37.0)
+      vite: 6.0.11(@types/node@22.13.8)(less@4.2.1)(sass@1.83.1)(terser@5.37.0)
     dev: true
 
-  /@vitejs/plugin-basic-ssl@1.2.0(vite@6.1.1):
+  /@vitejs/plugin-basic-ssl@1.2.0(vite@6.2.0):
     resolution: {integrity: sha512-mkQnxTkcldAzIsomk1UuLfAu9n+kpQ3JbHcpCp7d2Oo6ITtji8pHS3QToOWjhPFvNQSnhlkAjmGbhv2QvwO/7Q==}
     engines: {node: '>=14.21.3'}
     peerDependencies:
       vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
     dependencies:
-      vite: 6.1.1(@types/node@22.13.5)(less@4.2.1)
+      vite: 6.2.0(@types/node@22.13.8)(less@4.2.1)
     dev: true
 
   /@vue/babel-helper-vue-jsx-merge-props@1.4.0:
@@ -14379,22 +14039,6 @@ packages:
       normalize-range: 0.1.2
       picocolors: 1.1.1
       postcss: 8.4.49
-      postcss-value-parser: 4.2.0
-    dev: true
-
-  /autoprefixer@10.4.20(postcss@8.5.2):
-    resolution: {integrity: sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==}
-    engines: {node: ^10 || ^12 || >=14}
-    hasBin: true
-    peerDependencies:
-      postcss: ^8.1.0
-    dependencies:
-      browserslist: 4.24.4
-      caniuse-lite: 1.0.30001696
-      fraction.js: 4.3.7
-      normalize-range: 0.1.2
-      picocolors: 1.1.1
-      postcss: 8.5.2
       postcss-value-parser: 4.2.0
     dev: true
 
@@ -16139,7 +15783,7 @@ packages:
       - ts-node
     dev: true
 
-  /create-jest@29.7.0(@types/node@22.13.5)(ts-node@10.9.2):
+  /create-jest@29.7.0(@types/node@22.13.8)(ts-node@10.9.2):
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -16148,7 +15792,7 @@ packages:
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.13.5)(ts-node@10.9.2)
+      jest-config: 29.7.0(@types/node@22.13.8)(ts-node@10.9.2)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -18342,7 +17986,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 6.21.0(@typescript-eslint/parser@6.21.0)(eslint@8.57.1)(typescript@5.4.5)
       '@typescript-eslint/utils': 7.18.0(eslint@8.57.1)(typescript@5.4.5)
       eslint: 8.57.1
-      jest: 29.7.0(@types/node@22.13.5)(ts-node@10.9.2)
+      jest: 29.7.0(@types/node@22.13.8)(ts-node@10.9.2)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -18408,7 +18052,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0)(eslint@8.57.1)(typescript@5.6.3)
       '@typescript-eslint/utils': 7.18.0(eslint@8.57.1)(typescript@5.6.3)
       eslint: 8.57.1
-      jest: 29.7.0(@types/node@22.13.5)(ts-node@10.9.2)
+      jest: 29.7.0(@types/node@22.13.8)(ts-node@10.9.2)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -18548,23 +18192,6 @@ packages:
         optional: true
     dependencies:
       eslint: 8.57.0
-      eslint-config-prettier: 9.1.0(eslint@9.18.0)
-      prettier: 2.8.8
-      prettier-linter-helpers: 1.0.0
-    dev: true
-
-  /eslint-plugin-prettier@4.2.1(eslint-config-prettier@9.1.0)(eslint@8.57.1)(prettier@2.8.8):
-    resolution: {integrity: sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      eslint: '>=7.28.0'
-      eslint-config-prettier: '*'
-      prettier: '>=2.0.0'
-    peerDependenciesMeta:
-      eslint-config-prettier:
-        optional: true
-    dependencies:
-      eslint: 8.57.1
       eslint-config-prettier: 9.1.0(eslint@9.18.0)
       prettier: 2.8.8
       prettier-linter-helpers: 1.0.0
@@ -21453,7 +21080,7 @@ packages:
       - ts-node
     dev: true
 
-  /jest-cli@29.7.0(@types/node@22.13.5)(ts-node@10.9.2):
+  /jest-cli@29.7.0(@types/node@22.13.8)(ts-node@10.9.2):
     resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -21467,10 +21094,10 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.13.5)(ts-node@10.9.2)
+      create-jest: 29.7.0(@types/node@22.13.8)(ts-node@10.9.2)
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@22.13.5)(ts-node@10.9.2)
+      jest-config: 29.7.0(@types/node@22.13.8)(ts-node@10.9.2)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.1
@@ -21604,7 +21231,7 @@ packages:
       - supports-color
     dev: true
 
-  /jest-config@29.7.0(@types/node@22.13.5)(ts-node@10.9.2):
+  /jest-config@29.7.0(@types/node@22.13.8)(ts-node@10.9.2):
     resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -21619,7 +21246,7 @@ packages:
       '@babel/core': 7.26.0
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.13.5
+      '@types/node': 22.13.8
       babel-jest: 29.7.0(@babel/core@7.26.0)
       chalk: 4.1.2
       ci-info: 3.8.0
@@ -21639,7 +21266,7 @@ packages:
       pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.2(@types/node@22.13.5)(typescript@5.6.3)
+      ts-node: 10.9.2(@types/node@22.13.8)(typescript@5.6.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -21880,13 +21507,13 @@ packages:
       jest: ^29.0.0
       typescript: '>=4.4'
     dependencies:
-      '@angular-devkit/build-angular': 19.1.6(@angular/compiler-cli@19.1.4)(@angular/compiler@19.1.4)(@types/node@22.13.5)(jest-environment-jsdom@29.7.0)(jest@29.7.0)(ng-packagr@16.2.3)(typescript@5.7.3)(vite@6.1.1)
+      '@angular-devkit/build-angular': 19.1.6(@angular/compiler-cli@19.1.4)(@angular/compiler@19.1.4)(@types/node@22.13.8)(jest-environment-jsdom@29.7.0)(jest@29.7.0)(ng-packagr@16.2.3)(typescript@5.7.3)(vite@6.2.0)
       '@angular/compiler-cli': 19.1.4(@angular/compiler@19.1.4)(typescript@5.7.3)
       '@angular/core': 19.1.4(rxjs@7.8.1)(zone.js@0.15.0)
       '@angular/platform-browser-dynamic': 19.1.4(@angular/common@19.1.4)(@angular/compiler@19.1.4)(@angular/core@19.1.4)(@angular/platform-browser@19.1.4)
       bs-logger: 0.2.6
       esbuild-wasm: 0.23.0
-      jest: 29.7.0(@types/node@22.13.5)(ts-node@10.9.2)
+      jest: 29.7.0(@types/node@22.13.8)(ts-node@10.9.2)
       jest-environment-jsdom: 29.7.0
       jest-util: 29.7.0
       pretty-format: 29.7.0
@@ -22221,7 +21848,7 @@ packages:
       - ts-node
     dev: true
 
-  /jest@29.7.0(@types/node@22.13.5)(ts-node@10.9.2):
+  /jest@29.7.0(@types/node@22.13.8)(ts-node@10.9.2):
     resolution: {integrity: sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -22234,7 +21861,7 @@ packages:
       '@jest/core': 29.7.0(ts-node@10.9.2)
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@22.13.5)(ts-node@10.9.2)
+      jest-cli: 29.7.0(@types/node@22.13.8)(ts-node@10.9.2)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -23814,50 +23441,6 @@ packages:
       rxjs: 7.8.1
       sass: 1.77.8
       tslib: 2.6.3
-      typescript: 5.7.3
-    optionalDependencies:
-      esbuild: 0.19.12
-    dev: true
-
-  /ng-packagr@16.2.3(@angular/compiler-cli@19.1.4)(tslib@2.8.1)(typescript@5.7.3):
-    resolution: {integrity: sha512-VTJ7Qtge52+1subkhmF5nOqLNbVutA8/igJ0A5vH6Mgpb8Z/3HeZomtD1SHzZF5Dqp+p+QPHE548FWYu1MdMSQ==}
-    engines: {node: ^16.14.0 || >=18.10.0}
-    hasBin: true
-    peerDependencies:
-      '@angular/compiler-cli': ^16.0.0 || ^16.2.0-next.0
-      tailwindcss: ^2.0.0 || ^3.0.0
-      tslib: ^2.3.0
-      typescript: '>=4.9.3 <5.2'
-    peerDependenciesMeta:
-      tailwindcss:
-        optional: true
-    dependencies:
-      '@angular/compiler-cli': 19.1.4(@angular/compiler@19.1.4)(typescript@5.7.3)
-      '@rollup/plugin-json': 6.1.0(rollup@3.29.5)
-      '@rollup/plugin-node-resolve': 15.2.3(rollup@3.29.5)
-      ajv: 8.17.1
-      ansi-colors: 4.1.3
-      autoprefixer: 10.4.20(postcss@8.5.2)
-      browserslist: 4.24.4
-      cacache: 18.0.4
-      chokidar: 3.6.0
-      commander: 11.1.0
-      convert-source-map: 2.0.0
-      dependency-graph: 0.11.0
-      esbuild-wasm: 0.19.12
-      fast-glob: 3.3.3
-      find-cache-dir: 3.3.2
-      injection-js: 2.4.0
-      jsonc-parser: 3.3.1
-      less: 4.2.1
-      ora: 5.4.1
-      piscina: 4.8.0
-      postcss: 8.5.2
-      postcss-url: 10.1.3(postcss@8.5.2)
-      rollup: 3.29.5
-      rxjs: 7.8.1
-      sass: 1.83.1
-      tslib: 2.8.1
       typescript: 5.7.3
     optionalDependencies:
       esbuild: 0.19.12
@@ -25652,19 +25235,6 @@ packages:
       xxhashjs: 0.2.2
     dev: true
 
-  /postcss-url@10.1.3(postcss@8.5.2):
-    resolution: {integrity: sha512-FUzyxfI5l2tKmXdYc6VTu3TWZsInayEKPbiyW+P6vmmIrrb4I6CGX0BFoewgYHLK+oIL5FECEK02REYRpBvUCw==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      postcss: ^8.0.0
-    dependencies:
-      make-dir: 3.1.0
-      mime: 2.5.2
-      minimatch: 3.0.8
-      postcss: 8.5.2
-      xxhashjs: 0.2.2
-    dev: true
-
   /postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
     dev: true
@@ -26966,32 +26536,32 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /rollup@4.34.8:
-    resolution: {integrity: sha512-489gTVMzAYdiZHFVA/ig/iYFllCcWFHMvUHI1rpFmkoUtRlQxqh6/yiNqnYibjMZ2b/+FUQwldG+aLsEt6bglQ==}
+  /rollup@4.34.9:
+    resolution: {integrity: sha512-nF5XYqWWp9hx/LrpC8sZvvvmq0TeTjQgaZHYmAgwysT9nh8sWnZhBnM8ZyVbbJFIQBLwHDNoMqsBZBbUo4U8sQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
     dependencies:
       '@types/estree': 1.0.6
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.34.8
-      '@rollup/rollup-android-arm64': 4.34.8
-      '@rollup/rollup-darwin-arm64': 4.34.8
-      '@rollup/rollup-darwin-x64': 4.34.8
-      '@rollup/rollup-freebsd-arm64': 4.34.8
-      '@rollup/rollup-freebsd-x64': 4.34.8
-      '@rollup/rollup-linux-arm-gnueabihf': 4.34.8
-      '@rollup/rollup-linux-arm-musleabihf': 4.34.8
-      '@rollup/rollup-linux-arm64-gnu': 4.34.8
-      '@rollup/rollup-linux-arm64-musl': 4.34.8
-      '@rollup/rollup-linux-loongarch64-gnu': 4.34.8
-      '@rollup/rollup-linux-powerpc64le-gnu': 4.34.8
-      '@rollup/rollup-linux-riscv64-gnu': 4.34.8
-      '@rollup/rollup-linux-s390x-gnu': 4.34.8
-      '@rollup/rollup-linux-x64-gnu': 4.34.8
-      '@rollup/rollup-linux-x64-musl': 4.34.8
-      '@rollup/rollup-win32-arm64-msvc': 4.34.8
-      '@rollup/rollup-win32-ia32-msvc': 4.34.8
-      '@rollup/rollup-win32-x64-msvc': 4.34.8
+      '@rollup/rollup-android-arm-eabi': 4.34.9
+      '@rollup/rollup-android-arm64': 4.34.9
+      '@rollup/rollup-darwin-arm64': 4.34.9
+      '@rollup/rollup-darwin-x64': 4.34.9
+      '@rollup/rollup-freebsd-arm64': 4.34.9
+      '@rollup/rollup-freebsd-x64': 4.34.9
+      '@rollup/rollup-linux-arm-gnueabihf': 4.34.9
+      '@rollup/rollup-linux-arm-musleabihf': 4.34.9
+      '@rollup/rollup-linux-arm64-gnu': 4.34.9
+      '@rollup/rollup-linux-arm64-musl': 4.34.9
+      '@rollup/rollup-linux-loongarch64-gnu': 4.34.9
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.34.9
+      '@rollup/rollup-linux-riscv64-gnu': 4.34.9
+      '@rollup/rollup-linux-s390x-gnu': 4.34.9
+      '@rollup/rollup-linux-x64-gnu': 4.34.9
+      '@rollup/rollup-linux-x64-musl': 4.34.9
+      '@rollup/rollup-win32-arm64-msvc': 4.34.9
+      '@rollup/rollup-win32-ia32-msvc': 4.34.9
+      '@rollup/rollup-win32-x64-msvc': 4.34.9
       fsevents: 2.3.3
     dev: true
 
@@ -28829,7 +28399,7 @@ packages:
       bs-logger: 0.2.6
       esbuild: 0.25.0
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@22.13.5)(ts-node@10.9.2)
+      jest: 29.7.0(@types/node@22.13.8)(ts-node@10.9.2)
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -28903,7 +28473,7 @@ packages:
       '@babel/core': 7.26.9
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@22.13.5)(ts-node@10.9.2)
+      jest: 29.7.0(@types/node@22.13.8)(ts-node@10.9.2)
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -29060,7 +28630,7 @@ packages:
       yn: 3.1.1
     dev: true
 
-  /ts-node@10.9.2(@swc/core@1.7.1)(@types/node@22.13.5)(typescript@5.4.5):
+  /ts-node@10.9.2(@swc/core@1.7.1)(@types/node@22.13.8)(typescript@5.4.5):
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
     hasBin: true
     peerDependencies:
@@ -29080,7 +28650,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
-      '@types/node': 22.13.5
+      '@types/node': 22.13.8
       acorn: 8.12.1
       acorn-walk: 8.2.0
       arg: 4.1.3
@@ -29185,7 +28755,7 @@ packages:
       yn: 3.1.1
     dev: true
 
-  /ts-node@10.9.2(@types/node@22.13.5)(typescript@5.6.3):
+  /ts-node@10.9.2(@types/node@22.13.8)(typescript@5.6.3):
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
     hasBin: true
     peerDependencies:
@@ -29204,7 +28774,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
-      '@types/node': 22.13.5
+      '@types/node': 22.13.8
       acorn: 8.12.1
       acorn-walk: 8.2.0
       arg: 4.1.3
@@ -29713,7 +29283,7 @@ packages:
     engines: {node: '>= 0.8'}
     dev: true
 
-  /vite@6.0.11(@types/node@22.13.5)(less@4.2.1)(sass@1.83.1)(terser@5.37.0):
+  /vite@6.0.11(@types/node@22.13.8)(less@4.2.1)(sass@1.83.1)(terser@5.37.0):
     resolution: {integrity: sha512-4VL9mQPKoHy4+FE0NnRE/kbY51TOfaknxAjt3fJbGJxhIpBZiqVzlZDEesWWsuREXHwNdAoOFZ9MkPEVXczHwg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
@@ -29753,7 +29323,7 @@ packages:
       yaml:
         optional: true
     dependencies:
-      '@types/node': 22.13.5
+      '@types/node': 22.13.8
       esbuild: 0.24.2
       less: 4.2.1
       postcss: 8.5.2
@@ -29764,8 +29334,8 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vite@6.1.1(@types/node@22.13.5)(less@4.2.1):
-    resolution: {integrity: sha512-4GgM54XrwRfrOp297aIYspIti66k56v16ZnqHvrIM7mG+HjDlAwS7p+Srr7J6fGvEdOJ5JcQ/D9T7HhtdXDTzA==}
+  /vite@6.2.0(@types/node@22.13.8)(less@4.2.1):
+    resolution: {integrity: sha512-7dPxoo+WsT/64rDcwoOjk76XHj+TqNTIvHKcuMQ1k4/SeHDaQt5GFAeLYzrimZrMpn/O6DtdI03WUjdxuPM0oQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -29804,11 +29374,11 @@ packages:
       yaml:
         optional: true
     dependencies:
-      '@types/node': 22.13.5
-      esbuild: 0.24.2
+      '@types/node': 22.13.8
+      esbuild: 0.25.0
       less: 4.2.1
       postcss: 8.5.3
-      rollup: 4.34.8
+      rollup: 4.34.9
     optionalDependencies:
       fsevents: 2.3.3
     dev: true
@@ -30782,7 +30352,7 @@ packages:
       next: 14.2.10(@babel/core@7.26.9)(react-dom@18.3.1)(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
-      '@descope/web-js-sdk': 1.24.1
+      '@descope/web-js-sdk': 1.25.0
     transitivePeerDependencies:
       - encoding
     dev: false
@@ -30805,7 +30375,7 @@ packages:
       next: 14.2.21(@babel/core@7.26.9)(react-dom@18.3.1)(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
-      '@descope/web-js-sdk': 1.24.1
+      '@descope/web-js-sdk': 1.25.0
     transitivePeerDependencies:
       - encoding
     dev: false


### PR DESCRIPTION


## Description
support http session cookie. 
 - take the session expiration from JWT response's top level attribute, and not from the session jwt (which might be on cookie)
 - improve high level sdk state management - to not consider session token existence as `is authenticated` state, but rather  manage this separately 
 
 still missing tests and some other considerations  (see comment in vue sdk)