### PR TITLE
fix: allow empty token on webauthn update

### DIFF
--- a/packages/sdks/core-js-sdk/src/sdk/webauthn.ts
+++ b/packages/sdks/core-js-sdk/src/sdk/webauthn.ts
@@ -9,7 +9,12 @@ import {
   PasskeyOptions,
   WebAuthnStartResponse,
 } from './types';
-import { string, stringNonEmpty, withValidations } from './validations';
+import {
+  isStringOrUndefinedValidator,
+  string,
+  stringNonEmpty,
+  withValidations,
+} from './validations';
 
 const loginIdStringValidations = string('loginId');
 const loginIdNonEmptyValidations = stringNonEmpty('loginId');
@@ -31,7 +36,7 @@ const withSignInStartValidations = withValidations(
 const withUpdateStartValidations = withValidations(
   loginIdNonEmptyValidations,
   originValidations,
-  stringNonEmpty('token'),
+  isStringOrUndefinedValidator('token'),
 );
 const withFinishValidations = withValidations(
   stringNonEmpty('transactionId'),
@@ -127,7 +132,7 @@ const withWebauthn = (httpClient: HttpClient) => ({
       (
         loginId: string,
         origin: string,
-        token: string,
+        token?: string,
         passkeyOptions?: PasskeyOptions,
       ): Promise<SdkResponse<WebAuthnStartResponse>> =>
         transformResponse(

--- a/packages/sdks/core-js-sdk/test/sdk/webauthn.test.ts
+++ b/packages/sdks/core-js-sdk/test/sdk/webauthn.test.ts
@@ -497,16 +497,16 @@ describe('webauthn', () => {
         );
       });
 
-      it('should throw an error when token is not a string', () => {
-        expect(() => sdk.webauthn.update.start('loginId', 'origin')).toThrow(
-          '"token" must be a string',
-        );
+      it('should throw an error when token is undefined', () => {
+        expect(() =>
+          sdk.webauthn.update.start('loginId', 'origin'),
+        ).not.toThrow();
       });
 
-      it('should throw an error when origin is empty', () => {
+      it('should throw an error when token is empty', () => {
         expect(() =>
           sdk.webauthn.update.start('loginId', 'origin', ''),
-        ).toThrow('"token" must not be empty');
+        ).not.toThrow();
       });
 
       it('should send the correct request', () => {

--- a/packages/sdks/web-js-sdk/src/sdk/webauthn.ts
+++ b/packages/sdks/web-js-sdk/src/sdk/webauthn.ts
@@ -94,7 +94,7 @@ const createWebAuthn = (sdk: CoreSdk) => ({
 
   async update(
     identifier: string,
-    token: string,
+    token?: string,
     passkeyOptions?: PasskeyOptions,
   ) {
     const startResponse = await sdk.webauthn.update.start(


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/9893

## Description
allow empty token on webauthn update