### PR TITLE
feat: Add login hint support for OAuth

### DIFF
--- a/packages/sdks/core-js-sdk/src/sdk/oauth/index.ts
+++ b/packages/sdks/core-js-sdk/src/sdk/oauth/index.ts
@@ -19,12 +19,14 @@ const withOauth = (httpClient: HttpClient) => ({
       redirectUrl?: string,
       loginOptions?: LoginOptions,
       token?: string,
+      loginHint?: string,
     ) => {
       return transformResponse(
         httpClient.post(apiPaths.oauth.start, loginOptions || {}, {
           queryParams: {
             provider,
             ...(redirectUrl && { redirectURL: redirectUrl }),
+            ...(loginHint && { loginHint }),
           },
           token,
         }),
@@ -37,12 +39,14 @@ const withOauth = (httpClient: HttpClient) => ({
           redirectUrl?: string,
           loginOptions?: LoginOptions,
           token?: string,
+          loginHint?: string,
         ) =>
           transformResponse(
             httpClient.post(apiPaths.oauth.start, loginOptions || {}, {
               queryParams: {
                 provider,
                 ...(redirectUrl && { redirectURL: redirectUrl }),
+                ...(loginHint && { loginHint }),
               },
               token,
             }),

--- a/packages/sdks/core-js-sdk/test/sdk/oauth.test.ts
+++ b/packages/sdks/core-js-sdk/test/sdk/oauth.test.ts
@@ -55,6 +55,26 @@ describe('oauth', () => {
       );
     });
 
+    it('should override the redirect url when provided and use loginHint', () => {
+      sdk.oauth.start.facebook(
+        'http://redirecturl.com/',
+        undefined,
+        undefined,
+        'someloginhint',
+      );
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        apiPaths.oauth.start,
+        {},
+        {
+          queryParams: {
+            provider: 'facebook',
+            redirectURL: 'http://redirecturl.com/',
+            loginHint: 'someloginhint',
+          },
+        },
+      );
+    });
+
     it('should run start with provider name', () => {
       sdk.oauth.start('test', 'http://redirecturl.com/');
       expect(mockHttpClient.post).toHaveBeenCalledWith(


### PR DESCRIPTION
## Related Issues

fixes: https://github.com/descope/etc/issues/9752
fixes: https://github.com/descope/etc/issues/10809


## Description

Add login hint support for OAuth

## Must

- [x] Tests
- [ ] Documentation (if applicable)
