### PR TITLE
Fix: Fixed README to say we don't support React 16

### DIFF
--- a/packages/sdks/react-sdk/README.md
+++ b/packages/sdks/react-sdk/README.md
@@ -4,7 +4,7 @@ The Descope SDK for React provides convenient access to the Descope for an appli
 
 ## Requirements
 
-- The SDK supports React version 16 and above.
+- The SDK supports React version 17 and above.
 - A Descope `Project ID` is required for using the SDK. Find it on the [project page in the Descope Console](https://app.descope.com/settings/project).
 
 ## Installing the SDK


### PR DESCRIPTION
## Related Issues

## Related PRs

| branch       | PR         |
| ------------ | ---------- |
| service a PR | Link to PR |
| service b PR | Link to PR |

## Description

Made it clear in the README that we don't support React 16.

## Must

- [ ] Tests
- [ ] Documentation (if applicable)
