### PR TITLE
fix: next peer dep version RELEASE

### DIFF
--- a/packages/sdks/nextjs-sdk/package.json
+++ b/packages/sdks/nextjs-sdk/package.json
@@ -140,7 +140,7 @@
 	},
 	"peerDependencies": {
 		"@types/react": ">=18",
-		"next": ">=15.2.4",
+		"next": ">=13",
 		"react": ">=18"
 	},
 	"optionalDependencies": {

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>descope/renovate-config", "security:only-security-updates"]
+  "extends": [
+    "local>descope/renovate-config",
+    "security:only-security-updates"
+  ],
+  "packageRules": [
+    {
+      "dependencyType": "peerDependencies",
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
Renovate upgraded the Next.js peer dependency version, and it’s causing issues
This PR fixes it and disable Renovate upgrades for peer dependencies
