### PR TITLE
Added Middleware Chaining

### DIFF
--- a/packages/sdks/nextjs-sdk/README.md
+++ b/packages/sdks/nextjs-sdk/README.md
@@ -161,6 +161,52 @@ export const config = {
 }
 ```
 
+##### Chaining Next.js Middleware Together
+
+You can chain the Descope Next.js SDK middleware with other middleware functions to apply multiple layers of processing to incoming requests. 
+
+This can help ensure the following things:
+
+- Authentication before applying other middleware logic.
+- Allows for a more modular middleware architecture.
+- Provides custom handling for different request types.
+
+For example, you can integrate Descope authentication with Next.js internationalization middleware:
+
+```ts
+// src/middleware.ts
+import { authMiddleware } from '@descope/nextjs-sdk/server';
+import createIntlMiddleware from 'next-intl/middleware';
+
+const intlMiddleware = createIntlMiddleware({
+  locales: ['en', 'es', 'fr'],
+  defaultLocale: 'en'
+});
+
+export default async function middleware(req) {
+  const authResponse = await authMiddleware({
+    publicRoutes: ['/home', '/about'],
+    privateRoutes: ['/dashboard', '/profile']
+  })(req);
+
+  if (authResponse) return authResponse; // Redirect if authentication fails
+
+  // Run internationalization middleware
+  return intlMiddleware(req);
+}
+
+export const config = {
+  matcher: ['/((?!_next|.*\\..*).*)', '/(api|trpc)(.*)']
+};
+```
+
+In the code above, we see: 
+
+1. The Descope middleware runs first, ensuring authentication for private routes.
+2. If the user is **not authenticated**, they are redirected before proceeding to other middleware.
+3. If authentication is successful, the request is passed to the next middleware.
+4. Localization middleware processes the request after authentication, setting language preferences.
+
 ##### Public and Private Route Definitions
 
 - **All routes are private by default.**


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/9404

## Related PRs

| branch       | PR         |
| ------------ | ---------- |
| service a PR | Link to PR |
| service b PR | Link to PR |

## Description

Added ability for `createAuthMiddleware` function to support middleware chaining. We can now accept a `next()` function and ensure it correctly forwards the request when authentication is successful.

Also added some code logic cleanup for persisting query parameter during middleware redirection for unauthenticated users.

## Must

- [X] Tests
- [X] Documentation (if applicable)
