### PR TITLE
feat: force refresh on first use

### DIFF
--- a/packages/sdks/react-sdk/examples/app/index.tsx
+++ b/packages/sdks/react-sdk/examples/app/index.tsx
@@ -15,6 +15,11 @@ root.render(
       baseUrl={process.env.DESCOPE_BASE_URL}
       baseStaticUrl={process.env.DESCOPE_BASE_STATIC_URL}
       refreshCookieName={process.env.DESCOPE_REFRESH_COOKIE_NAME}
+      // we want to pass undefined if the value is not set
+      forceRefreshOnFirstUse={
+        process.env.DESCOPE_REFRESH_ON_FIRST_USE &&
+        process.env.DESCOPE_REFRESH_ON_FIRST_USE === 'true'
+      }
     >
       <App />
     </AuthProvider>

--- a/packages/sdks/react-sdk/src/components/AuthProvider/AuthProvider.tsx
+++ b/packages/sdks/react-sdk/src/components/AuthProvider/AuthProvider.tsx
@@ -31,6 +31,8 @@ interface IAuthProviderProps {
   // Use this option if the authentication is done via cookie, and configured with a different name
   // Currently, this is done using Descope Flows
   refreshCookieName?: string;
+  // If true, session will be refreshed even if the user is not logged in (default: true)
+  forceRefreshOnFirstUse?: boolean;
   children?: React.ReactNode;
 }
 
@@ -43,6 +45,9 @@ const AuthProvider: FC<IAuthProviderProps> = ({
   storeLastAuthenticatedUser = true,
   keepLastAuthenticatedUserAfterLogout = false,
   refreshCookieName = '',
+   // Currently the default is true
+   // but we want to change it to false after we make sure it works on all cases
+  forceRefreshOnFirstUse = true,
   children = undefined,
 }) => {
   const [user, setUser] = useState<User>();
@@ -87,7 +92,9 @@ const AuthProvider: FC<IAuthProviderProps> = ({
     isSessionFetched.current = true;
 
     setIsSessionLoading(true);
-    withValidation(sdk?.refresh)().then(() => {
+    const onlyIfLoggedIn = !forceRefreshOnFirstUse;
+    // @ts-ignore - This is because the refresh override with the chaining
+    withValidation(sdk?.refresh)(undefined, onlyIfLoggedIn).then(() => {
       setIsSessionLoading(false);
     });
   }, [sdk]);

--- a/packages/sdks/web-js-sdk/src/constants.ts
+++ b/packages/sdks/web-js-sdk/src/constants.ts
@@ -4,3 +4,6 @@ export const IS_BROWSER = typeof window !== 'undefined';
 // Maximum timeout value for setTimeout
 // For more information, refer to https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#maximum_delay_value
 export const MAX_TIMEOUT = Math.pow(2, 31) - 1;
+
+// Errors
+export const REFRESH_ERROR_USER_NOT_LOGGED_IN = 'J152001';

--- a/packages/sdks/web-js-sdk/src/enhancers/withConditionalRefresh/constants.ts
+++ b/packages/sdks/web-js-sdk/src/enhancers/withConditionalRefresh/constants.ts
@@ -1,0 +1,2 @@
+// A key holding true if the user is logged in, false otherwise
+export const LOGGED_IN_KEY = 'descope_logged_in';

--- a/packages/sdks/web-js-sdk/src/enhancers/withConditionalRefresh/index.ts
+++ b/packages/sdks/web-js-sdk/src/enhancers/withConditionalRefresh/index.ts
@@ -1,0 +1,70 @@
+import { JWTResponse, SdkFnWrapper, SdkResponse, wrapWith } from '@descope/core-js-sdk';
+import { CreateWebSdk } from '../../sdk';
+import { AfterRequestHook } from '../../types';
+import { addHooks, getAuthInfoFromResponse } from '../helpers';
+import logger from '../helpers/logger';
+import { REFRESH_ERROR_USER_NOT_LOGGED_IN } from '../../constants';
+import { LOGGED_IN_KEY } from './constants';
+import { getSessionToken } from '../withPersistTokens/helpers';
+
+const isEmptyObject = (obj: Object) => obj && Object.keys(obj).length === 0;
+
+/**
+ * Enhancer that overrides the refresh method to only refresh if the user is logged in
+ * This is done by maintaining a logged in state in the local storage that is
+ * - set to true when the user logs in
+ * - cleared when the user logs out or receives a 401
+*/
+export const withConditionalRefresh =
+  <T extends CreateWebSdk>(createSdk: T) =>
+  (config: Parameters<T>[0]) => {
+    // a hook that will set the logged in state in the local storage
+    const afterRequest: AfterRequestHook = async (_req, res) => {
+      const authInfo = (await getAuthInfoFromResponse(res)) as JWTResponse;
+
+      // if we got 401 we want to clear the logged in state
+      if (res?.status === 401) {
+        logger.debug('Received 401, clearing logged in state');
+        localStorage.removeItem(LOGGED_IN_KEY);
+      } else if (!isEmptyObject(authInfo)) {
+        // set as logged in
+        localStorage.setItem(LOGGED_IN_KEY, 'true');
+      }
+    };
+
+    const sdk = createSdk(addHooks(config, { afterRequest }));
+
+    const logoutWrapper: SdkFnWrapper<{}> =
+      (fn) =>
+      async (...args) => {
+        const resp = await fn(...args);
+        if (resp.ok) {
+          logger.debug('Clearing logged in state');
+          localStorage.removeItem(LOGGED_IN_KEY);
+        }
+        return resp;
+      };
+
+    const sdkRes = wrapWith(sdk, ['logout', 'logoutAll'], logoutWrapper);
+
+    return {
+      ...sdkRes,
+      refresh: (token?: string , onlyIfLoggedIn?: boolean) => {
+        // get the session expiration from the local storage
+        // we fallback to getSessionToken to reduce the likelihood of a refresh loop
+        const loggedIn = localStorage.getItem(LOGGED_IN_KEY) || getSessionToken();
+
+        let res: Promise<SdkResponse<JWTResponse>>
+       if (!loggedIn && onlyIfLoggedIn) {
+          logger.debug('Not logged in, skipping refresh');
+          res = Promise.resolve({ ok: false, error: {
+            errorCode : REFRESH_ERROR_USER_NOT_LOGGED_IN,
+            errorDescription: 'Did not refresh token because user is not logged in'
+          }});
+        } else {
+          res = sdkRes.refresh(token);
+        }
+        return res;
+      },
+    };
+  };

--- a/packages/sdks/web-js-sdk/src/index.ts
+++ b/packages/sdks/web-js-sdk/src/index.ts
@@ -1,6 +1,7 @@
 import { compose } from './enhancers/helpers';
 import { withAnalytics } from './enhancers/withAnalytics';
 import { withAutoRefresh } from './enhancers/withAutoRefresh';
+import { withConditionalRefresh } from './enhancers/withConditionalRefresh';
 import { withFingerprint } from './enhancers/withFingerprint';
 import { withLastLoggedInUser } from './enhancers/withLastLoggedInUser';
 import { withNotifications } from './enhancers/withNotifications';
@@ -11,6 +12,7 @@ const decoratedCreateSdk = compose(
   withFingerprint,
   withAutoRefresh,
   withAnalytics,
+  withConditionalRefresh,
   withNotifications,
   withLastLoggedInUser, // must be one before last due to TS types
   withPersistTokens, // must be last due to TS known limitation https://github.com/microsoft/TypeScript/issues/30727


### PR DESCRIPTION
## Related Issues

instead https://github.com/descope/descope-js/pull/877

https://github.com/descope/etc/issues/2862


## Description
support a property for eager refresh (default is true, like today)
if `eagerRefreshOnFirstUseSession` off, sdk only refresh if user was logged in before

few notes
 - keeping the default behavior as `true` even though imho a sane default is `false`, but we don't want to break backwards
 - lets talk about
    (a) usage of this functionality (AuthProvider vs useSession)
    (a) naming of this prop (`callRefreshIfLoggedIn`?)
 - if we agree on the solution - I'll write tests and implement also in other sdks (vue/angular)
