### PR TITLE
feat: outbound connect api

### DIFF
--- a/packages/sdks/core-js-sdk/src/constants/apiPaths.ts
+++ b/packages/sdks/core-js-sdk/src/constants/apiPaths.ts
@@ -44,6 +44,9 @@ export default {
       verifyOneTapIDToken: '/v1/auth/onetap/idtoken/verify',
     },
   },
+  outbound: {
+    connect: '/v1/outbound/oauth/connect',
+  },
   saml: {
     start: '/v1/auth/saml/authorize',
     exchange: '/v1/auth/saml/exchange',

--- a/packages/sdks/core-js-sdk/src/sdk/index.ts
+++ b/packages/sdks/core-js-sdk/src/sdk/index.ts
@@ -13,6 +13,7 @@ import {
 } from './helpers';
 import withMagicLink from './magicLink';
 import withOauth from './oauth';
+import withOutbound from './outbound';
 import withOtp from './otp';
 import withSaml from './saml';
 import withTotp from './totp';
@@ -48,6 +49,7 @@ export default (httpClient: HttpClient) => ({
   magicLink: withMagicLink(httpClient),
   enchantedLink: withEnchantedLink(httpClient),
   oauth: withOauth(httpClient),
+  outbound: withOutbound(httpClient),
   saml: withSaml(httpClient),
   totp: withTotp(httpClient),
   notp: withNotp(httpClient),

--- a/packages/sdks/core-js-sdk/src/sdk/outbound/index.ts
+++ b/packages/sdks/core-js-sdk/src/sdk/outbound/index.ts
@@ -1,0 +1,31 @@
+import { apiPaths } from '../../constants';
+import { HttpClient } from '../../httpClient';
+import { transformResponse } from '../helpers';
+import { ConnectOptions } from './types';
+import { SdkResponse, URLResponse } from '../types';
+import { withConnectValidations } from './validations';
+
+const withOutbound = (httpClient: HttpClient) => ({
+  connect: withConnectValidations(
+    (
+      appId: string,
+      options?: ConnectOptions,
+      token?: string,
+    ): Promise<SdkResponse<URLResponse>> => {
+      return transformResponse(
+        httpClient.post(
+          apiPaths.outbound.connect,
+          {
+            appId,
+            options,
+          },
+          {
+            token,
+          },
+        ),
+      );
+    },
+  ),
+});
+
+export default withOutbound;

--- a/packages/sdks/core-js-sdk/src/sdk/outbound/types.ts
+++ b/packages/sdks/core-js-sdk/src/sdk/outbound/types.ts
@@ -1,0 +1,4 @@
+export type ConnectOptions = {
+  redirectURL?: string;
+  scopes?: string[];
+};

--- a/packages/sdks/core-js-sdk/src/sdk/outbound/validations.ts
+++ b/packages/sdks/core-js-sdk/src/sdk/outbound/validations.ts
@@ -1,0 +1,8 @@
+import {
+  isStringOrUndefinedValidator,
+  stringNonEmpty,
+  withValidations,
+} from '../validations';
+
+const appIdValidation = stringNonEmpty('appId');
+export const withConnectValidations = withValidations(appIdValidation);

--- a/packages/sdks/core-js-sdk/test/sdk/outbound.test.ts
+++ b/packages/sdks/core-js-sdk/test/sdk/outbound.test.ts
@@ -1,0 +1,72 @@
+// @ts-nocheck
+import { apiPaths } from '../../src/constants';
+import createSdk from '../../src/sdk';
+import { mockHttpClient } from '../utils';
+
+const sdk = createSdk(mockHttpClient);
+
+describe('outbound', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    mockHttpClient.reset();
+  });
+  describe('connect', () => {
+    it('should return the correct url', async () => {
+      const httpRespJson = { url: 'http://redirecturl.com/' };
+      const httpResponse = {
+        ok: true,
+        json: () => Promise.resolve(httpRespJson),
+        clone: () => ({
+          json: () => Promise.resolve(httpRespJson),
+        }),
+        status: 200,
+      };
+      mockHttpClient.post.mockResolvedValueOnce(httpResponse);
+      const resp = await sdk.outbound.connect('google', {}, '');
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        apiPaths.outbound.connect,
+        {
+          appId: 'google',
+          options: {},
+        },
+        {
+          token: '',
+        },
+      );
+
+      expect(resp).toEqual({
+        code: 200,
+        data: httpRespJson,
+        ok: true,
+        response: httpResponse,
+      });
+    });
+
+    it('should send the redirect url, scopes and token when provided', () => {
+      sdk.outbound.connect(
+        'google',
+        { redirectURL: 'http://new.com/', scopes: '["s1", "s2"]' },
+        'token',
+      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        apiPaths.outbound.connect,
+        {
+          appId: 'google',
+          options: {
+            redirectURL: 'http://new.com/',
+            scopes: '["s1", "s2"]',
+          },
+        },
+        {
+          token: 'token',
+        },
+      );
+    });
+
+    it('should fail connect without appId', () => {
+      expect(() => sdk.outbound.connect('', {})).toThrow(
+        '"appId" must not be empty',
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Related Issues

Related to https://docs.descope.com/api/management/users/update-user-login-id

## Description

Support outbound app connect API in SDK
The request requires the user to be authenticated
The request variables are:
- `appId` (required)
- `options` object containing `redirectUrl` and `scopes` (optional)
- `token` (optional) as a string and will be used from the cookie

## Must
- [x] Tests
- [ ] Documentation (if applicable)
