### PR TITLE
fix: add base cdn url to react sdk

### DIFF
--- a/packages/sdks/react-sdk/examples/app/index.tsx
+++ b/packages/sdks/react-sdk/examples/app/index.tsx
@@ -19,6 +19,7 @@ root.render(
       }
       baseUrl={process.env.DESCOPE_BASE_URL}
       baseStaticUrl={process.env.DESCOPE_BASE_STATIC_URL}
+      baseCdnUrl={process.env.DESCOPE_BASE_CDN_URL}
       refreshCookieName={process.env.DESCOPE_REFRESH_COOKIE_NAME}
     >
       <App />

--- a/packages/sdks/react-sdk/src/components/AuthProvider/AuthProvider.tsx
+++ b/packages/sdks/react-sdk/src/components/AuthProvider/AuthProvider.tsx
@@ -17,6 +17,8 @@ interface IAuthProviderProps {
   baseUrl?: string;
   // allows to override the base URL that is used to fetch static files
   baseStaticUrl?: string;
+  // allows to override the base URL that is used to fetch external script files
+  baseCdnUrl?: string;
   // If true, tokens will be stored on local storage and can accessed with getToken function
   persistTokens?: boolean;
   // If true, session token (jwt) will be stored on cookie. Otherwise, the session token will be
@@ -43,6 +45,7 @@ const AuthProvider: FC<IAuthProviderProps> = ({
   projectId,
   baseUrl = '',
   baseStaticUrl = '',
+  baseCdnUrl = '',
   sessionTokenViaCookie = false,
   persistTokens = true,
   oidcConfig = undefined,
@@ -144,6 +147,7 @@ const AuthProvider: FC<IAuthProviderProps> = ({
       projectId,
       baseUrl,
       baseStaticUrl,
+      baseCdnUrl,
       storeLastAuthenticatedUser,
       keepLastAuthenticatedUserAfterLogout,
       refreshCookieName,
@@ -166,6 +170,7 @@ const AuthProvider: FC<IAuthProviderProps> = ({
       projectId,
       baseUrl,
       baseStaticUrl,
+      baseCdnUrl,
       keepLastAuthenticatedUserAfterLogout,
       refreshCookieName,
       setUser,


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/10442

## Related PRs
https://github.com/descope/descope-js/pull/1014

## Description
add `baseCdnUrl` prop to `<AuthProvider />` component
