### PR TITLE
BugFix in createFetchLogger

### DIFF
--- a/packages/sdks/core-js-sdk/src/httpClient/helpers/createFetchLogger.ts
+++ b/packages/sdks/core-js-sdk/src/httpClient/helpers/createFetchLogger.ts
@@ -91,7 +91,13 @@ const fetchWrapper =
     const respText = await resp.text();
 
     resp.text = () => Promise.resolve(respText);
-    resp.json = () => Promise.resolve(JSON.parse(respText));
+    resp.json = () => Promise.resolve(() => {
+      try {
+        return JSON.parse(respText);
+      } catch (e) {
+        return {};
+      }
+    });
     resp.clone = () => resp;
 
     return resp;


### PR DESCRIPTION
## Description

A fix to avoid error while parsing JSON. In some cases `respText` turns out to be HTML. This is being invalid JSON, `resp.json()` thrown an error instead of resolving the promise with error message.

I haven't added any error log in this case. Do mention if you would like to add logs / return an error message