### PR TITLE
Fix: Fixed README to say we support React 16

### DIFF
--- a/packages/sdks/react-sdk/README.md
+++ b/packages/sdks/react-sdk/README.md
@@ -4,7 +4,7 @@ The Descope SDK for React provides convenient access to the Descope for an appli
 
 ## Requirements
 
-- The SDK supports React version 17 and above.
+- The SDK supports React version 16 and above.
 - A Descope `Project ID` is required for using the SDK. Find it on the [project page in the Descope Console](https://app.descope.com/settings/project).
 
 ## Installing the SDK


### PR DESCRIPTION
## Description

Reverted message back to show support for React 16 with React SDK.

## Must

- [ ] Tests
- [ ] Documentation (if applicable)
