### PR TITLE
feat: force on first use

### DIFF
--- a/packages/sdks/react-sdk/examples/app/index.tsx
+++ b/packages/sdks/react-sdk/examples/app/index.tsx
@@ -15,6 +15,11 @@ root.render(
       baseUrl={process.env.DESCOPE_BASE_URL}
       baseStaticUrl={process.env.DESCOPE_BASE_STATIC_URL}
       refreshCookieName={process.env.DESCOPE_REFRESH_COOKIE_NAME}
+      // we want to pass undefined if the value is not set
+      forceRefreshOnFirstUse={
+        process.env.DESCOPE_REFRESH_ON_FIRST_USE &&
+        process.env.DESCOPE_REFRESH_ON_FIRST_USE === 'true'
+      }
     >
       <App />
     </AuthProvider>

--- a/packages/sdks/web-js-sdk/src/index.ts
+++ b/packages/sdks/web-js-sdk/src/index.ts
@@ -3,6 +3,7 @@ import { withAnalytics } from './enhancers/withAnalytics';
 import { withAutoRefresh } from './enhancers/withAutoRefresh';
 import { withFingerprint } from './enhancers/withFingerprint';
 import { withLastLoggedInUser } from './enhancers/withLastLoggedInUser';
+import { withAuthState } from './enhancers/withAuthState';
 import { withNotifications } from './enhancers/withNotifications';
 import withPersistTokens from './enhancers/withPersistTokens';
 import createSdk from './sdk';
@@ -12,6 +13,7 @@ const decoratedCreateSdk = compose(
   withAutoRefresh,
   withAnalytics,
   withNotifications,
+  withAuthState,
   withLastLoggedInUser, // must be one before last due to TS types
   withPersistTokens, // must be last due to TS known limitation https://github.com/microsoft/TypeScript/issues/30727
 )(createSdk);


### PR DESCRIPTION
## Related Issues

instead https://github.com/descope/descope-js/pull/877

https://github.com/descope/etc/issues/2862


## Description
support a property for eager refresh (default is true, like today)
if `forceRefreshOnFirstUse` off, sdk only refresh if user was logged in before

few notes
 - keeping the default behavior as `true` even though imho a sane default is `false`, but we don't want to break backwards
 - if we agree on the solution - I'll write tests and implement also in other sdks (vue/angular)
