### PR TITLE
fix: short timeout

### DIFF
--- a/packages/sdks/nextjs-sdk/README.md
+++ b/packages/sdks/nextjs-sdk/README.md
@@ -1,13 +1,13 @@
-# Descope SDK for NextJS
+# Descope SDK for Next.js
 
-The Descope SDK for NextJS provides convenient access to the Descope for an application written on top of NextJS. You can read more on the [Descope Website](https://descope.com).
+The Descope SDK for Next.js provides convenient access to the Descope for an application written on top of Next.js. You can read more on the [Descope Website](https://descope.com).
 
 This SDK uses under the hood the Descope React SDK and Descope Node SDK
 Refer to the [Descope React SDK](https://github.com/descope/descope-js/tree/main/packages/sdks/react-sdk) and [Descope Node SDK](https://github.com/descope/node-sdk) for more details.
 
 ## Requirements
 
-- The SDK supports NextJS version 13 and above.
+- The SDK supports Next.js version 13 and above.
 - A Descope `Project ID` is required for using the SDK. Find it on the [project page in the Descope Console](https://app.descope.com/settings/project).
 
 ## Installing the SDK
@@ -131,7 +131,7 @@ const App = () => {
 
 ##### Require authentication for application (Middleware)
 
-You can use NextJS Middleware to require authentication for a page/route or a group of pages/routes.
+You can use Next.js Middleware to require authentication for a page/route or a group of pages/routes.
 
 Descope SDK provides a middleware function that can be used to require authentication for a page/route or a group of pages/routes.
 
@@ -229,12 +229,24 @@ Route handler:
 // src/pages/api/routes.ts
 export async function GET() {
 	const currSession = await session();
-	if (!currSession.isAuthenticated) {
+	if (!currSession) {
 		// ...
 	}
 
 	// Use the session jwt or parsed token
 	const { jwt, token } = currSession;
+}
+```
+
+The `session()` function uses Next.js's `cookies()` and `headers()` functions to retrieve the session token. If you are using Next.js Version 13, you can use the `getSession(req)` instead.
+
+```js
+import { getSession } from '@descope/nextjs-sdk/server';
+
+export async function GET(req) {
+	const currSession = await getSession(req);
+
+	// ...
 }
 ```
 

--- a/packages/sdks/web-js-sdk/src/constants.ts
+++ b/packages/sdks/web-js-sdk/src/constants.ts
@@ -4,3 +4,6 @@ export const IS_BROWSER = typeof window !== 'undefined';
 // Maximum timeout value for setTimeout
 // For more information, refer to https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#maximum_delay_value
 export const MAX_TIMEOUT = Math.pow(2, 31) - 1;
+
+// The amount of time (ms) to trigger the refresh before session expires
+export const REFRESH_THRESHOLD = 20 * 1000; // 20 sec

--- a/packages/sdks/web-js-sdk/src/enhancers/withAutoRefresh/helpers.ts
+++ b/packages/sdks/web-js-sdk/src/enhancers/withAutoRefresh/helpers.ts
@@ -1,5 +1,6 @@
 import { jwtDecode, JwtPayload } from 'jwt-decode';
 import logger from '../helpers/logger';
+import { MAX_TIMEOUT, REFRESH_THRESHOLD } from '../../constants';
 
 /**
  * Get the JWT expiration WITHOUT VALIDATING the JWT
@@ -44,4 +45,17 @@ export const createTimerFunctions = () => {
   };
 
   return { clearAllTimers, setTimer };
+};
+
+export const getAutoRefreshTimeout = (sessionExpiration: Date) => {
+  let timeout = millisecondsUntilDate(sessionExpiration) - REFRESH_THRESHOLD;
+
+  if (timeout > MAX_TIMEOUT) {
+    logger.debug(
+      `Timeout is too large (${timeout}ms), setting it to ${MAX_TIMEOUT}ms`,
+    );
+    timeout = MAX_TIMEOUT;
+  }
+
+  return timeout;
 };

--- a/packages/sdks/web-js-sdk/src/enhancers/withAutoRefresh/index.ts
+++ b/packages/sdks/web-js-sdk/src/enhancers/withAutoRefresh/index.ts
@@ -68,6 +68,11 @@ export const withAutoRefresh =
         clearAllTimers();
 
         if (timeout <= REFRESH_THRESHOLD) {
+          /*
+            When receiving a session with very short expiration - it means that the refresh token is also close to expiration
+            This happens because session expiration cannot be more than the refresh expiration
+            In this case - the user is going to be logged out soon, so we don't want to set a refresh timer
+          */
           logger.debug(
             'Session is too close to expiration, not setting refresh timer',
           );

--- a/packages/sdks/web-js-sdk/test/autoRefresh.test.ts
+++ b/packages/sdks/web-js-sdk/test/autoRefresh.test.ts
@@ -271,6 +271,26 @@ describe('autoRefresh', () => {
     expect(loggerDebugMock).not.toHaveBeenCalled();
   });
 
+  it('should not refresh token when visibilitychange event and there is no session', async () => {
+    const loggerDebugMock = logger.debug as jest.Mock;
+
+    const sdk = createSdk({ projectId: 'pid', autoRefresh: true });
+    const refreshSpy = jest
+      .spyOn(sdk, 'refresh')
+      .mockReturnValue(new Promise(() => {}));
+
+    await new Promise(process.nextTick);
+
+    // trigger visibilitychange event and ensure refresh called
+    const event = new Event('visibilitychange');
+    document.dispatchEvent(event);
+    expect(refreshSpy).not.toHaveBeenCalled();
+
+    expect(loggerDebugMock).not.toHaveBeenCalledWith(
+      'Expiration time passed, refreshing session',
+    );
+  });
+
   it('should refresh token when visibilitychange event and session expired', async () => {
     const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
     const loggerDebugMock = logger.debug as jest.Mock;
@@ -300,27 +320,7 @@ describe('autoRefresh', () => {
     expect(loggerDebugMock).toHaveBeenCalledWith(
       'Expiration time passed, refreshing session',
     );
-  });
-
-  it('should not refresh token when visibilitychange event and there is no session', async () => {
-    const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
-    const loggerDebugMock = logger.debug as jest.Mock;
-
-    const sdk = createSdk({ projectId: 'pid', autoRefresh: true });
-    const refreshSpy = jest
-      .spyOn(sdk, 'refresh')
-      .mockReturnValue(new Promise(() => {}));
-
-    await new Promise(process.nextTick);
-
-    // trigger visibilitychange event and ensure refresh called
-    const event = new Event('visibilitychange');
-    document.dispatchEvent(event);
-    expect(refreshSpy).not.toHaveBeenCalled();
-
-    expect(loggerDebugMock).not.toHaveBeenCalledWith(
-      'Expiration time passed, refreshing session',
-    );
+    loggerDebugMock.mockClear();
   });
 
   it('should handle a case where jwt decoding fail', async () => {


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/8912
Fixes https://github.com/descope/etc/issues/7424

## Description

handle too close timeouts in the following ways
 - after auth request - if calculated timeout is less than 20 seconds - do not set refresh timeout
 - when window becomes visible - do not refresh if refresh failed  