### PR TITLE
Add Descope MCP SDK for Node.js

### DIFF
--- a/packages/sdks/mcp-sdk/CHANGELOG.md
+++ b/packages/sdks/mcp-sdk/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2025-01-XX
+
+### Added
+- Initial release of @descope/mcp-sdk
+- Core TokenManager for JWT validation and outbound token management
+- defineToolWithDescope function for creating authenticated MCP tools
+- Automatic scope validation and authorization
+- Type-safe tool builder with Zod schema validation
+- Authentication middleware for custom MCP servers
+- Token caching for improved performance
+- Comprehensive test suite with unit and integration tests
+- Examples for basic tools and multi-provider integration
+- Full TypeScript support with generic types
+- Documentation and API reference
+
+### Features
+- ✅ JWT validation with signature verification
+- ✅ Scope-based authorization system
+- ✅ Outbound token fetching for third-party APIs
+- ✅ Request/response type safety with Zod
+- ✅ Error handling with standardized MCP error responses
+- ✅ Token caching and performance optimization
+- ✅ Environment variable configuration
+- ✅ Middleware support for custom authentication flows

--- a/packages/sdks/mcp-sdk/CHANGELOG.md
+++ b/packages/sdks/mcp-sdk/CHANGELOG.md
@@ -9,23 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Initial release of @descope/mcp-sdk
-- Core TokenManager for JWT validation and outbound token management
-- defineToolWithDescope function for creating authenticated MCP tools
-- Automatic scope validation and authorization
-- Type-safe tool builder with Zod schema validation
-- Authentication middleware for custom MCP servers
-- Token caching for improved performance
+- `createAuthenticatedTool` function for building authenticated MCP tools with automatic scope validation
+- `createMcpAuthMiddleware` for authentication middleware with OAuth 2.0 compliance
+- `getOutboundToken` for accessing external provider tokens (GitHub, Google, Slack, etc.)
+- OAuth 2.0 Protected Resource Metadata (RFC 9728) support with `buildResourceMetadata`
+- `buildWWWAuthenticate` for compliant OAuth error responses
+- Type-safe tool builder with JSON Schema validation
+- Comprehensive framework examples (Express.js, Next.js App Router, Next.js Pages Router)
+- Full TypeScript support with type definitions
 - Comprehensive test suite with unit and integration tests
-- Examples for basic tools and multi-provider integration
-- Full TypeScript support with generic types
 - Documentation and API reference
 
 ### Features
+- ✅ Authenticated MCP tools with built-in scope checking
+- ✅ Outbound token access via Descope for external providers
+- ✅ Automatic OAuth 2.0 scope validation with compliant error responses
+- ✅ Protected Resource Metadata (RFC 9728) endpoints
 - ✅ JWT validation with signature verification
-- ✅ Scope-based authorization system
-- ✅ Outbound token fetching for third-party APIs
-- ✅ Request/response type safety with Zod
-- ✅ Error handling with standardized MCP error responses
+- ✅ WWW-Authenticate header generation for OAuth compliance
 - ✅ Token caching and performance optimization
 - ✅ Environment variable configuration
-- ✅ Middleware support for custom authentication flows
+- ✅ Framework integration examples

--- a/packages/sdks/mcp-sdk/LICENSE
+++ b/packages/sdks/mcp-sdk/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Descope
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/sdks/mcp-sdk/README.md
+++ b/packages/sdks/mcp-sdk/README.md
@@ -1,0 +1,397 @@
+# @descope/mcp-sdk
+
+Secure Model Context Protocol (MCP) SDK for Node.js with Descope authentication. Build MCP servers with enterprise-grade authentication, scope-based access control, and OAuth 2.0 compliance.
+
+## Prerequisites
+
+Before using this SDK, you need:
+
+1. **Descope Account**: Sign up at [https://app.descope.com](https://app.descope.com)
+2. **Project ID**: Get your project ID from the Descope console
+3. **Node.js**: Version 18 or higher
+4. **MCP Knowledge**: Basic understanding of [Model Context Protocol](https://modelcontextprotocol.io)
+
+### Environment Setup
+
+Set the required environment variable:
+
+```bash
+export DESCOPE_PROJECT_ID=P2abc123def456ghi789  # Your actual project ID
+export DESCOPE_BASE_URL=https://api.descope.com # Optional: defaults to production
+```
+
+## Why Use This SDK?
+
+### 🎯 **1. Automatic Scope Validation Out-of-the-Box**
+
+Define required scopes in your middleware or tools, and get automatic OAuth 2.0 compliant validation with proper `WWW-Authenticate` headers when scopes are missing.
+
+```typescript
+// Middleware automatically validates required scopes
+const authMiddleware = await createMcpAuthMiddleware({
+  requiredScopes: ['mcp:access', 'user:read'], // Missing scopes = automatic 403 with proper headers
+});
+
+// Tools get scope validation automatically
+const tool = createAuthenticatedTool({
+  requiredScopes: ['user:write'], // Validated before tool execution
+  // ...
+});
+```
+
+### 🔗 **2. Access Tokens from Other Providers via Descope Outbound Apps**
+
+Seamlessly get tokens for external services (Google, GitHub, Slack, etc.) through Descope's outbound application feature.
+
+```typescript
+const tool = createAuthenticatedTool(
+  {
+    name: 'syncWithGitHub',
+    requiredScopes: ['github:read'],
+  },
+  async ({ descope }) => {
+    // Get GitHub token for the authenticated user via Descope
+    const githubToken = await descope.getOutboundToken('github-app');
+
+    // Use GitHub token to call GitHub API
+    const response = await fetch('https://api.github.com/user/repos', {
+      headers: { Authorization: `Bearer ${githubToken}` },
+    });
+  },
+);
+```
+
+### 📝 **3. Easy Protected Resource Metadata APIs**
+
+Serve RFC 9728 compliant OAuth 2.0 Protected Resource Metadata endpoints with minimal setup across popular frameworks.
+
+#### Express.js
+
+```typescript
+import express from 'express';
+import { buildResourceMetadata, createMcpAuthMiddleware } from '@descope/mcp-sdk';
+
+const app = express();
+
+// Serve OAuth metadata endpoint
+app.get('/.well-known/oauth-protected-resource', (req, res) => {
+  const metadata = buildResourceMetadata({
+    resource: 'https://api.example.com',
+    authorizationServers: ['https://auth.descope.com/YOUR_PROJECT_ID'],
+    scopes: ['mcp:read', 'mcp:write'],
+  });
+  res.json(metadata);
+});
+
+// Protected route with automatic scope validation
+app.get('/api/protected', async (req, res) => {
+  const authMiddleware = await createMcpAuthMiddleware({
+    requiredScopes: ['mcp:read'],
+  });
+  // Middleware handles token validation and scope checking automatically
+});
+```
+
+#### Next.js (App Router)
+
+```typescript
+// app/.well-known/oauth-protected-resource/route.ts
+import { buildResourceMetadata } from '@descope/mcp-sdk';
+
+export async function GET() {
+  const metadata = buildResourceMetadata({
+    resource: 'https://api.example.com',
+    authorizationServers: ['https://auth.descope.com/YOUR_PROJECT_ID'],
+    scopes: ['mcp:read', 'mcp:write'],
+  });
+
+  return NextResponse.json(metadata, {
+    headers: { 'Cache-Control': 'public, max-age=3600' },
+  });
+}
+```
+
+#### Next.js (Pages Router)
+
+```typescript
+// pages/.well-known/oauth-protected-resource.ts
+import { buildResourceMetadata } from '@descope/mcp-sdk';
+
+export default async function handler(req, res) {
+  const metadata = buildResourceMetadata({
+    resource: 'https://api.example.com',
+    authorizationServers: ['https://auth.descope.com/YOUR_PROJECT_ID'],
+    scopes: ['mcp:read', 'mcp:write'],
+  });
+
+  res.setHeader('Cache-Control', 'public, max-age=3600');
+  res.json(metadata);
+}
+```
+
+> 💡 **See Complete Framework Examples**: Check `/examples/metadata/` for full implementations with authentication, error handling, and MCP tool integration.
+
+## Installation
+
+```bash
+npm install @descope/mcp-sdk
+```
+
+## Quick Start
+
+### 1. Setup Authentication Middleware with Scope Validation
+
+```typescript
+import { createMcpAuthMiddleware } from '@descope/mcp-sdk';
+
+// Create middleware with automatic scope validation
+const authMiddleware = await createMcpAuthMiddleware({
+  requiredScopes: ['mcp:access'], // Automatically returns 403 + WWW-Authenticate if missing
+});
+
+// When user lacks 'mcp:access' scope, automatically returns:
+// 403 Forbidden with header: WWW-Authenticate: Bearer, error="insufficient_scope", scope="mcp:access"
+```
+
+### 2. Build Tools with Multi-Provider Token Access
+
+```typescript
+import { createAuthenticatedTool } from '@descope/mcp-sdk';
+
+const syncGitHubRepos = createAuthenticatedTool(
+  {
+    name: 'syncGitHubRepos',
+    description: 'Sync user repositories from GitHub',
+    requiredScopes: ['github:read'], // Scope validation happens automatically
+  },
+  async ({ descope }) => {
+    // Get GitHub token via Descope outbound app - no complex OAuth flow needed!
+    const githubToken = await descope.getOutboundToken('github-app');
+
+    if (!githubToken) {
+      return { error: 'GitHub access not configured for user' };
+    }
+
+    // Call GitHub API with the token
+    const repos = await fetch('https://api.github.com/user/repos', {
+      headers: { Authorization: `Bearer ${githubToken}` },
+    }).then((r) => r.json());
+
+    return { repositories: repos.map((r) => r.name) };
+  },
+);
+```
+
+### 3. Serve Protected Resource Metadata
+
+For framework-specific implementations, see the [Easy Protected Resource Metadata APIs](#-3-easy-protected-resource-metadata-apis) section above or check the complete examples in `/examples/metadata/`:
+
+- **Express.js**: `/examples/metadata/express-metadata.ts`
+- **Next.js App Router**: `/examples/metadata/nextjs-app-router.ts`
+- **Next.js Pages Router**: `/examples/metadata/nextjs-pages-router.ts`
+
+Basic metadata generation:
+
+```typescript
+import { buildResourceMetadata } from '@descope/mcp-sdk';
+
+const metadata = buildResourceMetadata({
+  resource: 'https://api.example.com',
+  authorizationServers: ['https://auth.descope.com/YOUR_PROJECT_ID'],
+  scopes: ['mcp:read', 'mcp:write', 'github:read'],
+});
+```
+
+## Automatic OAuth 2.0 Error Handling
+
+When required scopes are missing, the SDK automatically returns proper OAuth 2.0 error responses:
+
+```typescript
+// When insufficient scopes
+{
+  "isError": true,
+  "code": 403,
+  "headers": {
+    "WWW-Authenticate": "Bearer, error=\"insufficient_scope\", error_description=\"Missing required scopes: user:write\", scope=\"user:write\""
+  },
+  "content": [{
+    "type": "text",
+    "text": "{\"error\": \"insufficient_scope\", \"error_description\": \"Missing required scopes: user:write\"}"
+  }]
+}
+```
+
+## API Reference
+
+### createAuthMiddleware(options)
+
+Creates authentication middleware for MCP requests.
+
+```typescript
+interface AuthMiddlewareOptions {
+  skipAuth?: boolean; // Skip authentication
+  requiredScopes?: string[]; // Required scopes for all requests
+  tokenManager?: TokenManager; // Custom token manager
+}
+```
+
+### defineToolWithDescope(options, handler)
+
+Creates an MCP tool with Descope authentication and context.
+
+```typescript
+interface ToolOptions {
+  name: string; // Tool name
+  description: string; // Tool description
+  inputSchema?: any; // JSON schema for inputs
+  requiredScopes?: string[]; // Required scopes for this tool
+}
+
+interface ToolExecutionContext {
+  descope: DescopeContext; // Descope user context
+  args: Record<string, unknown>; // Tool arguments
+}
+```
+
+### DescopeContext
+
+Injected context for authenticated requests:
+
+```typescript
+interface DescopeContext {
+  projectId: string; // Descope project ID
+  userId: string; // Authenticated user ID
+  userScopes: string[]; // User's granted scopes
+  descopeToken: string; // Original Descope token
+  getOutboundToken: (
+    // Get token for external services
+    appId: string,
+    scopes?: string[],
+  ) => Promise<string | null>;
+}
+```
+
+### OAuth Error Types
+
+```typescript
+interface OAuthError {
+  error: 'invalid_token' | 'insufficient_scope' | 'invalid_request';
+  error_description?: string;
+  error_uri?: string;
+  scope?: string;
+}
+
+interface McpOAuthError extends Error {
+  code: number;
+  oauthError: OAuthError;
+  wwwAuthenticate: string;
+}
+```
+
+## Protected Resource Metadata
+
+The SDK also provides OAuth 2.0 Protected Resource Metadata (RFC 9728) support:
+
+### Resource Metadata Configuration
+
+```typescript
+import { buildResourceMetadata, buildWWWAuthenticate } from '@descope/mcp-sdk';
+
+const resourceConfig = {
+  resource: 'https://api.example.com',
+  authorizationServers: ['https://auth.descope.com/YOUR_PROJECT_ID'],
+  scopes: ['mcp:read', 'mcp:write'],
+  docsUrl: 'https://docs.example.com/mcp',
+};
+
+// Generate metadata for /.well-known/oauth-protected-resource
+const metadata = buildResourceMetadata(resourceConfig);
+
+// Generate WWW-Authenticate headers (with resource metadata URL for MCP compliance)
+const authHeader = buildWWWAuthenticate({
+  error: 'insufficient_scope',
+  error_description: 'Missing required scopes: mcp:write',
+  scope: 'mcp:write',
+  resourceMetadataUrl: 'https://api.example.com/.well-known/oauth-protected-resource',
+});
+```
+
+### Metadata Endpoint Response
+
+```json
+{
+  "resource": "https://api.example.com",
+  "authorization_servers": ["https://auth.descope.com/P123456789"],
+  "scopes_supported": ["mcp:read", "mcp:write"],
+  "bearer_methods_supported": ["header"],
+  "resource_documentation": "https://docs.example.com/mcp"
+}
+```
+
+## Utility Functions
+
+The SDK provides utility functions for common operations:
+
+```typescript
+import { validateScopes } from '@descope/mcp-sdk';
+
+// Validate scopes
+const scopeCheck = validateScopes(['read', 'write'], userScopes);
+console.log(scopeCheck.valid); // boolean
+console.log(scopeCheck.missing); // string[] - missing scopes
+```
+
+## Custom Token Validation
+
+Provide your own token validator:
+
+```typescript
+const customAuthMiddleware = await createMcpAuthMiddleware({
+  validateToken: async (token: string) => {
+    // Custom validation logic
+    return {
+      valid: true,
+      userId: 'user123',
+      scopes: ['read', 'write'],
+    };
+  },
+});
+```
+
+## Framework Examples
+
+Complete working examples are available in the `/examples/metadata/` directory:
+
+| Framework                | File                     | Features                                           |
+| ------------------------ | ------------------------ | -------------------------------------------------- |
+| **Express.js**           | `express-metadata.ts`    | Middleware setup, protected routes, error handling |
+| **Next.js App Router**   | `nextjs-app-router.ts`   | Route handlers, middleware, API routes             |
+| **Next.js Pages Router** | `nextjs-pages-router.ts` | API routes, HOC patterns, dynamic tools            |
+
+Each example includes:
+
+- ✅ OAuth 2.0 Protected Resource Metadata endpoint (`/.well-known/oauth-protected-resource`)
+- ✅ Protected API routes with automatic scope validation
+- ✅ MCP tool integration with authentication
+- ✅ Proper error handling with WWW-Authenticate headers
+- ✅ TypeScript definitions and best practices
+
+## Key Benefits Summary
+
+✅ **No Manual Scope Checking** - Define `requiredScopes` once, get automatic validation  
+✅ **Multi-Provider Token Access** - Get GitHub, Google, Slack tokens via Descope outbound apps  
+✅ **OAuth 2.0 Compliance** - Proper WWW-Authenticate headers and error responses  
+✅ **Protected Resource Metadata** - RFC 9728 compliant endpoints with minimal setup  
+✅ **Enterprise Security** - Built on Descope's enterprise authentication platform  
+✅ **Framework Support** - Complete examples for Express.js and Next.js (App Router & Pages Router)
+
+## Environment Variables
+
+```bash
+DESCOPE_PROJECT_ID=P123456789              # Your Descope project ID (required)
+DESCOPE_BASE_URL=https://auth.descope.com  # Optional: Custom Descope URL
+```
+
+## License
+
+MIT License - see [LICENSE](https://github.com/descope/descope-js/blob/main/LICENSE)

--- a/packages/sdks/mcp-sdk/README.md
+++ b/packages/sdks/mcp-sdk/README.md
@@ -40,7 +40,7 @@ const userProfileTool = createAuthenticatedTool(
       userId: descope.userId,
       scopes: descope.userScopes,
       // Access external providers too:
-      githubToken: await descope.getOutboundToken('github-app'),
+      githubToken: await descope.getOutboundToken('github', ['repo:read']),
     };
   },
 );
@@ -95,7 +95,7 @@ const tool = createAuthenticatedTool(
   },
   async ({ descope }) => {
     // Get GitHub token for the authenticated user via Descope
-    const githubToken = await descope.getOutboundToken('github-app');
+    const githubToken = await descope.getOutboundToken('github', ['repo:read']);
 
     // Use GitHub token to call GitHub API
     const response = await fetch('https://api.github.com/user/repos', {

--- a/packages/sdks/mcp-sdk/README.md
+++ b/packages/sdks/mcp-sdk/README.md
@@ -1,6 +1,50 @@
 # @descope/mcp-sdk
 
-Secure Model Context Protocol (MCP) SDK for Node.js with Descope authentication. Build MCP servers with enterprise-grade authentication, scope-based access control, and OAuth 2.0 compliance.
+[![Version](https://img.shields.io/npm/v/@descope/mcp-sdk.svg)](https://www.npmjs.com/package/@descope/mcp-sdk)
+[![MCP Compatible](https://img.shields.io/badge/MCP-Compatible-green)](https://modelcontextprotocol.io)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.0+-blue.svg)](https://www.typescriptlang.org/)
+[![Node.js](https://img.shields.io/badge/Node.js-18+-green.svg)](https://nodejs.org/)
+[![License](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+🚀 **Build secure MCP servers with enterprise-grade authentication in minutes**
+
+Secure Model Context Protocol (MCP) SDK for Node.js with Descope authentication. Create authenticated tools, access external provider tokens, and ensure OAuth 2.0 compliance—all with just a few lines of code.
+
+## ✨ What You Get
+
+🔧 **Authenticated MCP Tools** - Built-in scope validation and user context  
+🔗 **Outbound Token Access** - Seamlessly connect to GitHub, Google, Slack, and more  
+⚡ **OAuth 2.0 Compliance** - Automatic error responses and WWW-Authenticate headers  
+📚 **Framework Ready** - Complete examples for Express.js and Next.js  
+🛡️ **Enterprise Security** - Powered by Descope's authentication platform
+
+## 🚀 Quick Start
+
+```bash
+npm install @descope/mcp-sdk
+```
+
+Create your first authenticated tool:
+
+```typescript
+import { createAuthenticatedTool } from '@descope/mcp-sdk';
+
+const userProfileTool = createAuthenticatedTool(
+  {
+    name: 'getUserProfile',
+    description: 'Get authenticated user profile',
+    requiredScopes: ['user:read'], // Automatic validation!
+  },
+  async ({ descope }) => {
+    return {
+      userId: descope.userId,
+      scopes: descope.userScopes,
+      // Access external providers too:
+      githubToken: await descope.getOutboundToken('github-app'),
+    };
+  },
+);
+```
 
 ## Prerequisites
 
@@ -131,77 +175,6 @@ export default async function handler(req, res) {
 
 > 💡 **See Complete Framework Examples**: Check `/examples/metadata/` for full implementations with authentication, error handling, and MCP tool integration.
 
-## Installation
-
-```bash
-npm install @descope/mcp-sdk
-```
-
-## Quick Start
-
-### 1. Setup Authentication Middleware with Scope Validation
-
-```typescript
-import { createMcpAuthMiddleware } from '@descope/mcp-sdk';
-
-// Create middleware with automatic scope validation
-const authMiddleware = await createMcpAuthMiddleware({
-  requiredScopes: ['mcp:access'], // Automatically returns 403 + WWW-Authenticate if missing
-});
-
-// When user lacks 'mcp:access' scope, automatically returns:
-// 403 Forbidden with header: WWW-Authenticate: Bearer, error="insufficient_scope", scope="mcp:access"
-```
-
-### 2. Build Tools with Multi-Provider Token Access
-
-```typescript
-import { createAuthenticatedTool } from '@descope/mcp-sdk';
-
-const syncGitHubRepos = createAuthenticatedTool(
-  {
-    name: 'syncGitHubRepos',
-    description: 'Sync user repositories from GitHub',
-    requiredScopes: ['github:read'], // Scope validation happens automatically
-  },
-  async ({ descope }) => {
-    // Get GitHub token via Descope outbound app - no complex OAuth flow needed!
-    const githubToken = await descope.getOutboundToken('github-app');
-
-    if (!githubToken) {
-      return { error: 'GitHub access not configured for user' };
-    }
-
-    // Call GitHub API with the token
-    const repos = await fetch('https://api.github.com/user/repos', {
-      headers: { Authorization: `Bearer ${githubToken}` },
-    }).then((r) => r.json());
-
-    return { repositories: repos.map((r) => r.name) };
-  },
-);
-```
-
-### 3. Serve Protected Resource Metadata
-
-For framework-specific implementations, see the [Easy Protected Resource Metadata APIs](#-3-easy-protected-resource-metadata-apis) section above or check the complete examples in `/examples/metadata/`:
-
-- **Express.js**: `/examples/metadata/express-metadata.ts`
-- **Next.js App Router**: `/examples/metadata/nextjs-app-router.ts`
-- **Next.js Pages Router**: `/examples/metadata/nextjs-pages-router.ts`
-
-Basic metadata generation:
-
-```typescript
-import { buildResourceMetadata } from '@descope/mcp-sdk';
-
-const metadata = buildResourceMetadata({
-  resource: 'https://api.example.com',
-  authorizationServers: ['https://auth.descope.com/YOUR_PROJECT_ID'],
-  scopes: ['mcp:read', 'mcp:write', 'github:read'],
-});
-```
-
 ## Automatic OAuth 2.0 Error Handling
 
 When required scopes are missing, the SDK automatically returns proper OAuth 2.0 error responses:
@@ -223,7 +196,7 @@ When required scopes are missing, the SDK automatically returns proper OAuth 2.0
 
 ## API Reference
 
-### createAuthMiddleware(options)
+### createMcpAuthMiddleware(options)
 
 Creates authentication middleware for MCP requests.
 
@@ -235,7 +208,7 @@ interface AuthMiddlewareOptions {
 }
 ```
 
-### defineToolWithDescope(options, handler)
+### createAuthenticatedTool(options, handler)
 
 Creates an MCP tool with Descope authentication and context.
 
@@ -375,15 +348,6 @@ Each example includes:
 - ✅ MCP tool integration with authentication
 - ✅ Proper error handling with WWW-Authenticate headers
 - ✅ TypeScript definitions and best practices
-
-## Key Benefits Summary
-
-✅ **No Manual Scope Checking** - Define `requiredScopes` once, get automatic validation  
-✅ **Multi-Provider Token Access** - Get GitHub, Google, Slack tokens via Descope outbound apps  
-✅ **OAuth 2.0 Compliance** - Proper WWW-Authenticate headers and error responses  
-✅ **Protected Resource Metadata** - RFC 9728 compliant endpoints with minimal setup  
-✅ **Enterprise Security** - Built on Descope's enterprise authentication platform  
-✅ **Framework Support** - Complete examples for Express.js and Next.js (App Router & Pages Router)
 
 ## Environment Variables
 

--- a/packages/sdks/mcp-sdk/examples/metadata/express-metadata.ts
+++ b/packages/sdks/mcp-sdk/examples/metadata/express-metadata.ts
@@ -1,0 +1,277 @@
+/**
+ * Express.js Protected Resource Metadata Example
+ *
+ * This example shows how to implement OAuth 2.0 Protected Resource Metadata (RFC 9728)
+ * endpoints in an Express.js application using the Descope MCP SDK.
+ *
+ * To use this example:
+ * 1. Install dependencies: npm install express @types/express
+ * 2. Uncomment the import statement and function call at the bottom
+ * 3. Set DESCOPE_PROJECT_ID environment variable
+ */
+
+import {
+  buildResourceMetadata,
+  buildWWWAuthenticate,
+  createMcpAuthMiddleware,
+} from '@descope/mcp-sdk';
+
+// Type definitions for Express (when available)
+interface ExpressApp {
+  get: (path: string, handler: (req: any, res: any) => void) => void;
+  use: (handler: (err: any, req: any, res: any, next: any) => void) => void;
+  listen: (port: number, callback: () => void) => void;
+}
+
+interface ExpressRequest {
+  method: string;
+  headers: {
+    authorization?: string;
+  };
+}
+
+interface ExpressResponse {
+  json: (data: any) => void;
+  status: (code: number) => ExpressResponse;
+  set: (header: string, value: string) => ExpressResponse;
+}
+
+// Configuration
+const DESCOPE_PROJECT_ID = process.env.DESCOPE_PROJECT_ID!;
+const API_BASE_URL = process.env.API_BASE_URL || 'http://localhost:3000';
+
+// Resource configuration for MCP compliance
+const resourceConfig = {
+  resource: API_BASE_URL,
+  authorizationServers: [`https://auth.descope.com/${DESCOPE_PROJECT_ID}`],
+  scopes: ['mcp:read', 'mcp:write', 'user:profile', 'admin:manage'],
+  docsUrl: `${API_BASE_URL}/docs`,
+};
+
+// ================================
+// Standalone Handler Functions (for use as middleware or in custom setups)
+// ================================
+
+// Option A: Public metadata endpoint handler
+export async function getMetadata(req: ExpressRequest, res: ExpressResponse) {
+  try {
+    const metadata = buildResourceMetadata(resourceConfig);
+
+    res
+      .set('Cache-Control', 'public, max-age=3600')
+      .set('Content-Type', 'application/json')
+      .json(metadata);
+  } catch (error) {
+    console.error('Error generating resource metadata:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+}
+
+// Option B: Protected metadata endpoint handler
+export async function getProtectedMetadata(
+  req: ExpressRequest,
+  res: ExpressResponse,
+) {
+  try {
+    const authHeader = req.headers.authorization;
+    const token = authHeader?.replace('Bearer ', '');
+
+    if (!token) {
+      return res
+        .status(401)
+        .set(
+          'WWW-Authenticate',
+          buildWWWAuthenticate({
+            error: 'invalid_request',
+            error_description: 'Authorization required to access metadata',
+            resourceMetadataUrl: `${API_BASE_URL}/.well-known/oauth-protected-resource`,
+          }),
+        )
+        .json({
+          error: 'invalid_request',
+          error_description: 'Authorization required to access metadata',
+        });
+    }
+
+    // Validate token (basic validation, no specific scopes required for metadata)
+    const authMiddleware = await createMcpAuthMiddleware({
+      requiredScopes: [], // No specific scopes required for metadata
+    });
+
+    const mockRequest = { method: req.method };
+    const mockExtra = {
+      signal: new AbortController().signal,
+      authInfo: { token },
+      descope: undefined as any,
+    };
+
+    await authMiddleware(mockRequest, mockExtra, async () => {
+      // Token is valid
+    });
+
+    const metadata = buildResourceMetadata(resourceConfig);
+
+    res
+      .set('Cache-Control', 'private, max-age=300')
+      .set('Content-Type', 'application/json')
+      .json(metadata);
+  } catch (error: any) {
+    if (error.code && error.oauthError) {
+      return res
+        .status(error.code)
+        .set('WWW-Authenticate', error.wwwAuthenticate)
+        .json(error.oauthError);
+    }
+
+    return res
+      .status(401)
+      .set(
+        'WWW-Authenticate',
+        buildWWWAuthenticate({
+          error: 'invalid_token',
+          error_description: 'Token validation failed',
+          resourceMetadataUrl: `${API_BASE_URL}/.well-known/oauth-protected-resource`,
+        }),
+      )
+      .json({
+        error: 'invalid_token',
+        error_description: 'Token validation failed',
+      });
+  }
+}
+
+export function createExpressApp(express: any): ExpressApp {
+  const app = express();
+  const PORT = parseInt(process.env.PORT || '3000');
+
+  // 1. OAuth 2.0 Protected Resource Metadata Endpoints
+
+  // Option A: Public metadata endpoint (common approach, similar to OpenID Connect)
+  app.get('/.well-known/oauth-protected-resource', getMetadata);
+
+  // Option B: Protected metadata endpoint (higher security)
+  app.get('/.well-known/oauth-protected-resource-auth', getProtectedMetadata);
+
+  // 2. Protected API endpoint with automatic scope validation
+  app.get(
+    '/api/protected',
+    async (req: ExpressRequest, res: ExpressResponse) => {
+      try {
+        const authMiddleware = await createMcpAuthMiddleware({
+          requiredScopes: ['mcp:read'],
+        });
+
+        const mockRequest = { method: 'GET' };
+        const mockExtra = {
+          signal: new AbortController().signal,
+          authInfo: {
+            token: req.headers.authorization?.replace('Bearer ', ''),
+          },
+          descope: undefined as any,
+        };
+
+        await authMiddleware(mockRequest, mockExtra, async () => {
+          res.json({
+            message: 'Access granted',
+            userId: mockExtra.descope?.userId,
+            scopes: mockExtra.descope?.userScopes,
+          });
+        });
+      } catch (error: any) {
+        if (error.code && error.oauthError) {
+          res
+            .status(error.code)
+            .set('WWW-Authenticate', error.wwwAuthenticate)
+            .json(error.oauthError);
+        } else {
+          res
+            .status(401)
+            .set(
+              'WWW-Authenticate',
+              buildWWWAuthenticate({
+                error: 'invalid_request',
+                error_description: 'Authentication required',
+                resourceMetadataUrl: `${API_BASE_URL}/.well-known/oauth-protected-resource`,
+              }),
+            )
+            .json({ error: 'Authentication required' });
+        }
+      }
+    },
+  );
+
+  // 3. Error handling middleware for OAuth errors
+  app.use((err: any, req: ExpressRequest, res: ExpressResponse, next: any) => {
+    if (err.oauthError) {
+      res
+        .status(err.code || 401)
+        .set('WWW-Authenticate', err.wwwAuthenticate)
+        .json(err.oauthError);
+    } else {
+      console.error('Unhandled error:', err);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  });
+
+  // 4. Start server function
+  const startServer = () => {
+    app.listen(PORT, () => {
+      console.log(`🚀 Express server running on http://localhost:${PORT}`);
+      console.log(
+        `📋 Public metadata endpoint: http://localhost:${PORT}/.well-known/oauth-protected-resource`,
+      );
+      console.log(
+        `🔐 Protected metadata endpoint: http://localhost:${PORT}/.well-known/oauth-protected-resource-auth`,
+      );
+      console.log(
+        `🔒 Protected API endpoint: http://localhost:${PORT}/api/protected`,
+      );
+      console.log(`📖 Example usage:`);
+      console.log(
+        `   curl http://localhost:${PORT}/.well-known/oauth-protected-resource`,
+      );
+      console.log(
+        `   curl -H "Authorization: Bearer YOUR_TOKEN" http://localhost:${PORT}/.well-known/oauth-protected-resource-auth`,
+      );
+      console.log(
+        `   curl -H "Authorization: Bearer YOUR_TOKEN" http://localhost:${PORT}/api/protected`,
+      );
+    });
+  };
+
+  return {
+    ...app,
+    startServer,
+  } as ExpressApp & { startServer: () => void };
+}
+
+// Example usage (uncomment when express is installed):
+/*
+import express from 'express';
+
+const app = createExpressApp(express);
+app.startServer();
+*/
+
+// Example usage of individual handlers in custom Express setup:
+/*
+import express from 'express';
+import { getMetadata, getProtectedMetadata } from './express-metadata';
+
+const app = express();
+
+// Use the handlers directly in your routes
+app.get('/.well-known/oauth-protected-resource', getMetadata);
+app.get('/.well-known/oauth-protected-resource-auth', getProtectedMetadata);
+
+app.listen(3000, () => {
+  console.log('Server running on port 3000');
+});
+*/
+
+// Export handlers for use in other Express applications
+export default {
+  createExpressApp,
+  getMetadata,
+  getProtectedMetadata,
+};

--- a/packages/sdks/mcp-sdk/examples/metadata/nextjs-app-router.ts
+++ b/packages/sdks/mcp-sdk/examples/metadata/nextjs-app-router.ts
@@ -1,0 +1,397 @@
+/**
+ * Next.js App Router Protected Resource Metadata Example
+ *
+ * This example shows how to implement OAuth 2.0 Protected Resource Metadata (RFC 9728)
+ * in Next.js 13+ using the App Router and the Descope MCP SDK.
+ *
+ * To use this example:
+ * 1. Install Next.js: npm install next react react-dom @types/react @types/react-dom
+ * 2. Create the appropriate route files in your Next.js app directory
+ * 3. Set DESCOPE_PROJECT_ID environment variable
+ *
+ * File structure:
+ * - app/.well-known/oauth-protected-resource/route.ts
+ * - app/api/protected/route.ts
+ * - app/api/mcp-tools/route.ts
+ */
+
+import {
+  buildResourceMetadata,
+  buildWWWAuthenticate,
+  createMcpAuthMiddleware,
+  createAuthenticatedTool,
+} from '@descope/mcp-sdk';
+
+// Type definitions for Next.js (when available)
+interface NextRequest {
+  headers: {
+    get: (name: string) => string | null;
+  };
+  method: string;
+  json: () => Promise<any>;
+}
+
+// Mock NextResponse for type safety
+const createNextResponse = () => ({
+  json: (
+    data: any,
+    options?: { headers?: Record<string, string>; status?: number },
+  ) => ({
+    data,
+    ...options,
+  }),
+});
+
+// Configuration
+const DESCOPE_PROJECT_ID = process.env.DESCOPE_PROJECT_ID!;
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL || 'https://yourdomain.com';
+
+// Resource configuration for MCP compliance
+const resourceConfig = {
+  resource: API_BASE_URL,
+  authorizationServers: [`https://auth.descope.com/${DESCOPE_PROJECT_ID}`],
+  scopes: ['mcp:read', 'mcp:write', 'user:profile', 'admin:manage'],
+  docsUrl: `${API_BASE_URL}/docs`,
+};
+
+// ================================
+// 1. OAuth Protected Resource Metadata Endpoint
+// File: app/.well-known/oauth-protected-resource/route.ts
+// ================================
+
+// Option A: Public metadata endpoint (common approach, similar to OpenID Connect)
+export async function getMetadata() {
+  try {
+    const metadata = buildResourceMetadata(resourceConfig);
+
+    const NextResponse = createNextResponse();
+    return NextResponse.json(metadata, {
+      headers: {
+        'Cache-Control': 'public, max-age=3600',
+        'Content-Type': 'application/json',
+      },
+    });
+  } catch (error) {
+    console.error('Error generating resource metadata:', error);
+    const NextResponse = createNextResponse();
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 },
+    );
+  }
+}
+
+// Option B: Protected metadata endpoint (higher security)
+export async function getProtectedMetadata(request: NextRequest) {
+  try {
+    const authHeader = request.headers.get('authorization');
+    const token = authHeader?.replace('Bearer ', '');
+
+    if (!token) {
+      const NextResponse = createNextResponse();
+      return NextResponse.json(
+        {
+          error: 'invalid_request',
+          error_description: 'Authorization required to access metadata',
+        },
+        {
+          status: 401,
+          headers: {
+            'WWW-Authenticate': buildWWWAuthenticate({
+              error: 'invalid_request',
+              error_description: 'Authorization required to access metadata',
+              resourceMetadataUrl: `${API_BASE_URL}/.well-known/oauth-protected-resource`,
+            }),
+          },
+        },
+      );
+    }
+
+    // Validate token (basic validation, no specific scopes required for metadata)
+    const authMiddleware = await createMcpAuthMiddleware({
+      requiredScopes: [], // No specific scopes required for metadata
+    });
+
+    const mockRequest = { method: request.method };
+    const mockExtra = {
+      signal: new AbortController().signal,
+      authInfo: { token },
+      descope: undefined as any,
+    };
+
+    await authMiddleware(mockRequest, mockExtra, async () => {
+      // Token is valid
+    });
+
+    const metadata = buildResourceMetadata({
+      resource: API_BASE_URL,
+      authorizationServers: [`https://auth.descope.com/${DESCOPE_PROJECT_ID}`],
+      scopes: ['mcp:read', 'mcp:write', 'user:profile', 'admin:manage'],
+      docsUrl: `${API_BASE_URL}/docs`,
+    });
+
+    const NextResponse = createNextResponse();
+    return NextResponse.json(metadata, {
+      headers: {
+        'Cache-Control': 'private, max-age=300',
+        'Content-Type': 'application/json',
+      },
+    });
+  } catch (error: any) {
+    const NextResponse = createNextResponse();
+
+    if (error.code && error.oauthError) {
+      return NextResponse.json(error.oauthError, {
+        status: error.code,
+        headers: {
+          'WWW-Authenticate': error.wwwAuthenticate,
+        },
+      });
+    }
+
+    return NextResponse.json(
+      {
+        error: 'invalid_token',
+        error_description: 'Token validation failed',
+      },
+      {
+        status: 401,
+        headers: {
+          'WWW-Authenticate': buildWWWAuthenticate({
+            error: 'invalid_token',
+            error_description: 'Token validation failed',
+          }),
+        },
+      },
+    );
+  }
+}
+
+// ================================
+// 2. Protected API Route with Scope Validation
+// File: app/api/protected/route.ts
+// ================================
+
+export async function protectedRouteHandler(request: NextRequest) {
+  try {
+    const authHeader = request.headers.get('authorization');
+    const token = authHeader?.replace('Bearer ', '');
+
+    if (!token) {
+      const NextResponse = createNextResponse();
+      return NextResponse.json(
+        {
+          error: 'invalid_request',
+          error_description: 'Authorization header required',
+        },
+        {
+          status: 401,
+          headers: {
+            'WWW-Authenticate': buildWWWAuthenticate({
+              error: 'invalid_request',
+              error_description: 'Authorization header required',
+            }),
+          },
+        },
+      );
+    }
+
+    const authMiddleware = await createMcpAuthMiddleware({
+      requiredScopes: ['mcp:read'],
+    });
+
+    const mockRequest = { method: request.method };
+    const mockExtra = {
+      signal: new AbortController().signal,
+      authInfo: { token },
+      descope: undefined as any,
+    };
+
+    await authMiddleware(mockRequest, mockExtra, async () => {
+      // Middleware passed - user is authenticated with required scopes
+    });
+
+    const NextResponse = createNextResponse();
+    return NextResponse.json({
+      message: 'Access granted to protected resource',
+      userId: mockExtra.descope?.userId,
+      projectId: mockExtra.descope?.projectId,
+      scopes: mockExtra.descope?.userScopes,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (error: any) {
+    const NextResponse = createNextResponse();
+
+    if (error.code && error.oauthError) {
+      return NextResponse.json(error.oauthError, {
+        status: error.code,
+        headers: {
+          'WWW-Authenticate': error.wwwAuthenticate,
+        },
+      });
+    }
+
+    return NextResponse.json(
+      {
+        error: 'invalid_token',
+        error_description: 'Token validation failed',
+      },
+      {
+        status: 401,
+        headers: {
+          'WWW-Authenticate': buildWWWAuthenticate({
+            error: 'invalid_token',
+            error_description: 'Token validation failed',
+          }),
+        },
+      },
+    );
+  }
+}
+
+// ================================
+// 3. MCP Tools API Route
+// File: app/api/mcp-tools/route.ts
+// ================================
+
+const userProfileTool = createAuthenticatedTool(
+  {
+    name: 'getUserProfile',
+    description: 'Get authenticated user profile information',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        includeScopes: {
+          type: 'boolean',
+          description: 'Include user scopes in response',
+        },
+      },
+      additionalProperties: false,
+    },
+    requiredScopes: ['user:profile'],
+  },
+  async ({ args, descope }) => {
+    const profile = {
+      userId: descope.userId,
+      projectId: descope.projectId,
+      timestamp: new Date().toISOString(),
+    };
+
+    if (args.includeScopes) {
+      (profile as any).scopes = descope.userScopes;
+    }
+
+    return profile;
+  },
+);
+
+export async function mcpToolsHandler(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { toolName, args } = body;
+
+    const authHeader = request.headers.get('authorization');
+    const token = authHeader?.replace('Bearer ', '');
+
+    if (!token) {
+      const NextResponse = createNextResponse();
+      return NextResponse.json(
+        { error: 'Authentication required' },
+        { status: 401 },
+      );
+    }
+
+    const mockExtra = {
+      signal: new AbortController().signal,
+      authInfo: { token },
+      descope: undefined as any,
+    };
+
+    let result: any;
+    switch (toolName) {
+      case 'getUserProfile':
+        result = await userProfileTool.handler(args || {}, mockExtra);
+        break;
+
+      default:
+        const NextResponse = createNextResponse();
+        return NextResponse.json({ error: 'Unknown tool' }, { status: 404 });
+    }
+
+    const NextResponse = createNextResponse();
+    return NextResponse.json(result);
+  } catch (error: any) {
+    const NextResponse = createNextResponse();
+
+    if (error.code && error.oauthError) {
+      return NextResponse.json(error.oauthError, {
+        status: error.code,
+        headers: {
+          'WWW-Authenticate': error.wwwAuthenticate,
+        },
+      });
+    }
+
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 },
+    );
+  }
+}
+
+// ================================
+// 4. Middleware for Global Auth (Optional)
+// File: middleware.ts (in project root)
+// ================================
+
+export function createNextJsMiddleware() {
+  return async function middleware(request: NextRequest) {
+    // Only apply to protected routes
+    if (request.headers.get('pathname')?.startsWith('/api/protected')) {
+      const authHeader = request.headers.get('authorization');
+
+      if (!authHeader) {
+        const NextResponse = createNextResponse();
+        return NextResponse.json(
+          {
+            error: 'invalid_request',
+            error_description: 'Authorization header required',
+          },
+          {
+            status: 401,
+            headers: {
+              'WWW-Authenticate': buildWWWAuthenticate({
+                error: 'invalid_request',
+                error_description: 'Authorization header required',
+              }),
+            },
+          },
+        );
+      }
+    }
+
+    return { next: true };
+  };
+}
+
+// Example usage in route files:
+/*
+// app/.well-known/oauth-protected-resource/route.ts
+export { getMetadata as GET };
+
+// app/api/protected/route.ts  
+export { protectedRouteHandler as GET, protectedRouteHandler as POST };
+
+// app/api/mcp-tools/route.ts
+export { mcpToolsHandler as POST };
+*/
+
+// Export all handlers for use in actual Next.js route files
+export default {
+  getMetadata,
+  getProtectedMetadata,
+  protectedRouteHandler,
+  mcpToolsHandler,
+  createNextJsMiddleware,
+};

--- a/packages/sdks/mcp-sdk/examples/metadata/nextjs-pages-router.ts
+++ b/packages/sdks/mcp-sdk/examples/metadata/nextjs-pages-router.ts
@@ -1,0 +1,461 @@
+/**
+ * Next.js Pages Router Protected Resource Metadata Example
+ *
+ * This example shows how to implement OAuth 2.0 Protected Resource Metadata (RFC 9728)
+ * in Next.js using the Pages Router and the Descope MCP SDK.
+ *
+ * To use this example:
+ * 1. Install Next.js: npm install next react react-dom @types/react @types/react-dom
+ * 2. Create the appropriate API route files in your Next.js pages/api directory
+ * 3. Set DESCOPE_PROJECT_ID environment variable
+ *
+ * File structure:
+ * - pages/.well-known/oauth-protected-resource.ts
+ * - pages/api/protected.ts
+ * - pages/api/mcp-tools/[tool].ts
+ */
+
+import {
+  buildResourceMetadata,
+  buildWWWAuthenticate,
+  createMcpAuthMiddleware,
+  createAuthenticatedTool,
+} from '@descope/mcp-sdk';
+
+// Type definitions for Next.js API (when available)
+interface NextApiRequest {
+  method?: string;
+  headers: {
+    authorization?: string;
+  };
+  query: {
+    [key: string]: string | string[];
+  };
+  body?: any;
+}
+
+interface NextApiResponse {
+  status: (statusCode: number) => NextApiResponse;
+  json: (data: any) => void;
+  setHeader: (name: string, value: string) => NextApiResponse;
+}
+
+// Configuration
+const DESCOPE_PROJECT_ID = process.env.DESCOPE_PROJECT_ID!;
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL || 'https://yourdomain.com';
+
+// Resource configuration for MCP compliance
+const resourceConfig = {
+  resource: API_BASE_URL,
+  authorizationServers: [`https://auth.descope.com/${DESCOPE_PROJECT_ID}`],
+  scopes: ['mcp:read', 'mcp:write', 'user:profile', 'admin:manage'],
+  docsUrl: `${API_BASE_URL}/docs`,
+};
+
+// ================================
+// 1. OAuth Protected Resource Metadata Endpoint
+// File: pages/.well-known/oauth-protected-resource.ts
+// ================================
+
+// Option A: Public metadata endpoint (common approach)
+export async function metadataHandler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  try {
+    const metadata = buildResourceMetadata(resourceConfig);
+
+    res.setHeader('Cache-Control', 'public, max-age=3600');
+    res.setHeader('Content-Type', 'application/json');
+
+    return res.status(200).json(metadata);
+  } catch (error) {
+    console.error('Error generating resource metadata:', error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+}
+
+// Option B: Protected metadata endpoint (higher security)
+export async function protectedMetadataHandler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  try {
+    const authHeader = req.headers.authorization;
+    const token = authHeader?.replace('Bearer ', '');
+
+    if (!token) {
+      const wwwAuth = buildWWWAuthenticate({
+        error: 'invalid_request',
+        error_description: 'Authorization required to access metadata',
+      });
+
+      res.setHeader('WWW-Authenticate', wwwAuth);
+      return res.status(401).json({
+        error: 'invalid_request',
+        error_description: 'Authorization required to access metadata',
+      });
+    }
+
+    // Validate token (basic validation, no specific scopes required for metadata)
+    const authMiddleware = await createMcpAuthMiddleware({
+      requiredScopes: [], // No specific scopes required for metadata
+    });
+
+    const mockRequest = { method: req.method };
+    const mockExtra = {
+      signal: new AbortController().signal,
+      authInfo: { token },
+      descope: undefined as any,
+    };
+
+    await authMiddleware(mockRequest, mockExtra, async () => {
+      // Token is valid
+    });
+
+    const metadata = buildResourceMetadata({
+      resource: API_BASE_URL,
+      authorizationServers: [`https://auth.descope.com/${DESCOPE_PROJECT_ID}`],
+      scopes: ['mcp:read', 'mcp:write', 'user:profile', 'admin:manage'],
+      docsUrl: `${API_BASE_URL}/docs`,
+    });
+
+    res.setHeader('Cache-Control', 'private, max-age=300');
+    res.setHeader('Content-Type', 'application/json');
+
+    return res.status(200).json(metadata);
+  } catch (error: any) {
+    if (error.code && error.oauthError) {
+      res.setHeader('WWW-Authenticate', error.wwwAuthenticate);
+      return res.status(error.code).json(error.oauthError);
+    }
+
+    const wwwAuth = buildWWWAuthenticate({
+      error: 'invalid_token',
+      error_description: 'Token validation failed',
+    });
+
+    res.setHeader('WWW-Authenticate', wwwAuth);
+    return res.status(401).json({
+      error: 'invalid_token',
+      error_description: 'Token validation failed',
+    });
+  }
+}
+
+// ================================
+// 2. Protected API Route with Scope Validation
+// File: pages/api/protected.ts
+// ================================
+
+export async function protectedApiHandler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  try {
+    const authHeader = req.headers.authorization;
+    const token = authHeader?.replace('Bearer ', '');
+
+    if (!token) {
+      const wwwAuth = buildWWWAuthenticate({
+        error: 'invalid_request',
+        error_description: 'Authorization header required',
+      });
+
+      res.setHeader('WWW-Authenticate', wwwAuth);
+      return res.status(401).json({
+        error: 'invalid_request',
+        error_description: 'Authorization header required',
+      });
+    }
+
+    const authMiddleware = await createMcpAuthMiddleware({
+      requiredScopes: ['mcp:read'],
+    });
+
+    const mockRequest = { method: req.method };
+    const mockExtra = {
+      signal: new AbortController().signal,
+      authInfo: { token },
+      descope: undefined as any,
+    };
+
+    await authMiddleware(mockRequest, mockExtra, async () => {
+      // Middleware passed - user is authenticated with required scopes
+    });
+
+    return res.status(200).json({
+      message: 'Access granted to protected resource',
+      userId: mockExtra.descope?.userId,
+      projectId: mockExtra.descope?.projectId,
+      scopes: mockExtra.descope?.userScopes,
+      timestamp: new Date().toISOString(),
+      method: req.method,
+    });
+  } catch (error: any) {
+    if (error.code && error.oauthError) {
+      res.setHeader('WWW-Authenticate', error.wwwAuthenticate);
+      return res.status(error.code).json(error.oauthError);
+    }
+
+    const wwwAuth = buildWWWAuthenticate({
+      error: 'invalid_token',
+      error_description: 'Token validation failed',
+    });
+
+    res.setHeader('WWW-Authenticate', wwwAuth);
+    return res.status(401).json({
+      error: 'invalid_token',
+      error_description: 'Token validation failed',
+    });
+  }
+}
+
+// ================================
+// 3. Dynamic MCP Tools API Route
+// File: pages/api/mcp-tools/[tool].ts
+// ================================
+
+const tools = {
+  getUserProfile: createAuthenticatedTool(
+    {
+      name: 'getUserProfile',
+      description: 'Get authenticated user profile information',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          includeScopes: {
+            type: 'boolean',
+            description: 'Include user scopes in response',
+            default: false,
+          },
+          format: {
+            type: 'string',
+            enum: ['simple', 'detailed'],
+            description: 'Response format',
+            default: 'simple',
+          },
+        },
+        additionalProperties: false,
+      },
+      requiredScopes: ['user:profile'],
+    },
+    async ({ args, descope }) => {
+      const baseProfile = {
+        userId: descope.userId,
+        projectId: descope.projectId,
+        timestamp: new Date().toISOString(),
+      };
+
+      if (args.format === 'detailed') {
+        return {
+          ...baseProfile,
+          scopes: args.includeScopes ? descope.userScopes : undefined,
+          tokenInfo: {
+            hasOutboundAccess: typeof descope.getOutboundToken === 'function',
+          },
+        };
+      }
+
+      return baseProfile;
+    },
+  ),
+
+  listUserScopes: createAuthenticatedTool(
+    {
+      name: 'listUserScopes',
+      description: 'List all scopes granted to the authenticated user',
+      requiredScopes: ['user:profile'],
+    },
+    async ({ descope }) => {
+      return {
+        userId: descope.userId,
+        scopes: descope.userScopes,
+        scopeCount: descope.userScopes.length,
+      };
+    },
+  ),
+};
+
+export async function mcpToolHandler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  try {
+    const { tool } = req.query;
+    const toolName = Array.isArray(tool) ? tool[0] : tool;
+
+    if (!toolName || !(toolName in tools)) {
+      return res.status(404).json({
+        error: 'Tool not found',
+        availableTools: Object.keys(tools),
+      });
+    }
+
+    const authHeader = req.headers.authorization;
+    const token = authHeader?.replace('Bearer ', '');
+
+    if (!token) {
+      const wwwAuth = buildWWWAuthenticate({
+        error: 'invalid_request',
+        error_description: 'Authorization header required',
+      });
+
+      res.setHeader('WWW-Authenticate', wwwAuth);
+      return res.status(401).json({
+        error: 'invalid_request',
+        error_description: 'Authorization header required',
+      });
+    }
+
+    const mockExtra = {
+      signal: new AbortController().signal,
+      authInfo: { token },
+      descope: undefined as any,
+    };
+
+    const selectedTool = tools[toolName as keyof typeof tools];
+    const result = await selectedTool.handler(req.body || {}, mockExtra);
+
+    return res.status(200).json(result);
+  } catch (error: any) {
+    if (error.code && error.oauthError) {
+      res.setHeader('WWW-Authenticate', error.wwwAuthenticate);
+      return res.status(error.code).json(error.oauthError);
+    }
+
+    console.error('Tool execution error:', error);
+    return res.status(500).json({
+      error: 'Internal server error',
+      message: error.message,
+    });
+  }
+}
+
+// ================================
+// 4. Higher-Order Component for Route Protection
+// File: lib/withAuth.ts
+// ================================
+
+export function withAuth(
+  handler: (req: NextApiRequest, res: NextApiResponse) => Promise<void>,
+  requiredScopes: string[] = [],
+) {
+  return async (req: NextApiRequest, res: NextApiResponse) => {
+    try {
+      const authHeader = req.headers.authorization;
+      const token = authHeader?.replace('Bearer ', '');
+
+      if (!token) {
+        const wwwAuth = buildWWWAuthenticate({
+          error: 'invalid_request',
+          error_description: 'Authorization header required',
+        });
+
+        res.setHeader('WWW-Authenticate', wwwAuth);
+        return res.status(401).json({
+          error: 'invalid_request',
+          error_description: 'Authorization header required',
+        });
+      }
+
+      if (requiredScopes.length > 0) {
+        const authMiddleware = await createMcpAuthMiddleware({
+          requiredScopes,
+        });
+
+        const mockRequest = { method: req.method };
+        const mockExtra = {
+          signal: new AbortController().signal,
+          authInfo: { token },
+          descope: undefined as any,
+        };
+
+        await authMiddleware(mockRequest, mockExtra, async () => {
+          (req as any).descope = mockExtra.descope;
+        });
+      }
+
+      return handler(req, res);
+    } catch (error: any) {
+      if (error.code && error.oauthError) {
+        res.setHeader('WWW-Authenticate', error.wwwAuthenticate);
+        return res.status(error.code).json(error.oauthError);
+      }
+
+      const wwwAuth = buildWWWAuthenticate({
+        error: 'invalid_token',
+        error_description: 'Token validation failed',
+      });
+
+      res.setHeader('WWW-Authenticate', wwwAuth);
+      return res.status(401).json({
+        error: 'invalid_token',
+        error_description: 'Token validation failed',
+      });
+    }
+  };
+}
+
+// ================================
+// 5. Example Usage of Higher-Order Component
+// ================================
+
+export const protectedRoute = withAuth(
+  async (req: NextApiRequest, res: NextApiResponse) => {
+    const descope = (req as any).descope;
+
+    res.json({
+      message: 'This is a protected route',
+      user: {
+        id: descope.userId,
+        projectId: descope.projectId,
+        scopes: descope.userScopes,
+      },
+    });
+  },
+  ['mcp:read'],
+);
+
+// Example usage in actual API route files:
+/*
+// pages/.well-known/oauth-protected-resource.ts
+export default metadataHandler;
+
+// pages/api/protected.ts  
+export default protectedApiHandler;
+
+// pages/api/mcp-tools/[tool].ts
+export default mcpToolHandler;
+
+// pages/api/secure-example.ts
+export default withAuth(async (req, res) => {
+  res.json({ message: 'Secure endpoint accessed successfully' });
+}, ['mcp:read']);
+*/
+
+// Export handlers for use in other files
+export default {
+  metadataHandler,
+  protectedMetadataHandler,
+  protectedApiHandler,
+  mcpToolHandler,
+  withAuth,
+  protectedRoute,
+};

--- a/packages/sdks/mcp-sdk/jest.config.cjs
+++ b/packages/sdks/mcp-sdk/jest.config.cjs
@@ -1,0 +1,18 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/test/**/*.test.ts'],
+  setupFilesAfterEnv: ['<rootDir>/test/setup.ts'],
+  collectCoverageFrom: ['src/**/*.ts', '!src/**/*.d.ts', '!src/index.ts'],
+  coverageThreshold: {
+    global: {
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80,
+    },
+  },
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+};

--- a/packages/sdks/mcp-sdk/package.json
+++ b/packages/sdks/mcp-sdk/package.json
@@ -1,0 +1,89 @@
+{
+  "name": "@descope/mcp-sdk",
+  "version": "1.0.0",
+  "description": "Descope Model Context Protocol (MCP) SDK with OAuth 2.0 Protected Resource Metadata support",
+  "author": "Descope Team <info@descope.com>",
+  "homepage": "https://github.com/descope/descope-js",
+  "bugs": {
+    "url": "https://github.com/descope/descope-js/issues",
+    "email": "help@descope.com"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/descope/descope-js.git",
+    "directory": "packages/sdks/mcp-sdk"
+  },
+  "license": "MIT",
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/cjs/index.js"
+      },
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/esm/index.js"
+      }
+    },
+    "./server": {
+      "require": {
+        "types": "./dist/server/index.d.ts",
+        "default": "./dist/cjs/server/index.js"
+      },
+      "import": {
+        "types": "./dist/server/index.d.ts",
+        "default": "./dist/esm/server/index.js"
+      }
+    }
+  },
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist/**/*"
+  ],
+  "scripts": {
+    "build": "rollup -c",
+    "test": "jest",
+    "lint": "eslint 'src/**/*.ts'",
+    "type-check": "tsc --noEmit",
+    "format": "prettier . -w --ignore-path .gitignore",
+    "format-check": "prettier . --check --ignore-path .gitignore",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": [
+    "descope",
+    "mcp",
+    "model-context-protocol",
+    "authentication",
+    "oauth2",
+    "authorization",
+    "protected-resource",
+    "resource-metadata",
+    "rfc8707"
+  ],
+  "dependencies": {
+    "@descope/core-js-sdk": "workspace:*",
+    "@descope/node-sdk": "0.0.0-next-ef3a9371-20250701",
+    "@modelcontextprotocol/sdk": "^0.5.0"
+  },
+  "devDependencies": {
+    "@rollup/plugin-commonjs": "^28.0.0",
+    "@rollup/plugin-node-resolve": "^15.2.3",
+    "@rollup/plugin-typescript": "^11.0.0",
+    "@types/jest": "^29.5.12",
+    "@types/node": "20.17.13",
+    "@typescript-eslint/parser": "^7.0.0",
+    "eslint": "8.57.1",
+    "eslint-config-prettier": "9.1.0",
+    "jest": "^29.7.0",
+    "jest-extended": "^4.0.0",
+    "prettier": "^3.0.0",
+    "ts-jest": "^29.0.0",
+    "typescript": "^5.0.2",
+    "rollup": "^4.0.0",
+    "rollup-plugin-dts": "^6.1.1"
+  }
+}

--- a/packages/sdks/mcp-sdk/project.json
+++ b/packages/sdks/mcp-sdk/project.json
@@ -1,0 +1,25 @@
+{
+  "name": "mcp-sdk",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/sdks/mcp-sdk/src",
+  "projectType": "library",
+  "targets": {
+    "version": {
+      "executor": "@jscutlery/semver:version",
+      "options": {
+        "trackDeps": true,
+        "push": false,
+        "preset": "conventional"
+      }
+    },
+    "licenseCheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": [
+          "tools/scripts/licenseValidation/thirdPartyLicenseCollector_linux_amd64 -npm-project {projectRoot}"
+        ]
+      }
+    }
+  },
+  "tags": []
+}

--- a/packages/sdks/mcp-sdk/rollup.config.mjs
+++ b/packages/sdks/mcp-sdk/rollup.config.mjs
@@ -1,0 +1,115 @@
+import typescript from '@rollup/plugin-typescript';
+import { nodeResolve } from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+import dts from 'rollup-plugin-dts';
+
+const external = [
+  '@descope/core-js-sdk',
+  '@descope/node-sdk',
+  '@modelcontextprotocol/sdk',
+  'node:crypto',
+  'node:buffer',
+  'node:http',
+  'node:https',
+  'node:util',
+  'crypto',
+  'buffer',
+  'http',
+  'https',
+  'util',
+];
+
+export default [
+  // Main ESM build
+  {
+    input: 'src/index.ts',
+    output: {
+      file: 'dist/esm/index.js',
+      format: 'esm',
+      sourcemap: true,
+    },
+    external,
+    plugins: [
+      nodeResolve({ preferBuiltins: true }),
+      typescript({
+        tsconfig: './tsconfig.json',
+        declaration: false,
+      }),
+    ],
+  },
+  // Main CJS build
+  {
+    input: 'src/index.ts',
+    output: {
+      file: 'dist/cjs/index.js',
+      format: 'cjs',
+      sourcemap: true,
+      exports: 'named',
+    },
+    external,
+    plugins: [
+      nodeResolve({ preferBuiltins: true }),
+      commonjs(),
+      typescript({
+        tsconfig: './tsconfig.json',
+        declaration: false,
+      }),
+    ],
+  },
+  // Server ESM build
+  {
+    input: 'src/server/index.ts',
+    output: {
+      file: 'dist/esm/server/index.js',
+      format: 'esm',
+      sourcemap: true,
+    },
+    external,
+    plugins: [
+      nodeResolve({ preferBuiltins: true }),
+      typescript({
+        tsconfig: './tsconfig.json',
+        declaration: false,
+      }),
+    ],
+  },
+  // Server CJS build
+  {
+    input: 'src/server/index.ts',
+    output: {
+      file: 'dist/cjs/server/index.js',
+      format: 'cjs',
+      sourcemap: true,
+      exports: 'named',
+    },
+    external,
+    plugins: [
+      nodeResolve({ preferBuiltins: true }),
+      commonjs(),
+      typescript({
+        tsconfig: './tsconfig.json',
+        declaration: false,
+      }),
+    ],
+  },
+  // Main Types build
+  {
+    input: 'src/index.ts',
+    output: {
+      file: 'dist/index.d.ts',
+      format: 'esm',
+    },
+    external,
+    plugins: [dts()],
+  },
+  // Server Types build
+  {
+    input: 'src/server/index.ts',
+    output: {
+      file: 'dist/server/index.d.ts',
+      format: 'esm',
+    },
+    external,
+    plugins: [dts()],
+  },
+];

--- a/packages/sdks/mcp-sdk/src/index.ts
+++ b/packages/sdks/mcp-sdk/src/index.ts
@@ -1,0 +1,2 @@
+// Main export provides server functionality
+export * from './server';

--- a/packages/sdks/mcp-sdk/src/server/auth.ts
+++ b/packages/sdks/mcp-sdk/src/server/auth.ts
@@ -1,0 +1,104 @@
+import {
+  validateScopes,
+  validateToken as defaultValidateToken,
+  getOutboundToken,
+} from './utils';
+import { createOAuth2Error, createError } from './errors';
+import type {
+  AuthMiddlewareOptions,
+  AuthContext,
+  McpRequestExtra,
+} from './types';
+
+/**
+ * Creates MCP authentication middleware for protecting MCP endpoints
+ * @param options Authentication middleware configuration options
+ * @returns Async middleware function for MCP request processing
+ * @example
+ * ```typescript
+ * const middleware = await createMcpAuthMiddleware({
+ *   requiredScopes: ['admin:read']
+ * });
+ *
+ * server.use(middleware);
+ * ```
+ */
+export async function createMcpAuthMiddleware(
+  options: AuthMiddlewareOptions = {},
+) {
+  const validateToken = options.validateToken || defaultValidateToken;
+
+  return async (
+    request: unknown,
+    extra: McpRequestExtra,
+    next: () => Promise<unknown>,
+  ) => {
+    if (options.skipAuth) {
+      return next();
+    }
+
+    const token = extra.authInfo?.token;
+    if (!token) {
+      const error = createOAuth2Error(
+        401,
+        'invalid_request',
+        'No authentication token provided',
+      );
+      if (options.errorHandler) {
+        options.errorHandler(error);
+      }
+      throw error;
+    }
+
+    const validation = await validateToken(token);
+    if (!validation.valid) {
+      const error = createOAuth2Error(
+        401,
+        'invalid_token',
+        validation.error || 'Invalid token',
+      );
+      if (options.errorHandler) {
+        options.errorHandler(error);
+      }
+      throw error;
+    }
+
+    if (options.requiredScopes?.length) {
+      const scopeValidation = validateScopes(
+        options.requiredScopes,
+        validation.scopes || [],
+      );
+
+      if (!scopeValidation.valid) {
+        const error = createOAuth2Error(
+          403,
+          'insufficient_scope',
+          `Missing required scopes: ${scopeValidation.missing.join(', ')}`,
+          scopeValidation.missing.join(' '),
+        );
+        if (options.errorHandler) {
+          options.errorHandler(error);
+        }
+        throw error;
+      }
+    }
+
+    // Attach Descope context to request
+    const authContext: AuthContext = {
+      projectId: validation.projectId!,
+      userId: validation.userId!,
+      userScopes: validation.scopes || [],
+      descopeToken: token,
+      getOutboundToken: (appId: string, scopes?: string[]) =>
+        getOutboundToken(appId, validation.userId!, scopes),
+    };
+
+    // Attach context to extra for use in handlers
+    extra.descope = authContext;
+
+    return next();
+  };
+}
+
+// Re-export error functions for backwards compatibility
+export { createOAuth2Error, createError } from './errors';

--- a/packages/sdks/mcp-sdk/src/server/errors.ts
+++ b/packages/sdks/mcp-sdk/src/server/errors.ts
@@ -1,0 +1,72 @@
+/**
+ * Error handling utilities for the MCP SDK
+ */
+
+import type { OAuth2Error, OAuthError } from './types';
+
+/**
+ * Creates an OAuth 2.0 error with proper structure and WWW-Authenticate header
+ * @param code HTTP status code
+ * @param error OAuth error type
+ * @param description Optional error description
+ * @param requiredScope Optional required scope for insufficient_scope errors
+ * @returns OAuth 2.0 compliant error object
+ * @example
+ * ```typescript
+ * const error = createOAuth2Error(401, 'invalid_token', 'Token has expired');
+ * // Error includes proper WWW-Authenticate header and OAuth structure
+ * ```
+ */
+export function createOAuth2Error(
+  code: number,
+  error: OAuthError['error'],
+  description?: string,
+  requiredScope?: string,
+): OAuth2Error {
+  const err = new Error(description || error) as OAuth2Error;
+  err.code = code;
+  err.oauthError = {
+    error,
+    error_description: description,
+    scope: requiredScope,
+  };
+
+  // Build WWW-Authenticate header
+  const parts = ['Bearer'];
+  parts.push(`error="${error}"`);
+  if (description) parts.push(`error_description="${description}"`);
+  if (requiredScope) parts.push(`scope="${requiredScope}"`);
+  err.wwwAuthenticate = parts.join(', ');
+
+  return err;
+}
+
+export interface McpError extends Error {
+  code: number;
+  details?: Record<string, unknown>;
+}
+
+/**
+ * Creates a generic MCP error
+ * @param code HTTP status code
+ * @param message Error message
+ * @param details Optional error details
+ * @returns MCP error object
+ * @example
+ * ```typescript
+ * const error = createError(500, 'Internal server error', { requestId: '123' });
+ * ```
+ */
+export function createError(
+  code: number,
+  message: string,
+  details?: Record<string, unknown>,
+): McpError {
+  const error = new Error(message) as McpError;
+  error.code = code;
+  error.details = details;
+  return error;
+}
+
+// Export the OAuth2Error type
+export type { OAuth2Error } from './types';

--- a/packages/sdks/mcp-sdk/src/server/index.ts
+++ b/packages/sdks/mcp-sdk/src/server/index.ts
@@ -1,0 +1,32 @@
+// Type exports
+export * from './types';
+
+// Validation exports
+export { validateScopes, validateToken, getOutboundToken } from './utils';
+
+// Authentication exports
+export { createMcpAuthMiddleware } from './auth';
+
+// Error exports
+export {
+  createOAuth2Error,
+  createError,
+  type McpError,
+  type OAuth2Error,
+} from './errors';
+
+// Tool Builder exports
+export {
+  createAuthenticatedTool,
+  type ToolOptions,
+  type ToolExecutionContext,
+  type ToolHandler,
+} from './tool-builder';
+
+// Resource Metadata exports
+export * from './oauth/resource-metadata/types';
+export {
+  buildWWWAuthenticate,
+  parseWWWAuthenticate,
+} from './oauth/resource-metadata/www-authenticate';
+export { buildResourceMetadata } from './oauth/resource-metadata/metadata';

--- a/packages/sdks/mcp-sdk/src/server/oauth/resource-metadata/metadata.ts
+++ b/packages/sdks/mcp-sdk/src/server/oauth/resource-metadata/metadata.ts
@@ -1,0 +1,27 @@
+import type { ProtectedResourceConfig, ResourceMetadata } from './types';
+
+/**
+ * Builds OAuth 2.0 Protected Resource Metadata according to RFC 9728
+ * @param config Protected resource configuration
+ * @returns Resource metadata object
+ */
+export function buildResourceMetadata(
+  config: ProtectedResourceConfig,
+): ResourceMetadata {
+  const metadata: ResourceMetadata = {
+    resource: config.resource,
+    authorization_servers: config.authorizationServers,
+    scopes_supported: config.scopes,
+    bearer_methods_supported: ['header'],
+  };
+
+  if (config.docsUrl) {
+    metadata.resource_documentation = config.docsUrl;
+  }
+
+  if (config.tokenIntrospectionEndpoint) {
+    metadata.resource_policy_uri = `${config.resource}/policy`;
+  }
+
+  return metadata;
+}

--- a/packages/sdks/mcp-sdk/src/server/oauth/resource-metadata/types.ts
+++ b/packages/sdks/mcp-sdk/src/server/oauth/resource-metadata/types.ts
@@ -1,0 +1,29 @@
+export interface ProtectedResourceConfig {
+  resource: string;
+  authorizationServers: string[];
+  scopes: string[];
+  docsUrl?: string;
+  tokenIntrospectionEndpoint?: string;
+  projectId?: string;
+}
+
+export interface ResourceMetadata {
+  resource: string;
+  authorization_servers: string[];
+  scopes_supported: string[];
+  bearer_methods_supported: string[];
+  resource_documentation?: string;
+  resource_policy_uri?: string;
+  resource_registration_uri?: string;
+  resource_type?: string;
+}
+
+export interface WWWAuthenticateParams {
+  realm?: string;
+  scope?: string;
+  error?: 'invalid_token' | 'insufficient_scope' | 'invalid_request';
+  error_description?: string;
+  error_uri?: string;
+  authorizationServers?: string[];
+  resourceMetadataUrl?: string;
+}

--- a/packages/sdks/mcp-sdk/src/server/oauth/resource-metadata/www-authenticate.ts
+++ b/packages/sdks/mcp-sdk/src/server/oauth/resource-metadata/www-authenticate.ts
@@ -1,0 +1,96 @@
+import type { WWWAuthenticateParams } from './types';
+
+/**
+ * Builds a WWW-Authenticate header value according to RFC 9728
+ * @param params WWW-Authenticate parameters
+ * @returns Formatted WWW-Authenticate header value
+ */
+export function buildWWWAuthenticate(params: WWWAuthenticateParams): string {
+  const parts: string[] = ['Bearer'];
+
+  if (params.realm) {
+    parts.push(`realm="${escapeHeaderValue(params.realm)}"`);
+  }
+
+  if (params.scope) {
+    parts.push(`scope="${escapeHeaderValue(params.scope)}"`);
+  }
+
+  if (params.error) {
+    parts.push(`error="${params.error}"`);
+
+    if (params.error_description) {
+      parts.push(
+        `error_description="${escapeHeaderValue(params.error_description)}"`,
+      );
+    }
+
+    if (params.error_uri) {
+      parts.push(`error_uri="${escapeHeaderValue(params.error_uri)}"`);
+    }
+  }
+
+  if (params.authorizationServers?.length) {
+    const asUris = params.authorizationServers
+      .map((uri) => escapeHeaderValue(uri))
+      .join(' ');
+    parts.push(`as_uri="${asUris}"`);
+  }
+
+  if (params.resourceMetadataUrl) {
+    parts.push(
+      `resource_metadata="${escapeHeaderValue(params.resourceMetadataUrl)}"`,
+    );
+  }
+
+  return parts.join(', ');
+}
+
+function escapeHeaderValue(value: string): string {
+  return value.replace(/"/g, '\\"').replace(/\r?\n/g, ' ');
+}
+
+/**
+ * Parses a WWW-Authenticate header value into structured parameters
+ * @param header WWW-Authenticate header value to parse
+ * @returns Parsed WWW-Authenticate parameters
+ */
+export function parseWWWAuthenticate(header: string): WWWAuthenticateParams {
+  const params: WWWAuthenticateParams = {};
+  const regex = /(\w+)="([^"]+)"/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = regex.exec(header)) !== null) {
+    const [, key, value] = match;
+
+    switch (key) {
+      case 'realm':
+        params.realm = unescapeHeaderValue(value);
+        break;
+      case 'scope':
+        params.scope = unescapeHeaderValue(value);
+        break;
+      case 'error':
+        params.error = value as any;
+        break;
+      case 'error_description':
+        params.error_description = unescapeHeaderValue(value);
+        break;
+      case 'error_uri':
+        params.error_uri = unescapeHeaderValue(value);
+        break;
+      case 'as_uri':
+        params.authorizationServers = unescapeHeaderValue(value).split(' ');
+        break;
+      case 'resource_metadata':
+        params.resourceMetadataUrl = unescapeHeaderValue(value);
+        break;
+    }
+  }
+
+  return params;
+}
+
+function unescapeHeaderValue(value: string): string {
+  return value.replace(/\\"/g, '"');
+}

--- a/packages/sdks/mcp-sdk/src/server/tool-builder.ts
+++ b/packages/sdks/mcp-sdk/src/server/tool-builder.ts
@@ -1,0 +1,187 @@
+import type {
+  CallToolResult,
+  Tool,
+  TextContent,
+} from '@modelcontextprotocol/sdk/types.js';
+import type { OAuth2Error, AuthContext, McpRequestExtra } from './types';
+
+export interface ToolOptions {
+  name: string;
+  description?: string;
+  inputSchema?: Tool['inputSchema'];
+  requiredScopes?: string[];
+}
+
+export interface ToolExecutionContext {
+  descope: AuthContext;
+  args: Record<string, unknown>;
+}
+
+export type ToolHandler = (context: ToolExecutionContext) => Promise<any>;
+
+function createTextContent(text: string): TextContent {
+  return {
+    type: 'text',
+    text,
+  };
+}
+
+/**
+ * Creates an authenticated MCP tool with automatic scope validation
+ * @param options Tool configuration including name, description, and required scopes
+ * @param handler Tool execution handler function
+ * @returns MCP tool definition with authentication and scope enforcement
+ * @example
+ * ```typescript
+ * const userTool = createAuthenticatedTool({
+ *   name: 'get-user',
+ *   description: 'Retrieve user information',
+ *   requiredScopes: ['user:read'],
+ *   inputSchema: {
+ *     type: 'object',
+ *     properties: {
+ *       userId: { type: 'string' }
+ *     },
+ *     required: ['userId']
+ *   }
+ * }, async ({ args, descope }) => {
+ *   return { userId: args.userId, projectId: descope.projectId };
+ * });
+ * ```
+ */
+
+export function createAuthenticatedTool(
+  options: ToolOptions,
+  handler: ToolHandler,
+) {
+  return {
+    name: options.name,
+    description: options.description,
+    inputSchema: options.inputSchema || {
+      type: 'object',
+      properties: {},
+      additionalProperties: false,
+    },
+    handler: async (
+      args: Record<string, unknown>,
+      extra: McpRequestExtra,
+    ): Promise<CallToolResult> => {
+      try {
+        // Check if Descope context is available
+        if (!extra.descope) {
+          return {
+            isError: true,
+            code: 401,
+            headers: {
+              'WWW-Authenticate':
+                'Bearer, error="invalid_request", error_description="Authentication required"',
+            },
+            content: [
+              createTextContent(
+                JSON.stringify(
+                  {
+                    error: 'unauthorized',
+                    error_description: 'Authentication required',
+                  },
+                  null,
+                  2,
+                ),
+              ),
+            ],
+          };
+        }
+
+        // Check scopes if required
+        if (options.requiredScopes?.length) {
+          const userScopes = extra.descope.userScopes || [];
+          const missingScopes = options.requiredScopes.filter(
+            (scope) => !userScopes.includes(scope),
+          );
+
+          if (missingScopes.length > 0) {
+            return {
+              isError: true,
+              code: 403,
+              headers: {
+                'WWW-Authenticate': `Bearer, error="insufficient_scope", error_description="Missing required scopes: ${missingScopes.join(
+                  ', ',
+                )}", scope="${missingScopes.join(' ')}"`,
+              },
+              content: [
+                createTextContent(
+                  JSON.stringify(
+                    {
+                      error: 'insufficient_scope',
+                      error_description: `Missing required scopes: ${missingScopes.join(
+                        ', ',
+                      )}`,
+                      scope: missingScopes.join(' '),
+                    },
+                    null,
+                    2,
+                  ),
+                ),
+              ],
+            };
+          }
+        }
+
+        // Execute the tool handler
+        const result = await handler({
+          descope: extra.descope,
+          args,
+        });
+
+        return {
+          content: [
+            createTextContent(
+              typeof result === 'string'
+                ? result
+                : JSON.stringify(result, null, 2),
+            ),
+          ],
+        };
+      } catch (error) {
+        const isOAuthError =
+          error && typeof error === 'object' && 'oauthError' in error;
+
+        if (isOAuthError) {
+          const oauthErr = error as OAuth2Error;
+          return {
+            isError: true,
+            code: oauthErr.code,
+            headers: {
+              'WWW-Authenticate': oauthErr.wwwAuthenticate,
+            },
+            content: [
+              createTextContent(JSON.stringify(oauthErr.oauthError, null, 2)),
+            ],
+          };
+        }
+
+        // Handle other errors
+        const isError = error && typeof error === 'object' && 'code' in error;
+        return {
+          isError: true,
+          code: isError ? (error as any).code : 500,
+          content: [
+            createTextContent(
+              JSON.stringify(
+                {
+                  error: error instanceof Error ? error.message : String(error),
+                  ...(isError && { code: (error as any).code }),
+                  ...(isError &&
+                    (error as any).details && {
+                      details: (error as any).details,
+                    }),
+                },
+                null,
+                2,
+              ),
+            ),
+          ],
+        };
+      }
+    },
+  };
+}

--- a/packages/sdks/mcp-sdk/src/server/types.ts
+++ b/packages/sdks/mcp-sdk/src/server/types.ts
@@ -1,0 +1,54 @@
+import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
+import type { ServerRequest } from '@modelcontextprotocol/sdk/types.js';
+
+export interface OAuthError {
+  error: 'invalid_token' | 'insufficient_scope' | 'invalid_request';
+  error_description?: string;
+  error_uri?: string;
+  scope?: string;
+}
+
+export interface OAuth2Error extends Error {
+  code: number;
+  oauthError: OAuthError;
+  wwwAuthenticate: string;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  projectId?: string;
+  userId?: string;
+  scopes?: string[];
+  error?: string;
+}
+
+export interface AuthContext {
+  projectId: string;
+  userId: string;
+  userScopes: string[];
+  descopeToken: string;
+  getOutboundToken: (
+    appId: string,
+    scopes?: string[],
+  ) => Promise<string | null>;
+}
+
+export interface AuthMiddlewareOptions {
+  skipAuth?: boolean;
+  requiredScopes?: string[];
+  validateToken?: (token: string) => Promise<ValidationResult>;
+  errorHandler?: (error: OAuth2Error) => void;
+}
+
+export interface McpRequestExtra extends RequestHandlerExtra {
+  authInfo?: {
+    token?: string;
+  };
+  descope?: AuthContext;
+}
+
+export type McpMiddleware = (
+  request: ServerRequest,
+  extra: McpRequestExtra,
+  next: () => Promise<unknown>,
+) => Promise<unknown>;

--- a/packages/sdks/mcp-sdk/src/server/utils.ts
+++ b/packages/sdks/mcp-sdk/src/server/utils.ts
@@ -1,0 +1,110 @@
+/**
+ * Validation utilities for the MCP SDK
+ */
+
+import descopeSdk from '@descope/node-sdk';
+import type { ValidationResult } from './types';
+
+// Initialize Descope SDK - it automatically reads DESCOPE_PROJECT_ID and DESCOPE_BASE_URL from env
+const descopeClient = descopeSdk({
+  projectId: process.env.DESCOPE_PROJECT_ID!,
+});
+
+/**
+ * Validates if user has all required scopes
+ * @param required Array of required scope strings
+ * @param userScopes Array of user's current scope strings
+ * @returns Validation result with missing scopes if any
+ * @example
+ * ```typescript
+ * const result = validateScopes(['admin:read'], ['admin:read', 'user:read']);
+ * // result.valid === true, result.missing === []
+ * ```
+ */
+export function validateScopes(
+  required: string[],
+  userScopes: string[],
+): { valid: boolean; missing: string[] } {
+  const missing = required.filter((scope) => !userScopes.includes(scope));
+  return {
+    valid: missing.length === 0,
+    missing,
+  };
+}
+
+/**
+ * Default token validation using Descope SDK
+ * @param token JWT token to validate
+ * @returns Promise with validation result including user information
+ * @example
+ * ```typescript
+ * const result = await validateToken('eyJhbGciOiJSUzI1NiIs...');
+ * if (result.valid) {
+ *   console.log('User ID:', result.userId);
+ * }
+ * ```
+ */
+export async function validateToken(token: string): Promise<ValidationResult> {
+  try {
+    const authInfo = await descopeClient.validateJwt(token);
+
+    return {
+      valid: true,
+      projectId: authInfo.token.iss?.split('/').pop(),
+      userId: authInfo.token.sub,
+      scopes: (authInfo.token as { permissions?: string[] }).permissions || [],
+    };
+  } catch (error) {
+    return {
+      valid: false,
+      error: error instanceof Error ? error.message : 'Token validation failed',
+    };
+  }
+}
+
+/**
+ * Get outbound token for external application access
+ * @param appId Target application ID
+ * @param userId User ID requesting the token
+ * @param scopes Optional scopes to request
+ * @returns Promise with outbound token or null if unavailable
+ * @example
+ * ```typescript
+ * const token = await getOutboundToken('my-app', 'user123', ['read:data']);
+ * if (token) {
+ *   // Use token for external API calls
+ * }
+ * ```
+ */
+export async function getOutboundToken(
+  appId: string,
+  userId: string,
+  scopes?: string[],
+): Promise<string | null> {
+  try {
+    const result =
+      await descopeClient.management.outboundApplication.fetchTokenByScopes(
+        appId,
+        userId,
+        scopes,
+        undefined, // options
+        undefined, // tenantId
+      );
+
+    if (result.ok) {
+      return result.data.token;
+    } else {
+      console.error(
+        'Outbound token exchange failed:',
+        result.error?.errorMessage,
+      );
+      return null;
+    }
+  } catch (error) {
+    console.error(
+      'Outbound token exchange error:',
+      error instanceof Error ? error.message : 'Token exchange failed',
+    );
+    return null;
+  }
+}

--- a/packages/sdks/mcp-sdk/test/errors/errors.test.ts
+++ b/packages/sdks/mcp-sdk/test/errors/errors.test.ts
@@ -1,0 +1,175 @@
+import {
+  createOAuth2Error,
+  createError,
+  type OAuth2Error,
+  type McpError,
+} from '../../src/server/errors';
+
+describe('Error Module', () => {
+  describe('createOAuth2Error', () => {
+    it('should create OAuth2 error with basic structure', () => {
+      const error = createOAuth2Error(401, 'invalid_token');
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error.code).toBe(401);
+      expect(error.oauthError.error).toBe('invalid_token');
+      expect(error.wwwAuthenticate).toBe('Bearer, error="invalid_token"');
+    });
+
+    it('should include description in error', () => {
+      const error = createOAuth2Error(
+        401,
+        'invalid_token',
+        'Token has expired',
+      );
+
+      expect(error.message).toBe('Token has expired');
+      expect(error.oauthError.error_description).toBe('Token has expired');
+      expect(error.wwwAuthenticate).toContain(
+        'error_description="Token has expired"',
+      );
+    });
+
+    it('should include scope for insufficient_scope errors', () => {
+      const error = createOAuth2Error(
+        403,
+        'insufficient_scope',
+        'Missing admin scope',
+        'admin:read admin:write',
+      );
+
+      expect(error.oauthError.scope).toBe('admin:read admin:write');
+      expect(error.wwwAuthenticate).toContain('scope="admin:read admin:write"');
+    });
+
+    it('should handle all OAuth error types', () => {
+      const errorTypes: Array<Parameters<typeof createOAuth2Error>[1]> = [
+        'invalid_token',
+        'insufficient_scope',
+        'invalid_request',
+      ];
+
+      errorTypes.forEach((errorType) => {
+        const error = createOAuth2Error(400, errorType);
+        expect(error.oauthError.error).toBe(errorType);
+      });
+    });
+
+    it('should build proper WWW-Authenticate header format', () => {
+      const error = createOAuth2Error(
+        403,
+        'insufficient_scope',
+        'Need more permissions',
+        'read write',
+      );
+
+      expect(error.wwwAuthenticate).toBe(
+        'Bearer, error="insufficient_scope", error_description="Need more permissions", scope="read write"',
+      );
+    });
+
+    it('should handle missing optional parameters', () => {
+      const error = createOAuth2Error(401, 'invalid_token');
+
+      expect(error.oauthError.error_description).toBeUndefined();
+      expect(error.oauthError.scope).toBeUndefined();
+      expect(error.wwwAuthenticate).toBe('Bearer, error="invalid_token"');
+    });
+
+    it('should use error type as message when no description provided', () => {
+      const error = createOAuth2Error(401, 'invalid_token');
+
+      expect(error.message).toBe('invalid_token');
+    });
+  });
+
+  describe('createError', () => {
+    it('should create basic MCP error', () => {
+      const error = createError(500, 'Internal server error');
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toBe('Internal server error');
+      expect(error.code).toBe(500);
+      expect(error.details).toBeUndefined();
+    });
+
+    it('should include details when provided', () => {
+      const details = {
+        requestId: 'req-123',
+        timestamp: '2023-01-01T00:00:00Z',
+      };
+      const error = createError(400, 'Bad request', details);
+
+      expect(error.details).toEqual(details);
+    });
+
+    it('should handle various error codes', () => {
+      const codes = [400, 401, 403, 404, 500];
+
+      codes.forEach((code) => {
+        const error = createError(code, `Error ${code}`);
+        expect(error.code).toBe(code);
+      });
+    });
+
+    it('should preserve error properties', () => {
+      const error = createError(422, 'Validation failed', {
+        field: 'email',
+        reason: 'invalid format',
+      });
+
+      expect(error.name).toBe('Error');
+      expect(error.stack).toBeDefined();
+      expect(error.code).toBe(422);
+      expect(error.details?.field).toBe('email');
+    });
+  });
+
+  describe('error type compatibility', () => {
+    it('should have OAuth2Error extend Error', () => {
+      const error = createOAuth2Error(401, 'invalid_token');
+
+      expect(error instanceof Error).toBe(true);
+      expect(typeof error.code).toBe('number');
+      expect(typeof error.oauthError).toBe('object');
+      expect(typeof error.wwwAuthenticate).toBe('string');
+    });
+
+    it('should have McpError extend Error', () => {
+      const error = createError(500, 'Server error');
+
+      expect(error instanceof Error).toBe(true);
+      expect(typeof error.code).toBe('number');
+    });
+  });
+
+  describe('serialization', () => {
+    it('should serialize OAuth2Error properly', () => {
+      const error = createOAuth2Error(
+        403,
+        'insufficient_scope',
+        'Missing scopes',
+        'admin',
+      );
+
+      const serialized = JSON.stringify(error.oauthError);
+      const parsed = JSON.parse(serialized);
+
+      expect(parsed).toEqual({
+        error: 'insufficient_scope',
+        error_description: 'Missing scopes',
+        scope: 'admin',
+      });
+    });
+
+    it('should serialize McpError details properly', () => {
+      const details = { field: 'name', value: null };
+      const error = createError(400, 'Validation error', details);
+
+      const serialized = JSON.stringify(error.details);
+      const parsed = JSON.parse(serialized);
+
+      expect(parsed).toEqual(details);
+    });
+  });
+});

--- a/packages/sdks/mcp-sdk/test/integration/full-flow.test.ts
+++ b/packages/sdks/mcp-sdk/test/integration/full-flow.test.ts
@@ -1,5 +1,0 @@
-describe('Full Flow Integration', () => {
-  it('placeholder test', () => {
-    expect(true).toBe(true);
-  });
-});

--- a/packages/sdks/mcp-sdk/test/integration/full-flow.test.ts
+++ b/packages/sdks/mcp-sdk/test/integration/full-flow.test.ts
@@ -1,0 +1,5 @@
+describe('Full Flow Integration', () => {
+  it('placeholder test', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/packages/sdks/mcp-sdk/test/middleware/auth.test.ts
+++ b/packages/sdks/mcp-sdk/test/middleware/auth.test.ts
@@ -1,0 +1,109 @@
+import {
+  createOAuth2Error,
+  createMcpAuthMiddleware,
+  createError,
+} from '../../src/server';
+
+describe('Auth Middleware', () => {
+  describe('createOAuth2Error', () => {
+    it('should create OAuth error with proper structure', () => {
+      const error = createOAuth2Error(401, 'invalid_token', 'Token expired');
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error.code).toBe(401);
+      expect(error.oauthError.error).toBe('invalid_token');
+      expect(error.oauthError.error_description).toBe('Token expired');
+      expect(error.wwwAuthenticate).toContain('Bearer');
+      expect(error.wwwAuthenticate).toContain('error="invalid_token"');
+    });
+
+    it('should include scope in WWW-Authenticate header', () => {
+      const error = createOAuth2Error(
+        403,
+        'insufficient_scope',
+        'Missing scopes',
+        'admin',
+      );
+
+      expect(error.wwwAuthenticate).toContain('scope="admin"');
+    });
+  });
+
+  describe('createMcpAuthMiddleware', () => {
+    let mockValidateToken: jest.Mock;
+    let mockRequest: unknown;
+    let mockExtra: {
+      authInfo?: { token?: string };
+      descope?: any;
+      signal: AbortSignal;
+    };
+    let mockNext: jest.Mock;
+
+    beforeEach(() => {
+      mockValidateToken = jest.fn();
+
+      mockRequest = {};
+      mockExtra = {
+        authInfo: { token: 'test-token' },
+        signal: new AbortController().signal,
+      };
+      mockNext = jest.fn().mockResolvedValue('success');
+    });
+
+    it('should skip auth when skipAuth is true', async () => {
+      const middleware = await createMcpAuthMiddleware({
+        skipAuth: true,
+        validateToken: mockValidateToken,
+      });
+
+      const result = await middleware(mockRequest, mockExtra, mockNext);
+
+      expect(result).toBe('success');
+      expect(mockNext).toHaveBeenCalled();
+      expect(mockValidateToken).not.toHaveBeenCalled();
+    });
+
+    it('should throw error when no token provided', async () => {
+      mockExtra.authInfo = undefined;
+
+      const middleware = await createMcpAuthMiddleware({
+        validateToken: mockValidateToken,
+      });
+
+      await expect(
+        middleware(mockRequest, mockExtra, mockNext),
+      ).rejects.toThrow();
+    });
+
+    it('should validate token and attach context', async () => {
+      mockValidateToken.mockResolvedValue({
+        valid: true,
+        projectId: 'proj123',
+        userId: 'user123',
+        scopes: ['read', 'write'],
+      });
+
+      const middleware = await createMcpAuthMiddleware({
+        validateToken: mockValidateToken,
+      });
+
+      const result = await middleware(mockRequest, mockExtra, mockNext);
+
+      expect(result).toBe('success');
+      expect(mockExtra.descope).toBeDefined();
+      expect(mockExtra.descope.userId).toBe('user123');
+      expect(mockExtra.descope.projectId).toBe('proj123');
+    });
+  });
+
+  describe('createError', () => {
+    it('should create basic error', () => {
+      const error = createError(400, 'Bad request', { param: 'invalid' });
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toBe('Bad request');
+      expect(error.code).toBe(400);
+      expect(error.details).toEqual({ param: 'invalid' });
+    });
+  });
+});

--- a/packages/sdks/mcp-sdk/test/resource-metadata/www-authenticate.test.ts
+++ b/packages/sdks/mcp-sdk/test/resource-metadata/www-authenticate.test.ts
@@ -1,0 +1,79 @@
+import {
+  buildWWWAuthenticate,
+  parseWWWAuthenticate,
+} from '../../src/server/oauth/resource-metadata/www-authenticate';
+
+describe('WWW-Authenticate Builder', () => {
+  describe('buildWWWAuthenticate', () => {
+    it('should build basic Bearer header', () => {
+      const header = buildWWWAuthenticate({});
+      expect(header).toBe('Bearer');
+    });
+
+    it('should include realm', () => {
+      const header = buildWWWAuthenticate({ realm: 'Example API' });
+      expect(header).toBe('Bearer, realm="Example API"');
+    });
+
+    it('should include scope', () => {
+      const header = buildWWWAuthenticate({ scope: 'read write' });
+      expect(header).toBe('Bearer, scope="read write"');
+    });
+
+    it('should include error information', () => {
+      const header = buildWWWAuthenticate({
+        error: 'insufficient_scope',
+        error_description: 'Missing required scopes: admin',
+        scope: 'admin',
+      });
+      expect(header).toContain('error="insufficient_scope"');
+      expect(header).toContain(
+        'error_description="Missing required scopes: admin"',
+      );
+      expect(header).toContain('scope="admin"');
+    });
+
+    it('should include multiple authorization servers', () => {
+      const header = buildWWWAuthenticate({
+        authorizationServers: [
+          'https://auth1.example.com',
+          'https://auth2.example.com',
+        ],
+      });
+      expect(header).toContain(
+        'as_uri="https://auth1.example.com https://auth2.example.com"',
+      );
+    });
+
+    it('should escape special characters', () => {
+      const header = buildWWWAuthenticate({
+        realm: 'API with "quotes"',
+        error: 'invalid_token',
+        error_description: 'Error with\nnewline',
+      });
+      expect(header).toContain('realm="API with \\"quotes\\""');
+      expect(header).toContain('error_description="Error with newline"');
+    });
+  });
+
+  describe('parseWWWAuthenticate', () => {
+    it('should parse basic Bearer header', () => {
+      const params = parseWWWAuthenticate('Bearer');
+      expect(params).toEqual({});
+    });
+
+    it('should parse header with all parameters', () => {
+      const header =
+        'Bearer, realm="Example API", scope="read write", error="insufficient_scope", error_description="Missing scopes", as_uri="https://auth.example.com"';
+      const params = parseWWWAuthenticate(header);
+
+      expect(params).toEqual({
+        realm: 'Example API',
+        scope: 'read write',
+        error: 'insufficient_scope',
+        error_description: 'Missing scopes',
+        authorizationServers: ['https://auth.example.com'],
+      });
+    });
+  });
+});

--- a/packages/sdks/mcp-sdk/test/setup.ts
+++ b/packages/sdks/mcp-sdk/test/setup.ts
@@ -1,0 +1,2 @@
+// Jest setup file - runs before each test file
+process.env.DESCOPE_PROJECT_ID = 'test-project-id';

--- a/packages/sdks/mcp-sdk/test/tool-builder/tool-builder.test.ts
+++ b/packages/sdks/mcp-sdk/test/tool-builder/tool-builder.test.ts
@@ -1,0 +1,319 @@
+import { createAuthenticatedTool } from '../../src/server/tool-builder';
+import type { McpRequestExtra, AuthContext } from '../../src/server/types';
+
+describe('Tool Builder', () => {
+  let mockAuthContext: AuthContext;
+  let mockExtra: McpRequestExtra;
+
+  beforeEach(() => {
+    mockAuthContext = {
+      projectId: 'test-project',
+      userId: 'test-user',
+      userScopes: ['read', 'write'],
+      descopeToken: 'test-token',
+      getOutboundToken: jest.fn().mockResolvedValue('outbound-token'),
+    };
+
+    mockExtra = {
+      signal: new AbortController().signal,
+      descope: mockAuthContext,
+    };
+  });
+
+  describe('createAuthenticatedTool', () => {
+    it('should create a tool with correct structure', () => {
+      const tool = createAuthenticatedTool(
+        {
+          name: 'test-tool',
+          description: 'A test tool',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              param: { type: 'string' },
+            },
+          },
+        },
+        async ({ args, descope }) => ({
+          success: true,
+          args,
+          projectId: descope.projectId,
+        }),
+      );
+
+      expect(tool.name).toBe('test-tool');
+      expect(tool.description).toBe('A test tool');
+      expect(tool.inputSchema).toEqual({
+        type: 'object',
+        properties: {
+          param: { type: 'string' },
+        },
+      });
+      expect(typeof tool.handler).toBe('function');
+    });
+
+    it('should use default inputSchema when not provided', () => {
+      const tool = createAuthenticatedTool(
+        {
+          name: 'test-tool',
+        },
+        async ({ args }) => ({ success: true }),
+      );
+
+      expect(tool.inputSchema).toEqual({
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      });
+    });
+
+    it('should execute handler with valid auth context', async () => {
+      const mockHandler = jest.fn().mockResolvedValue({ success: true });
+      const tool = createAuthenticatedTool(
+        {
+          name: 'test-tool',
+          description: 'Test tool',
+        },
+        mockHandler,
+      );
+
+      const result = await tool.handler({ param: 'value' }, mockExtra);
+
+      expect(mockHandler).toHaveBeenCalledWith({
+        descope: mockAuthContext,
+        args: { param: 'value' },
+      });
+
+      expect(result).toEqual({
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({ success: true }, null, 2),
+          },
+        ],
+      });
+    });
+
+    it('should return string results directly', async () => {
+      const tool = createAuthenticatedTool(
+        {
+          name: 'test-tool',
+        },
+        async () => 'simple string result',
+      );
+
+      const result = await tool.handler({}, mockExtra);
+
+      expect(result).toEqual({
+        content: [
+          {
+            type: 'text',
+            text: 'simple string result',
+          },
+        ],
+      });
+    });
+
+    it('should return 401 when no auth context provided', async () => {
+      const tool = createAuthenticatedTool(
+        {
+          name: 'test-tool',
+        },
+        async () => ({ success: true }),
+      );
+
+      const result = await tool.handler(
+        {},
+        {
+          signal: new AbortController().signal,
+        },
+      );
+
+      expect(result).toEqual({
+        isError: true,
+        code: 401,
+        headers: {
+          'WWW-Authenticate':
+            'Bearer, error="invalid_request", error_description="Authentication required"',
+        },
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(
+              {
+                error: 'unauthorized',
+                error_description: 'Authentication required',
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+      });
+    });
+
+    it('should return 403 when required scopes are missing', async () => {
+      const tool = createAuthenticatedTool(
+        {
+          name: 'test-tool',
+          requiredScopes: ['admin', 'write'],
+        },
+        async () => ({ success: true }),
+      );
+
+      const result = await tool.handler({}, mockExtra);
+
+      expect(result).toEqual({
+        isError: true,
+        code: 403,
+        headers: {
+          'WWW-Authenticate':
+            'Bearer, error="insufficient_scope", error_description="Missing required scopes: admin", scope="admin"',
+        },
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(
+              {
+                error: 'insufficient_scope',
+                error_description: 'Missing required scopes: admin',
+                scope: 'admin',
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+      });
+    });
+
+    it('should execute when user has all required scopes', async () => {
+      const tool = createAuthenticatedTool(
+        {
+          name: 'test-tool',
+          requiredScopes: ['read', 'write'],
+        },
+        async () => ({ success: true }),
+      );
+
+      const result = await tool.handler({}, mockExtra);
+
+      expect(result).toEqual({
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({ success: true }, null, 2),
+          },
+        ],
+      });
+    });
+
+    it('should handle OAuth2 errors', async () => {
+      const oauthError = {
+        oauthError: {
+          error: 'invalid_token',
+          error_description: 'Token expired',
+        },
+        code: 401,
+        wwwAuthenticate: 'Bearer, error="invalid_token"',
+      };
+
+      const tool = createAuthenticatedTool(
+        {
+          name: 'test-tool',
+        },
+        async () => {
+          throw oauthError;
+        },
+      );
+
+      const result = await tool.handler({}, mockExtra);
+
+      expect(result).toEqual({
+        isError: true,
+        code: 401,
+        headers: {
+          'WWW-Authenticate': 'Bearer, error="invalid_token"',
+        },
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(
+              {
+                error: 'invalid_token',
+                error_description: 'Token expired',
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+      });
+    });
+
+    it('should handle generic errors', async () => {
+      const tool = createAuthenticatedTool(
+        {
+          name: 'test-tool',
+        },
+        async () => {
+          throw new Error('Something went wrong');
+        },
+      );
+
+      const result = await tool.handler({}, mockExtra);
+
+      expect(result).toEqual({
+        isError: true,
+        code: 500,
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(
+              {
+                error: 'Something went wrong',
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+      });
+    });
+
+    it('should handle errors with code property', async () => {
+      const customError = new Error('Custom error') as any;
+      customError.code = 400;
+      customError.details = { field: 'invalid' };
+
+      const tool = createAuthenticatedTool(
+        {
+          name: 'test-tool',
+        },
+        async () => {
+          throw customError;
+        },
+      );
+
+      const result = await tool.handler({}, mockExtra);
+
+      expect(result).toEqual({
+        isError: true,
+        code: 400,
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify(
+              {
+                error: 'Custom error',
+                code: 400,
+                details: { field: 'invalid' },
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+      });
+    });
+  });
+});

--- a/packages/sdks/mcp-sdk/tsconfig.json
+++ b/packages/sdks/mcp-sdk/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "rootDir": "./",
+    "target": "es2020",
+    "lib": ["es2020", "dom"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": false,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "declaration": false,
+    "noErrorTruncation": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "test"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,16 +26,16 @@ importers:
         version: 19.1.0(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))
       '@nrwl/eslint-plugin-nx':
         specifier: 19.8.4
-        version: 19.8.4(@babel/traverse@7.27.1)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@typescript-eslint/parser@7.2.0(eslint@9.18.0(jiti@1.21.0))(typescript@5.7.3))(eslint-config-prettier@9.1.0(eslint@9.18.0(jiti@1.21.0)))(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)
+        version: 19.8.4(@babel/traverse@7.27.7)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@typescript-eslint/parser@7.2.0(eslint@9.18.0(jiti@1.21.0))(typescript@5.7.3))(eslint-config-prettier@9.1.0(eslint@9.18.0(jiti@1.21.0)))(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)
       '@nrwl/jest':
         specifier: 19.8.4
-        version: 19.8.4(@babel/traverse@7.27.1)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3))(typescript@5.7.3)
+        version: 19.8.4(@babel/traverse@7.27.7)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3))(typescript@5.7.3)
       '@nrwl/js':
         specifier: 19.8.4
-        version: 19.8.4(@babel/traverse@7.27.1)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)
+        version: 19.8.4(@babel/traverse@7.27.7)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)
       '@nrwl/linter':
         specifier: 19.8.4
-        version: 19.8.4(@babel/traverse@7.27.1)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@zkochan/js-yaml@0.0.7)(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))
+        version: 19.8.4(@babel/traverse@7.27.7)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@zkochan/js-yaml@0.0.7)(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))
       '@nrwl/workspace':
         specifier: 19.8.4
         version: 19.8.4(@swc/core@1.7.1(@swc/helpers@0.5.15))
@@ -739,136 +739,6 @@ importers:
         specifier: ~0.15.0
         version: 0.15.0
 
-  packages/sdks/angular-sdk/projects/angular-sdk:
-    dependencies:
-      '@descope/access-key-management-widget':
-        specifier: workspace:*
-        version: link:../../../../widgets/access-key-management-widget
-      '@descope/applications-portal-widget':
-        specifier: workspace:*
-        version: link:../../../../widgets/applications-portal-widget
-      '@descope/audit-management-widget':
-        specifier: workspace:*
-        version: link:../../../../widgets/audit-management-widget
-      '@descope/core-js-sdk':
-        specifier: workspace:*
-        version: link:../../../core-js-sdk
-      '@descope/role-management-widget':
-        specifier: workspace:*
-        version: link:../../../../widgets/role-management-widget
-      '@descope/user-management-widget':
-        specifier: workspace:*
-        version: link:../../../../widgets/user-management-widget
-      '@descope/user-profile-widget':
-        specifier: workspace:*
-        version: link:../../../../widgets/user-profile-widget
-      '@descope/web-component':
-        specifier: workspace:*
-        version: link:../../../web-component
-      '@descope/web-js-sdk':
-        specifier: workspace:*
-        version: link:../../../web-js-sdk
-      tslib:
-        specifier: ^2.3.0
-        version: 2.8.1
-    devDependencies:
-      '@angular-devkit/build-angular':
-        specifier: ^19.0.0
-        version: 19.1.6(@angular/compiler-cli@19.1.4(@angular/compiler@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.7.3))(@angular/compiler@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@22.13.17)(chokidar@4.0.3)(html-webpack-plugin@5.6.0(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))))(jest-environment-jsdom@29.7.0)(jest@29.7.0(@types/node@22.13.17)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3)))(jiti@1.21.0)(ng-packagr@16.2.3(@angular/compiler-cli@19.1.4(@angular/compiler@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.7.3))(tslib@2.8.1)(typescript@5.7.3))(typescript@5.7.3)(vite@6.0.11(@types/node@22.13.17)(jiti@1.21.0)(less@4.2.1)(sass@1.83.1)(terser@5.37.0)(yaml@2.4.5))(yaml@2.4.5)
-      '@angular-eslint/builder':
-        specifier: 19.0.2
-        version: 19.0.2(chokidar@4.0.3)(eslint@8.57.1)(typescript@5.7.3)
-      '@angular-eslint/eslint-plugin':
-        specifier: 19.0.2
-        version: 19.0.2(@typescript-eslint/utils@8.29.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3)
-      '@angular-eslint/eslint-plugin-template':
-        specifier: 19.0.2
-        version: 19.0.2(@typescript-eslint/types@8.29.0)(@typescript-eslint/utils@8.29.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3)
-      '@angular-eslint/schematics':
-        specifier: 19.0.2
-        version: 19.0.2(@typescript-eslint/types@8.29.0)(@typescript-eslint/utils@8.29.0(eslint@8.57.1)(typescript@5.7.3))(chokidar@4.0.3)(eslint@8.57.1)(typescript@5.7.3)
-      '@angular-eslint/template-parser':
-        specifier: 19.0.2
-        version: 19.0.2(eslint@8.57.1)(typescript@5.7.3)
-      '@angular/animations':
-        specifier: ^19.0.0
-        version: 19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0))
-      '@angular/cli':
-        specifier: ^19.0.0
-        version: 19.1.6(@types/node@22.13.17)(chokidar@4.0.3)
-      '@angular/common':
-        specifier: ^19.0.0
-        version: 19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1)
-      '@angular/compiler':
-        specifier: ^19.0.0
-        version: 19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0))
-      '@angular/compiler-cli':
-        specifier: ^19.0.0
-        version: 19.1.4(@angular/compiler@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.7.3)
-      '@angular/core':
-        specifier: ^19.0.0
-        version: 19.1.4(rxjs@7.8.1)(zone.js@0.15.0)
-      '@angular/forms':
-        specifier: ^19.0.0
-        version: 19.1.4(@angular/common@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0))(@angular/platform-browser@19.1.4(@angular/animations@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/common@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(rxjs@7.8.1)
-      '@angular/platform-browser':
-        specifier: ^19.0.0
-        version: 19.1.4(@angular/animations@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/common@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0))
-      '@angular/platform-browser-dynamic':
-        specifier: ^19.0.0
-        version: 19.1.4(@angular/common@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/compiler@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0))(@angular/platform-browser@19.1.4(@angular/animations@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/common@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))
-      '@angular/router':
-        specifier: ^19.0.0
-        version: 19.1.4(@angular/common@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0))(@angular/platform-browser@19.1.4(@angular/animations@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/common@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(rxjs@7.8.1)
-      '@types/jest':
-        specifier: ^29.5.5
-        version: 29.5.14
-      '@typescript-eslint/eslint-plugin':
-        specifier: 6.21.0
-        version: 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3)
-      '@typescript-eslint/parser':
-        specifier: 6.21.0
-        version: 6.21.0(eslint@8.57.1)(typescript@5.7.3)
-      eslint:
-        specifier: ^8.51.0
-        version: 8.57.1
-      eslint-plugin-prettier:
-        specifier: ^4.2.1
-        version: 4.2.1(eslint-config-prettier@9.1.0(eslint@9.18.0(jiti@1.21.0)))(eslint@8.57.1)(prettier@2.8.8)
-      jest:
-        specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.13.17)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3))
-      jest-preset-angular:
-        specifier: ^13.1.2
-        version: 13.1.6(138181bc1bf7c15203e440c2f268f646)
-      lint-staged:
-        specifier: ^15.2.0
-        version: 15.2.7
-      ng-mocks:
-        specifier: ^14.11.0
-        version: 14.13.0(@angular/common@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0))(@angular/forms@19.1.4(@angular/common@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0))(@angular/platform-browser@19.1.4(@angular/animations@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/common@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(rxjs@7.8.1))(@angular/platform-browser@19.1.4(@angular/animations@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/common@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))
-      ng-packagr:
-        specifier: ^16.2.3
-        version: 16.2.3(@angular/compiler-cli@19.1.4(@angular/compiler@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.7.3))(tslib@2.8.1)(typescript@5.7.3)
-      oidc-client-ts:
-        specifier: 3.2.0
-        version: 3.2.0
-      prettier:
-        specifier: 2.8.8
-        version: 2.8.8
-      pretty-quick:
-        specifier: ^3.1.3
-        version: 3.3.1(prettier@2.8.8)
-      rxjs:
-        specifier: ~7.8.1
-        version: 7.8.1
-      typescript:
-        specifier: ^5.5.0
-        version: 5.7.3
-      zone.js:
-        specifier: ~0.15.0
-        version: 0.15.0
-
   packages/sdks/core-js-sdk:
     dependencies:
       jwt-decode:
@@ -997,6 +867,64 @@ importers:
         version: 5.4.5
 
   packages/sdks/core-js-sdk/dist/cjs: {}
+
+  packages/sdks/mcp-sdk:
+    dependencies:
+      '@descope/core-js-sdk':
+        specifier: workspace:*
+        version: link:../core-js-sdk
+      '@descope/node-sdk':
+        specifier: 0.0.0-next-ef3a9371-20250701
+        version: 0.0.0-next-ef3a9371-20250701(encoding@0.1.13)
+      '@modelcontextprotocol/sdk':
+        specifier: ^0.5.0
+        version: 0.5.0
+    devDependencies:
+      '@rollup/plugin-commonjs':
+        specifier: ^28.0.0
+        version: 28.0.2(rollup@4.34.6)
+      '@rollup/plugin-node-resolve':
+        specifier: ^15.2.3
+        version: 15.2.3(rollup@4.34.6)
+      '@rollup/plugin-typescript':
+        specifier: ^11.0.0
+        version: 11.1.6(rollup@4.34.6)(tslib@2.8.1)(typescript@5.7.3)
+      '@types/jest':
+        specifier: ^29.5.12
+        version: 29.5.14
+      '@types/node':
+        specifier: 20.17.13
+        version: 20.17.13
+      '@typescript-eslint/parser':
+        specifier: ^7.0.0
+        version: 7.18.0(eslint@8.57.1)(typescript@5.7.3)
+      eslint:
+        specifier: 8.57.1
+        version: 8.57.1
+      eslint-config-prettier:
+        specifier: 9.1.0
+        version: 9.1.0(eslint@8.57.1)
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@20.17.13)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3))
+      jest-extended:
+        specifier: ^4.0.0
+        version: 4.0.2(jest@29.7.0(@types/node@20.17.13)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3)))
+      prettier:
+        specifier: ^3.0.0
+        version: 3.5.3
+      rollup:
+        specifier: ^4.0.0
+        version: 4.34.6
+      rollup-plugin-dts:
+        specifier: ^6.1.1
+        version: 6.1.1(rollup@4.34.6)(typescript@5.7.3)
+      ts-jest:
+        specifier: ^29.0.0
+        version: 29.2.5(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(jest@29.7.0(@types/node@20.17.13)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3)))(typescript@5.7.3)
+      typescript:
+        specifier: ^5.0.2
+        version: 5.7.3
 
   packages/sdks/nextjs-sdk:
     dependencies:
@@ -1639,7 +1567,7 @@ importers:
     devDependencies:
       '@descope/web-components-ui':
         specifier: latest
-        version: 1.76.0
+        version: 1.104.0
       '@open-wc/rollup-plugin-html':
         specifier: 1.2.5
         version: 1.2.5
@@ -1961,7 +1889,7 @@ importers:
     devDependencies:
       '@descope/web-components-ui':
         specifier: latest
-        version: 1.76.0
+        version: 1.104.0
       '@open-wc/rollup-plugin-html':
         specifier: 1.2.5
         version: 1.2.5
@@ -2139,7 +2067,7 @@ importers:
     devDependencies:
       '@descope/web-components-ui':
         specifier: latest
-        version: 1.76.0
+        version: 1.104.0
       '@open-wc/rollup-plugin-html':
         specifier: 1.2.5
         version: 1.2.5
@@ -2317,7 +2245,7 @@ importers:
     devDependencies:
       '@descope/web-components-ui':
         specifier: latest
-        version: 1.76.0
+        version: 1.104.0
       '@open-wc/rollup-plugin-html':
         specifier: 1.2.5
         version: 1.2.5
@@ -2495,7 +2423,7 @@ importers:
     devDependencies:
       '@descope/web-components-ui':
         specifier: latest
-        version: 1.76.0
+        version: 1.104.0
       '@open-wc/rollup-plugin-html':
         specifier: 1.2.5
         version: 1.2.5
@@ -2676,7 +2604,7 @@ importers:
     devDependencies:
       '@descope/web-components-ui':
         specifier: latest
-        version: 1.76.0
+        version: 1.104.0
       '@open-wc/rollup-plugin-html':
         specifier: 1.2.5
         version: 1.2.5
@@ -2857,7 +2785,7 @@ importers:
     devDependencies:
       '@descope/web-components-ui':
         specifier: latest
-        version: 1.76.0
+        version: 1.104.0
       '@open-wc/rollup-plugin-html':
         specifier: 1.2.5
         version: 1.2.5
@@ -3265,8 +3193,8 @@ packages:
     resolution: {integrity: sha512-XvcZi1KWf88RVbF9wn8MN6tYFloU5qX8KjuF3E1PVBmJ9eypXfs4GRiJwLuTZL0iSnJUKn1BFPa5BPZZJyFzPg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/compat-data@7.27.1':
-    resolution: {integrity: sha512-Q+E+rd/yBzNQhXkG+zQnF58e4zoZfBedaxwzPmicKsiK3nt8iJYrSrDbjwFFDGC4f+rPafqRaPH6TsDoSvMf7A==}
+  '@babel/compat-data@7.27.7':
+    resolution: {integrity: sha512-xgu/ySj2mTiUFmdE9yCMfBxLp4DHd5DwmbbD05YAuICfodYT3VvRxbrh81LGQ/8UpSdtMdfKMn3KouYDX59DGQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/core@7.26.0':
@@ -3289,8 +3217,8 @@ packages:
     resolution: {integrity: sha512-VybsKvpiN1gU1sdMZIp7FcqphVVKEwcuj02x73uvcHE0PTihx1nlBcowYWhDwjpoAXRv43+gDzyggGnn1XZhVw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@7.27.1':
-    resolution: {integrity: sha512-UnJfnIpc/+JO0/+KRVQNGU+y5taA5vCbwN8+azkX6beii/ZF+enZJSOKo11ZSzGJjlNfJHfQtmQT8H+9TXPG2w==}
+  '@babel/generator@7.27.5':
+    resolution: {integrity: sha512-ZGhA37l0e/g2s1Cnzdix0O3aLYm66eF8aufiVteOgnwxgnRP8GoyMj7VWsgWnQbVKXyge7hqrFh2K2TQM6t1Hw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-annotate-as-pure@7.25.9':
@@ -3305,8 +3233,8 @@ packages:
     resolution: {integrity: sha512-IXuyn5EkouFJscIDuFF5EsiSolseme1s0CZB+QxVugqJLYmKdxI1VfIBOst0SUu4rnk2Z7kqTwmoO1lp3HIfnA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-compilation-targets@7.27.1':
-    resolution: {integrity: sha512-2YaDd/Rd9E598B5+WIc8wJPmWETiiJXFYVE60oX8FDohv7rAUU3CQj+A1MgeEmcsk2+dQuEjIe/GDvig0SqL4g==}
+  '@babel/helper-compilation-targets@7.27.2':
+    resolution: {integrity: sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-create-class-features-plugin@7.24.8':
@@ -3380,8 +3308,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/helper-module-transforms@7.27.1':
-    resolution: {integrity: sha512-9yHn519/8KvTU5BjTVEEeIM3w9/2yXNKoD82JifINImhpKkARMJKPP59kLo+BafpdN5zgNeIcS4jsGDmd3l58g==}
+  '@babel/helper-module-transforms@7.27.3':
+    resolution: {integrity: sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -3476,8 +3404,8 @@ packages:
     resolution: {integrity: sha512-8NHiL98vsi0mbPQmYAGWwfcFaOy4j2HY49fXJCfuDcdE7fMIsH9a7GdaeXpIBsbT7307WU8KCMp5pUVDNL4f9A==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helpers@7.27.1':
-    resolution: {integrity: sha512-FCvFTm0sWV8Fxhpp2McP5/W53GPllQ9QeQ7SiqGWjMf/LVG07lFa5+pgK05IRhVwtvafT22KF+ZSnM9I545CvQ==}
+  '@babel/helpers@7.27.6':
+    resolution: {integrity: sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==}
     engines: {node: '>=6.9.0'}
 
   '@babel/highlight@7.23.4':
@@ -3503,8 +3431,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/parser@7.27.1':
-    resolution: {integrity: sha512-I0dZ3ZpCrJ1c04OqlNsQcKiZlsrXf/kkE4FXzID9rIOYICsAbA8mMDzhW/luRNAHdCNt7os/u8wenklZDlUVUQ==}
+  '@babel/parser@7.27.7':
+    resolution: {integrity: sha512-qnzXzDXdr/po3bOTbTIQZ7+TxNKxpkN5IifVLXS+r7qwynkZfPyjZfE7hCXbo7IoO9TNcSyibgONsf2HauUd3Q==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -4065,8 +3993,8 @@ packages:
     resolution: {integrity: sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/template@7.27.1':
-    resolution: {integrity: sha512-Fyo3ghWMqkHHpHQCoBs2VnYjR4iWFFjguTDEqA5WgZDOrFesVjMhMM2FSqTKSoUSDO1VQtavj8NFpdRBEvJTtg==}
+  '@babel/template@7.27.2':
+    resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/traverse@7.24.8':
@@ -4077,8 +4005,8 @@ packages:
     resolution: {integrity: sha512-1x1sgeyRLC3r5fQOM0/xtQKsYjyxmFjaOrLJNtZ81inNjyJHGIolTULPiSc/2qe1/qfpFLisLQYFnnZl7QoedA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/traverse@7.27.1':
-    resolution: {integrity: sha512-ZCYtZciz1IWJB4U61UPu4KEaqyfj+r5T1Q5mqPo+IBpcG9kHv30Z0aD8LXPgC1trYa6rK0orRyAhqUgk4MjmEg==}
+  '@babel/traverse@7.27.7':
+    resolution: {integrity: sha512-X6ZlfR/O/s5EQ/SnUSLzr+6kGnkg8HXGMzpgsMsrJVcfDtH1vIp6ctCN4eZ1LS5c0+te5Cb6Y514fASjMRJ1nw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.24.8':
@@ -4093,8 +4021,8 @@ packages:
     resolution: {integrity: sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.27.1':
-    resolution: {integrity: sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==}
+  '@babel/types@7.27.7':
+    resolution: {integrity: sha512-8OLQgDScAOHXnAz2cV+RfzzNMipuLVBz2biuAJFMV9bfkNf393je3VM8CLkjQodW5+iWsSJdSgSWT6rsZoXHPw==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@0.2.3':
@@ -4182,47 +4110,53 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
-  '@descope-ui/common@0.0.11':
-    resolution: {integrity: sha512-owu9z9YJ5XYEUvDx+SJYpLSD2M3g622/27p00GKOIOuY8USfEJc5C1cInupXjjbpLdYI9ZcIHU5mdx9gkPhLKg==}
+  '@descope-ui/common@0.0.16':
+    resolution: {integrity: sha512-6gOvezmlVBXAncDtafmqL56vCsaBM4eILbNWayRVTGCQcCrz+MHiLPussuFADl0SlzQ1RVBj3H/nNaAntie4ZQ==}
 
-  '@descope-ui/descope-address-field@0.0.11':
-    resolution: {integrity: sha512-ZWQKLq9dpQVIrFBfodBXTKILKI32sl9p8gnTlDjLK0db9NFwpyJGT4f48A1n7wA/IJfS71xK2EWWZigVTh5HUg==}
+  '@descope-ui/descope-address-field@0.0.18':
+    resolution: {integrity: sha512-dAJ40Pa0nE93702Nu0hzf98sZ6RNmDOFd4/Jp6fcrEXvsNprHDOqTsovWA5qsHHimPM26BQzlhQqEOrk0huwWA==}
 
-  '@descope-ui/descope-autocomplete-field@0.0.12':
-    resolution: {integrity: sha512-YHuHTJtrrZ7lAlJqGjj+nxUhxh2xCYwXN0m3jfGAtpIsDA9hI1Diw2wTZfCBnLEBnx++v1QAzh4vZKorXVFMwg==}
+  '@descope-ui/descope-autocomplete-field@0.0.19':
+    resolution: {integrity: sha512-qd4B4DlwIDb/mE0uZV75yAIZNicO2j10lUTsROer3uEHjDP51weQIUQBPvNfqvFCb2tZJ/kJvT86QsBHCfXXTg==}
 
-  '@descope-ui/descope-avatar@0.0.11':
-    resolution: {integrity: sha512-FyUFA+DWzPFWE7fk2xXd/V+cffBkjV0xOBIfNFE8vk2KZZSp8tm8AxVDSzhBf7Qj833ae/kO5SsD+0U1bpWw2A==}
+  '@descope-ui/descope-avatar@0.0.17':
+    resolution: {integrity: sha512-jauVZoXFgRRbd/65iK9wzT51cDEeZy42X4c6ScBgTOmL0v5jPIie2QT7M5j/GOQFn+sgyWthccVGZ/rZqU53xA==}
 
-  '@descope-ui/descope-button@0.0.7':
-    resolution: {integrity: sha512-ueft60QctR3BRISl++bxjWfnAc5gjdyt9YUuC1gj9gQeRCBykpuxNuBcSgxffW4J6nO0twdSM9dLZM2Lqu4J5Q==}
+  '@descope-ui/descope-button@0.0.15':
+    resolution: {integrity: sha512-9VypcZDQN1iPcwsM9RB+irFadJ5VYNt6zr7GN6DP0Kdkgr5JpjcMoUYl85z01UPBSHsRMGiwSVCFH0BnoaYdNg==}
 
-  '@descope-ui/descope-collapsible-container@0.0.6':
-    resolution: {integrity: sha512-9XCtb67flPOaFBxbHmaqL4axxn67GtCMtMxFbh8z8XYZ43C3O3nbBgtRfDzSoLLopjfn/aNeHF8kRcZR0SeaZw==}
+  '@descope-ui/descope-collapsible-container@0.0.14':
+    resolution: {integrity: sha512-vNs0ccTjIReS7hCBZk/+z9a6zl0DO/yMB5BYIJbgHUXfJIQsja1bQYTXiYKLIc3Js2FrHI1wG62UJ9TMdGdGvQ==}
 
-  '@descope-ui/descope-combo-box@0.0.13':
-    resolution: {integrity: sha512-8436JoIjwuw9SzXLsWf+i7rHjSTSzy9QW/aH3HSvpF91soSHpLMoZVbrpHc8BEHlr0uenDJ84waTZWWumN23pQ==}
+  '@descope-ui/descope-combo-box@0.1.6':
+    resolution: {integrity: sha512-Jw5sqlyz20Qgg/0QAeXKW0xTA/l/XgfoW+srwc93sDwTJgORk6ZCgn9ddxRWNbeCLlJLmGVpI3YUBJZNOVWTZA==}
 
-  '@descope-ui/descope-icon@0.0.6':
-    resolution: {integrity: sha512-TaXocIkF4L/ncN5Wvd6nPoVu6YOJNe6EewXnAT0mMda52A7gQWsYqKcg7u1oAlG1H1blD1qqVIXbppke25achg==}
+  '@descope-ui/descope-icon@0.0.14':
+    resolution: {integrity: sha512-lmlcNGQ/dSM7PeNQGtqvTH9rngO/lgdw5ttF12abcr5ZVOiAaSevkLxNS/i6I7eoCgn+o6qGIroTP0fl/2z8Uw==}
 
-  '@descope-ui/descope-password-strength@0.0.3':
-    resolution: {integrity: sha512-gMK46936rgLgw8mlnKC0HVLSO6HRtby5y7N//Pu5CQl6E9tLOOAEqZHqwbEL1xQGzdn2XMf8IVc+w2QQnKwr+w==}
+  '@descope-ui/descope-image@0.0.8':
+    resolution: {integrity: sha512-l9JnMaylUR7hWUOXoZ/ygDgwp03FccnAiz9bbw5Zy9ZF9Rw0LAimNjjMF1myBKefxzrFjI4oDRhJGXG18loCQQ==}
 
-  '@descope-ui/descope-text@0.0.11':
-    resolution: {integrity: sha512-9SWVqqK+9URHHAGFAIL1eqIwkqYQZDGmL4MO3wJFjd3GQYrVTf9jf4DUycyO1IVhJwVBE6pmgztJN5AUVb3qFw==}
+  '@descope-ui/descope-password-strength@0.0.10':
+    resolution: {integrity: sha512-tBFKbAFXM2xY5fl0+vt8HC6LX03ljjH62rutM9YM9eG7FVmy32YNsrlTQq/51jPxUZ/+s5xUfn+Rrbuia/VV5Q==}
 
-  '@descope-ui/descope-timer-button@0.0.7':
-    resolution: {integrity: sha512-GBy1J40AgJieFAgwwtS6zISdSUg7m5bDbXiU6GPAhAebMvHh0sWSon6EvOoR81skP6i8t8LaH3G0z5W5DDgD3w==}
+  '@descope-ui/descope-recovery-codes@0.0.3':
+    resolution: {integrity: sha512-wpTTbnFy/HFN9OYo8RTIzdUGLSAdQuT05EOALWmjLTQ2qq1+GYvATmK7CJ5JY74plQXoPA498+U/vBcQsQSrmA==}
 
-  '@descope-ui/descope-timer@0.0.5':
-    resolution: {integrity: sha512-AQX0L7FzaHs5Ns8YhOY0lPk1akXK5azPktR1/U83ciaM51/kbh3B9s8cVPdW1NSqAVNyucCX7wHG1a1z6Kij+A==}
+  '@descope-ui/descope-text@0.0.17':
+    resolution: {integrity: sha512-AlDRlYoSvauPa1HVdJLGLKhQQA/b7s/B/DQEs9U8tuCwm3ELN3n9dSq5zJ01D9KeDc0wRLJha+oThL/O/07Qwg==}
 
-  '@descope-ui/theme-globals@0.0.11':
-    resolution: {integrity: sha512-IaRQZTGRXZpk9+KoJ1/i4eJu+4mhrz+pgpkVh+Cdv3ntWQUb71voLa/WC4JBFqMnwGkcm49CodlljL9A4W5FYQ==}
+  '@descope-ui/descope-timer-button@0.0.15':
+    resolution: {integrity: sha512-S5B59jDe8clxogyliyIUTiWOMJDvYb8HDUL5E5OtOWVWZHOBoqYdeGNVrDQeIszD444PiMh8CstGuh1kWWjw9Q==}
 
-  '@descope-ui/theme-input-wrapper@0.0.11':
-    resolution: {integrity: sha512-HkMMxnPuCiFYfEcoAM0xqJ5hdPCmsxPp71xP/RXbcvFYiT0LjCRkdNEhHA/iCfaNKFTufMUa1mveQGaevNmwXg==}
+  '@descope-ui/descope-timer@0.0.13':
+    resolution: {integrity: sha512-OgpxaUICMtKHYgPcQRRaqtpGnvfd+CgdqjSnMhz7jRlDXtrAhWZyQMxcdgZQeu3yU9z2kefNPCsE8rLsfRrDmg==}
+
+  '@descope-ui/theme-globals@0.0.17':
+    resolution: {integrity: sha512-xIVmPhL5NPxOUCFBBIjX2BS0WKzHjG0L6LGiRJIaWVhFXAvztcvD7YnPHGR6Qj5B6Z7d8A9uZygm7DuJykiD3A==}
+
+  '@descope-ui/theme-input-wrapper@0.1.6':
+    resolution: {integrity: sha512-t7XWtdJeDp/OWDCER2Vp28eNDiWiPvWm8MUXNmQGV56FbvuOmdrcWMGES3LB9/1B3+VwYslQ1+niCoKq1Ejb0A==}
 
   '@descope/core-js-sdk@2.31.0':
     resolution: {integrity: sha512-y5Z8wQwmOt4IEt67XwS006jbtSVGumbcXDx6k+1/e3jHFzSLZdVnt9sgKKU0biQQl5jAi3GVNsilWVNIC4D2Ww==}
@@ -4230,19 +4164,26 @@ packages:
   '@descope/core-js-sdk@2.40.0':
     resolution: {integrity: sha512-hFr/SzQO0QbyDaI1LlN//HKi3hXNJAnU0lFUpsqwo92YmCvYzhSZ7r6aBvT0DU2jaXmvt/0Y9TyNQuEKsGpT/A==}
 
+  '@descope/core-js-sdk@2.44.3':
+    resolution: {integrity: sha512-JTEgnVuSonaYQg8BOuWFAQr2m5lQTnxbIcx1TRe0ALwxKTwpdnboUdr6Afd5U0RgHLfAE/njpDk/+RYyHjPALA==}
+
   '@descope/nextjs-sdk@file:packages/sdks/nextjs-sdk':
     resolution: {directory: packages/sdks/nextjs-sdk, type: directory}
     peerDependencies:
       '@types/react': '>=18'
-      next: '>=15.2.4'
+      next: '>=13'
       react: '>=18'
+
+  '@descope/node-sdk@0.0.0-next-ef3a9371-20250701':
+    resolution: {integrity: sha512-cbVoBAQR63rkpa0kKJZiJYZzUBDxLso6wVS+MheL87BrFSg7xL37g1WoaYFqpybNdPCpSFnw+fU9cf/rGQyaIg==}
+    engines: {node: '>= 12.0.0'}
 
   '@descope/node-sdk@1.6.13':
     resolution: {integrity: sha512-6r0ArtJkkky67wQR0J1cS5WRNcrE3dgMDE0wqWdmq/OZPIYVwLf950I24I4wPVh97Ya40TAqm8kt7VP1zJFfKw==}
     engines: {node: '>= 12.0.0'}
 
-  '@descope/web-components-ui@1.76.0':
-    resolution: {integrity: sha512-22mSjJCFFWpgLPg5wPkYyKdxpcYrzsMZFisI/W97Ya2HF1QabMdG2MC1kt/uNFedpoJtPsksWc9n+8rqEoTFJA==}
+  '@descope/web-components-ui@1.104.0':
+    resolution: {integrity: sha512-z3oSS0Yuo4Ri+boFsdEvuoOSaQvr25kXoGoLGJMIcz/kqlfKdvVDpJqduenXriqJVVdmmVC9Ui3hZluIySzTdA==}
 
   '@descope/web-js-sdk@1.29.1':
     resolution: {integrity: sha512-YUMJQ9TrEhp8SDtOcERF4tr7IguBt5//0sm8k8/tFc/9qb1uZ9Hz1z2+1NX8cnni+tMpOUH7tRFEoprpKayPEw==}
@@ -5020,12 +4961,6 @@ packages:
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
 
-  '@eslint-community/eslint-utils@4.6.1':
-    resolution: {integrity: sha512-KTsJMmobmbrFLe3LDh0PC2FXpcSYJt/MLjlkh/9LEnmKYLSYmT/0EW9JWANjeoemiuZrmogti0tW5Ch+qNUYDw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
-
   '@eslint-community/eslint-utils@4.7.0':
     resolution: {integrity: sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -5499,6 +5434,9 @@ packages:
     resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  '@jridgewell/gen-mapping@0.3.11':
+    resolution: {integrity: sha512-C512c1ytBTio4MrpWKlJpyFHT6+qfFL8SZ58zBzJ1OOzUEjHeF1BtjY2fH7n4x/g2OV/KiiMLAivOp1DXmiMMw==}
+
   '@jridgewell/gen-mapping@0.3.5':
     resolution: {integrity: sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==}
     engines: {node: '>=6.0.0'}
@@ -5509,6 +5447,10 @@ packages:
 
   '@jridgewell/resolve-uri@3.1.1':
     resolution: {integrity: sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
 
   '@jridgewell/set-array@1.2.1':
@@ -5524,8 +5466,14 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
 
+  '@jridgewell/sourcemap-codec@1.5.3':
+    resolution: {integrity: sha512-AiR5uKpFxP3PjO4R19kQGIMwxyRyPuXmKEEy301V1C0+1rVjS94EZQXf1QKZYN8Q0YM+estSPhmx5JwNftv6nw==}
+
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+
+  '@jridgewell/trace-mapping@0.3.28':
+    resolution: {integrity: sha512-KNNHHwW3EIp4EDYOvYFGyIFfx36R2dNJYH4knnZlF8T5jdbD5Wx8xmSaQ2gP9URkJ04LGEtlcCtwArKcmFcwKw==}
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
@@ -5565,8 +5513,14 @@ packages:
   '@lit-labs/ssr-dom-shim@1.2.1':
     resolution: {integrity: sha512-wx4aBmgeGvFmOKucFKY+8VFJSYZxs9poN3SDNQFF6lT6NrQUnHiPB2PWz2sc4ieEcAaYYzN+1uWahEeTq2aRIQ==}
 
+  '@lit-labs/ssr-dom-shim@1.3.0':
+    resolution: {integrity: sha512-nQIWonJ6eFAvUUrSlwyHDm/aE8PBDu5kRpL0vHMg6K8fK3Diq1xdPjTnsJSwxABhaZ+5eBi1btQB5ShUTKo4nQ==}
+
   '@lit/reactive-element@2.0.4':
     resolution: {integrity: sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==}
+
+  '@lit/reactive-element@2.1.0':
+    resolution: {integrity: sha512-L2qyoZSQClcBmq0qajBVbhYEcG6iK0XfLn66ifLe/RfC0/ihpc+pl0Wdn8bJ8o+hj38cG0fGXRgSS20MuXn7qA==}
 
   '@lmdb/lmdb-darwin-arm64@3.2.2':
     resolution: {integrity: sha512-WBSJT9Z7DTol5viq+DZD2TapeWOw7mlwXxiSBHgAzqVwsaVb0h/ekMD9iu/jDD8MUA20tO9N0WEdnT06fsUp+g==}
@@ -5597,6 +5551,9 @@ packages:
     resolution: {integrity: sha512-Y0qoSCAja+xZE7QQ0LCHoYAuyI1n9ZqukQJa8lv9X3yCvWahFF7OYHAgVH1ejp43XWstj3U89/PAAzcowgF/uQ==}
     cpu: [x64]
     os: [win32]
+
+  '@modelcontextprotocol/sdk@0.5.0':
+    resolution: {integrity: sha512-RXgulUX6ewvxjAG0kOpLMEdXXWkzWgaoCGaA2CwNW7cQCIphjpJhjpHSiaPdVCnisjRF/0Cm9KWHUuIoeiAblQ==}
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
@@ -6367,6 +6324,9 @@ packages:
 
   '@polymer/polymer@3.5.1':
     resolution: {integrity: sha512-JlAHuy+1qIC6hL1ojEUfIVD58fzTpJAoCxFwV5yr0mYTXV1H8bz5zy0+rC963Cgr9iNXQ4T9ncSjC2fkF9BQfw==}
+
+  '@polymer/polymer@3.5.2':
+    resolution: {integrity: sha512-fWwImY/UH4bb2534DVSaX+Azs2yKg8slkMBHOyGeU2kKx7Xmxp6Lee0jP8p6B3d7c1gFUPB2Z976dTUtX81pQA==}
 
   '@reduxjs/toolkit@2.0.1':
     resolution: {integrity: sha512-fxIjrR9934cmS8YXIGd9e7s1XRsEU++aFc9DVNMFMRTM5Vtsg2DCRMj21eslGtDt43IUf9bJL3h5bwUlZleibA==}
@@ -9534,6 +9494,15 @@ packages:
       supports-color:
         optional: true
 
+  debug@4.4.1:
+    resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   decimal.js@10.4.3:
     resolution: {integrity: sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==}
 
@@ -9714,8 +9683,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.2.4:
-    resolution: {integrity: sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==}
+  dompurify@3.2.6:
+    resolution: {integrity: sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==}
 
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
@@ -10311,6 +10280,10 @@ packages:
 
   eslint-visitor-keys@4.2.0:
     resolution: {integrity: sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   eslint-webpack-plugin@3.2.0:
@@ -12068,11 +12041,20 @@ packages:
   lit-element@4.1.0:
     resolution: {integrity: sha512-gSejRUQJuMQjV2Z59KAS/D4iElUhwKpIyJvZ9w+DIagIQjfJnhR20h2Q5ddpzXGS+fF0tMZ/xEYGMnKmaI/iww==}
 
+  lit-element@4.2.0:
+    resolution: {integrity: sha512-MGrXJVAI5x+Bfth/pU9Kst1iWID6GHDLEzFEnyULB/sFiRLgkd8NPK/PeeXxktA3T6EIIaq8U3KcbTU5XFcP2Q==}
+
   lit-html@3.2.0:
     resolution: {integrity: sha512-pwT/HwoxqI9FggTrYVarkBKFN9MlTUpLrDHubTmW4SrkL3kkqW5gxwbxMMUnbbRHBC0WTZnYHcjDSCM559VyfA==}
 
+  lit-html@3.3.0:
+    resolution: {integrity: sha512-RHoswrFAxY2d8Cf2mm4OZ1DgzCoBKUKSPvA1fhtSELxUERq2aQQ2h05pO9j81gS1o7RIRJ+CePLogfyahwmynw==}
+
   lit@3.2.0:
     resolution: {integrity: sha512-s6tI33Lf6VpDu7u4YqsSX78D28bYQulM+VAzsGch4fx2H0eLZnJsUBsPWmGYSGoKDNbjtRv02rio1o+UdPVwvw==}
+
+  lit@3.3.0:
+    resolution: {integrity: sha512-DGVsqsOIHBww2DqnuZzW7QsuCdahp50ojuDaBPC7jUDRpYoH0z7kHBBYZewRzer75FwtrkmkKk7iOAwSaWdBmw==}
 
   livereload-js@3.4.1:
     resolution: {integrity: sha512-5MP0uUeVCec89ZbNOT/i97Mc+q3SxXmiUGhRFOTmhrGPn//uWVQdCvcLJDy64MSBR5MidFdOR7B9viumoavy6g==}
@@ -13434,6 +13416,10 @@ packages:
     resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+    engines: {node: ^10 || ^12 || >=14}
+
   prelude-ls@1.1.2:
     resolution: {integrity: sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==}
     engines: {node: '>= 0.8.0'}
@@ -13602,6 +13588,10 @@ packages:
 
   raw-body@2.5.2:
     resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
+    engines: {node: '>= 0.8'}
+
+  raw-body@3.0.0:
+    resolution: {integrity: sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==}
     engines: {node: '>= 0.8'}
 
   rc@1.2.8:
@@ -14184,6 +14174,11 @@ packages:
 
   semver@7.7.1:
     resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.7.2:
+    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -15737,6 +15732,9 @@ packages:
     resolution: {integrity: sha512-jcKpkthap6x63MB4TxwCyuIGkV0oYP/YRyuQU5UO0Yz/E/ZAu+653/uov+phdmO54n6BcvFRyyt0RRrWdN2mpw==}
     engines: {node: '>=4'}
 
+  zod@3.25.67:
+    resolution: {integrity: sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==}
+
   zone.js@0.15.0:
     resolution: {integrity: sha512-9oxn0IIjbCZkJ67L+LkhYWRyAy7axphb3VgE2MBDlOqnmHMPWGYMxJxBYFueFq/JGY2GMwS0rU+UCLunEmy5UA==}
 
@@ -15768,7 +15766,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.1901.6(chokidar@4.0.3)
-      '@angular-devkit/build-webpack': 0.1901.6(chokidar@4.0.3)(webpack-dev-server@5.2.0(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))))(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15)))
+      '@angular-devkit/build-webpack': 0.1901.6(chokidar@4.0.3)(webpack-dev-server@5.2.0(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))(esbuild@0.24.2)))(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))(esbuild@0.24.2))
       '@angular-devkit/core': 19.1.6(chokidar@4.0.3)
       '@angular/build': 19.1.6(@angular/compiler-cli@19.1.4(@angular/compiler@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.7.3))(@angular/compiler@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(@types/node@22.13.17)(chokidar@4.0.3)(jiti@1.21.0)(less@4.2.1)(ng-packagr@16.2.3(@angular/compiler-cli@19.1.4(@angular/compiler@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.7.3))(tslib@2.6.3)(typescript@5.7.3))(postcss@8.4.49)(terser@5.37.0)(typescript@5.7.3)(yaml@2.4.5)
       '@angular/compiler-cli': 19.1.4(@angular/compiler@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.7.3)
@@ -15782,14 +15780,14 @@ snapshots:
       '@babel/preset-env': 7.26.0(@babel/core@7.26.0)
       '@babel/runtime': 7.26.0
       '@discoveryjs/json-ext': 0.6.3
-      '@ngtools/webpack': 19.1.6(@angular/compiler-cli@19.1.4(@angular/compiler@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.7.3))(typescript@5.7.3)(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15)))
+      '@ngtools/webpack': 19.1.6(@angular/compiler-cli@19.1.4(@angular/compiler@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.7.3))(typescript@5.7.3)(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))(esbuild@0.24.2))
       '@vitejs/plugin-basic-ssl': 1.2.0(vite@6.0.11(@types/node@22.13.17)(jiti@1.21.0)(less@4.2.1)(sass@1.83.1)(terser@5.37.0)(yaml@2.4.5))
       ansi-colors: 4.1.3
       autoprefixer: 10.4.20(postcss@8.4.49)
-      babel-loader: 9.2.1(@babel/core@7.26.0)(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15)))
+      babel-loader: 9.2.1(@babel/core@7.26.0)(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))(esbuild@0.24.2))
       browserslist: 4.24.4
-      copy-webpack-plugin: 12.0.2(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15)))
-      css-loader: 7.1.2(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15)))
+      copy-webpack-plugin: 12.0.2(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))(esbuild@0.24.2))
+      css-loader: 7.1.2(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))(esbuild@0.24.2))
       esbuild-wasm: 0.24.2
       fast-glob: 3.3.3
       http-proxy-middleware: 3.0.3
@@ -15797,32 +15795,32 @@ snapshots:
       jsonc-parser: 3.3.1
       karma-source-map-support: 1.4.0
       less: 4.2.1
-      less-loader: 12.2.0(less@4.2.1)(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15)))
-      license-webpack-plugin: 4.0.2(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15)))
+      less-loader: 12.2.0(less@4.2.1)(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))(esbuild@0.24.2))
+      license-webpack-plugin: 4.0.2(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))(esbuild@0.24.2))
       loader-utils: 3.3.1
-      mini-css-extract-plugin: 2.9.2(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15)))
+      mini-css-extract-plugin: 2.9.2(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))(esbuild@0.24.2))
       open: 10.1.0
       ora: 5.4.1
       picomatch: 4.0.2
       piscina: 4.8.0
       postcss: 8.4.49
-      postcss-loader: 8.1.1(postcss@8.4.49)(typescript@5.7.3)(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15)))
+      postcss-loader: 8.1.1(postcss@8.4.49)(typescript@5.7.3)(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))(esbuild@0.24.2))
       resolve-url-loader: 5.0.0
       rxjs: 7.8.1
       sass: 1.83.1
-      sass-loader: 16.0.4(sass@1.83.1)(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15)))
+      sass-loader: 16.0.4(sass@1.83.1)(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))(esbuild@0.24.2))
       semver: 7.6.3
-      source-map-loader: 5.0.0(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15)))
+      source-map-loader: 5.0.0(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))(esbuild@0.24.2))
       source-map-support: 0.5.21
       terser: 5.37.0
       tree-kill: 1.2.2
       tslib: 2.8.1
       typescript: 5.7.3
       webpack: 5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))(esbuild@0.24.2)
-      webpack-dev-middleware: 7.4.2(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15)))
-      webpack-dev-server: 5.2.0(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15)))
+      webpack-dev-middleware: 7.4.2(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))(esbuild@0.24.2))
+      webpack-dev-server: 5.2.0(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))(esbuild@0.24.2))
       webpack-merge: 6.0.1
-      webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.6.0(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))))(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15)))
+      webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.6.0(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))))(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))(esbuild@0.24.2))
     optionalDependencies:
       esbuild: 0.24.2
       jest: 29.7.0(@types/node@22.13.17)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3))
@@ -15851,99 +15849,12 @@ snapshots:
       - webpack-cli
       - yaml
 
-  '@angular-devkit/build-angular@19.1.6(@angular/compiler-cli@19.1.4(@angular/compiler@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.7.3))(@angular/compiler@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@22.13.17)(chokidar@4.0.3)(html-webpack-plugin@5.6.0(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))))(jest-environment-jsdom@29.7.0)(jest@29.7.0(@types/node@22.13.17)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3)))(jiti@1.21.0)(ng-packagr@16.2.3(@angular/compiler-cli@19.1.4(@angular/compiler@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.7.3))(tslib@2.8.1)(typescript@5.7.3))(typescript@5.7.3)(vite@6.0.11(@types/node@22.13.17)(jiti@1.21.0)(less@4.2.1)(sass@1.83.1)(terser@5.37.0)(yaml@2.4.5))(yaml@2.4.5)':
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@angular-devkit/architect': 0.1901.6(chokidar@4.0.3)
-      '@angular-devkit/build-webpack': 0.1901.6(chokidar@4.0.3)(webpack-dev-server@5.2.0(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))))(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15)))
-      '@angular-devkit/core': 19.1.6(chokidar@4.0.3)
-      '@angular/build': 19.1.6(@angular/compiler-cli@19.1.4(@angular/compiler@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.7.3))(@angular/compiler@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(@types/node@22.13.17)(chokidar@4.0.3)(jiti@1.21.0)(less@4.2.1)(ng-packagr@16.2.3(@angular/compiler-cli@19.1.4(@angular/compiler@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.7.3))(tslib@2.8.1)(typescript@5.7.3))(postcss@8.4.49)(terser@5.37.0)(typescript@5.7.3)(yaml@2.4.5)
-      '@angular/compiler-cli': 19.1.4(@angular/compiler@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.7.3)
-      '@babel/core': 7.26.0
-      '@babel/generator': 7.26.3
-      '@babel/helper-annotate-as-pure': 7.25.9
-      '@babel/helper-split-export-declaration': 7.24.7
-      '@babel/plugin-transform-async-generator-functions': 7.25.9(@babel/core@7.26.0)
-      '@babel/plugin-transform-async-to-generator': 7.25.9(@babel/core@7.26.0)
-      '@babel/plugin-transform-runtime': 7.25.9(@babel/core@7.26.0)
-      '@babel/preset-env': 7.26.0(@babel/core@7.26.0)
-      '@babel/runtime': 7.26.0
-      '@discoveryjs/json-ext': 0.6.3
-      '@ngtools/webpack': 19.1.6(@angular/compiler-cli@19.1.4(@angular/compiler@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.7.3))(typescript@5.7.3)(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15)))
-      '@vitejs/plugin-basic-ssl': 1.2.0(vite@6.0.11(@types/node@22.13.17)(jiti@1.21.0)(less@4.2.1)(sass@1.83.1)(terser@5.37.0)(yaml@2.4.5))
-      ansi-colors: 4.1.3
-      autoprefixer: 10.4.20(postcss@8.4.49)
-      babel-loader: 9.2.1(@babel/core@7.26.0)(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15)))
-      browserslist: 4.24.4
-      copy-webpack-plugin: 12.0.2(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15)))
-      css-loader: 7.1.2(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15)))
-      esbuild-wasm: 0.24.2
-      fast-glob: 3.3.3
-      http-proxy-middleware: 3.0.3
-      istanbul-lib-instrument: 6.0.3
-      jsonc-parser: 3.3.1
-      karma-source-map-support: 1.4.0
-      less: 4.2.1
-      less-loader: 12.2.0(less@4.2.1)(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15)))
-      license-webpack-plugin: 4.0.2(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15)))
-      loader-utils: 3.3.1
-      mini-css-extract-plugin: 2.9.2(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15)))
-      open: 10.1.0
-      ora: 5.4.1
-      picomatch: 4.0.2
-      piscina: 4.8.0
-      postcss: 8.4.49
-      postcss-loader: 8.1.1(postcss@8.4.49)(typescript@5.7.3)(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15)))
-      resolve-url-loader: 5.0.0
-      rxjs: 7.8.1
-      sass: 1.83.1
-      sass-loader: 16.0.4(sass@1.83.1)(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15)))
-      semver: 7.6.3
-      source-map-loader: 5.0.0(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15)))
-      source-map-support: 0.5.21
-      terser: 5.37.0
-      tree-kill: 1.2.2
-      tslib: 2.8.1
-      typescript: 5.7.3
-      webpack: 5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))(esbuild@0.24.2)
-      webpack-dev-middleware: 7.4.2(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15)))
-      webpack-dev-server: 5.2.0(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15)))
-      webpack-merge: 6.0.1
-      webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.6.0(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))))(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15)))
-    optionalDependencies:
-      esbuild: 0.24.2
-      jest: 29.7.0(@types/node@22.13.17)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3))
-      jest-environment-jsdom: 29.7.0
-      ng-packagr: 16.2.3(@angular/compiler-cli@19.1.4(@angular/compiler@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.7.3))(tslib@2.8.1)(typescript@5.7.3)
-    transitivePeerDependencies:
-      - '@angular/compiler'
-      - '@rspack/core'
-      - '@swc/core'
-      - '@types/node'
-      - bufferutil
-      - chokidar
-      - debug
-      - html-webpack-plugin
-      - jiti
-      - lightningcss
-      - node-sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - tsx
-      - uglify-js
-      - utf-8-validate
-      - vite
-      - webpack-cli
-      - yaml
-
-  '@angular-devkit/build-webpack@0.1901.6(chokidar@4.0.3)(webpack-dev-server@5.2.0(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))))(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15)))':
+  '@angular-devkit/build-webpack@0.1901.6(chokidar@4.0.3)(webpack-dev-server@5.2.0(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))(esbuild@0.24.2)))(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))(esbuild@0.24.2))':
     dependencies:
       '@angular-devkit/architect': 0.1901.6(chokidar@4.0.3)
       rxjs: 7.8.1
       webpack: 5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))(esbuild@0.24.2)
-      webpack-dev-server: 5.2.0(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15)))
+      webpack-dev-server: 5.2.0(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))(esbuild@0.24.2))
     transitivePeerDependencies:
       - chokidar
 
@@ -15977,15 +15888,6 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular-eslint/builder@19.0.2(chokidar@4.0.3)(eslint@8.57.1)(typescript@5.7.3)':
-    dependencies:
-      '@angular-devkit/architect': 0.1901.6(chokidar@4.0.3)
-      '@angular-devkit/core': 19.1.6(chokidar@4.0.3)
-      eslint: 8.57.1
-      typescript: 5.7.3
-    transitivePeerDependencies:
-      - chokidar
-
   '@angular-eslint/bundled-angular-compiler@19.0.2': {}
 
   '@angular-eslint/eslint-plugin-template@19.0.2(@typescript-eslint/types@8.29.0)(@typescript-eslint/utils@8.29.0(eslint@8.57.0)(typescript@5.7.3))(eslint@8.57.0)(typescript@5.7.3)':
@@ -15999,31 +15901,12 @@ snapshots:
       eslint: 8.57.0
       typescript: 5.7.3
 
-  '@angular-eslint/eslint-plugin-template@19.0.2(@typescript-eslint/types@8.29.0)(@typescript-eslint/utils@8.29.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3)':
-    dependencies:
-      '@angular-eslint/bundled-angular-compiler': 19.0.2
-      '@angular-eslint/utils': 19.0.2(@typescript-eslint/utils@8.29.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3)
-      '@typescript-eslint/types': 8.29.0
-      '@typescript-eslint/utils': 8.29.0(eslint@8.57.1)(typescript@5.7.3)
-      aria-query: 5.3.2
-      axobject-query: 4.1.0
-      eslint: 8.57.1
-      typescript: 5.7.3
-
   '@angular-eslint/eslint-plugin@19.0.2(@typescript-eslint/utils@8.29.0(eslint@8.57.0)(typescript@5.7.3))(eslint@8.57.0)(typescript@5.7.3)':
     dependencies:
       '@angular-eslint/bundled-angular-compiler': 19.0.2
       '@angular-eslint/utils': 19.0.2(@typescript-eslint/utils@8.29.0(eslint@8.57.0)(typescript@5.7.3))(eslint@8.57.0)(typescript@5.7.3)
       '@typescript-eslint/utils': 8.29.0(eslint@8.57.0)(typescript@5.7.3)
       eslint: 8.57.0
-      typescript: 5.7.3
-
-  '@angular-eslint/eslint-plugin@19.0.2(@typescript-eslint/utils@8.29.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3)':
-    dependencies:
-      '@angular-eslint/bundled-angular-compiler': 19.0.2
-      '@angular-eslint/utils': 19.0.2(@typescript-eslint/utils@8.29.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3)
-      '@typescript-eslint/utils': 8.29.0(eslint@8.57.1)(typescript@5.7.3)
-      eslint: 8.57.1
       typescript: 5.7.3
 
   '@angular-eslint/schematics@19.0.2(@typescript-eslint/types@8.29.0)(@typescript-eslint/utils@8.29.0(eslint@8.57.0)(typescript@5.7.3))(chokidar@4.0.3)(eslint@8.57.0)(typescript@5.7.3)':
@@ -16042,33 +15925,10 @@ snapshots:
       - eslint
       - typescript
 
-  '@angular-eslint/schematics@19.0.2(@typescript-eslint/types@8.29.0)(@typescript-eslint/utils@8.29.0(eslint@8.57.1)(typescript@5.7.3))(chokidar@4.0.3)(eslint@8.57.1)(typescript@5.7.3)':
-    dependencies:
-      '@angular-devkit/core': 19.1.6(chokidar@4.0.3)
-      '@angular-devkit/schematics': 19.1.6(chokidar@4.0.3)
-      '@angular-eslint/eslint-plugin': 19.0.2(@typescript-eslint/utils@8.29.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3)
-      '@angular-eslint/eslint-plugin-template': 19.0.2(@typescript-eslint/types@8.29.0)(@typescript-eslint/utils@8.29.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3)
-      ignore: 6.0.2
-      semver: 7.6.3
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - '@typescript-eslint/types'
-      - '@typescript-eslint/utils'
-      - chokidar
-      - eslint
-      - typescript
-
   '@angular-eslint/template-parser@19.0.2(eslint@8.57.0)(typescript@5.7.3)':
     dependencies:
       '@angular-eslint/bundled-angular-compiler': 19.0.2
       eslint: 8.57.0
-      eslint-scope: 8.2.0
-      typescript: 5.7.3
-
-  '@angular-eslint/template-parser@19.0.2(eslint@8.57.1)(typescript@5.7.3)':
-    dependencies:
-      '@angular-eslint/bundled-angular-compiler': 19.0.2
-      eslint: 8.57.1
       eslint-scope: 8.2.0
       typescript: 5.7.3
 
@@ -16077,13 +15937,6 @@ snapshots:
       '@angular-eslint/bundled-angular-compiler': 19.0.2
       '@typescript-eslint/utils': 8.29.0(eslint@8.57.0)(typescript@5.7.3)
       eslint: 8.57.0
-      typescript: 5.7.3
-
-  '@angular-eslint/utils@19.0.2(@typescript-eslint/utils@8.29.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3)':
-    dependencies:
-      '@angular-eslint/bundled-angular-compiler': 19.0.2
-      '@typescript-eslint/utils': 8.29.0(eslint@8.57.1)(typescript@5.7.3)
-      eslint: 8.57.1
       typescript: 5.7.3
 
   '@angular/animations@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0))':
@@ -16126,55 +15979,6 @@ snapshots:
       less: 4.2.1
       lmdb: 3.2.2
       ng-packagr: 16.2.3(@angular/compiler-cli@19.1.4(@angular/compiler@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.7.3))(tslib@2.6.3)(typescript@5.7.3)
-      postcss: 8.4.49
-    transitivePeerDependencies:
-      - '@types/node'
-      - chokidar
-      - jiti
-      - lightningcss
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  '@angular/build@19.1.6(@angular/compiler-cli@19.1.4(@angular/compiler@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.7.3))(@angular/compiler@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(@types/node@22.13.17)(chokidar@4.0.3)(jiti@1.21.0)(less@4.2.1)(ng-packagr@16.2.3(@angular/compiler-cli@19.1.4(@angular/compiler@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.7.3))(tslib@2.8.1)(typescript@5.7.3))(postcss@8.4.49)(terser@5.37.0)(typescript@5.7.3)(yaml@2.4.5)':
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@angular-devkit/architect': 0.1901.6(chokidar@4.0.3)
-      '@angular-devkit/core': 19.1.6(chokidar@4.0.3)
-      '@angular/compiler': 19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0))
-      '@angular/compiler-cli': 19.1.4(@angular/compiler@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.7.3)
-      '@babel/core': 7.26.0
-      '@babel/helper-annotate-as-pure': 7.25.9
-      '@babel/helper-split-export-declaration': 7.24.7
-      '@babel/plugin-syntax-import-attributes': 7.26.0(@babel/core@7.26.0)
-      '@inquirer/confirm': 5.1.1(@types/node@22.13.17)
-      '@vitejs/plugin-basic-ssl': 1.2.0(vite@6.0.11(@types/node@22.13.17)(jiti@1.21.0)(less@4.2.1)(sass@1.83.1)(terser@5.37.0)(yaml@2.4.5))
-      beasties: 0.2.0
-      browserslist: 4.24.4
-      esbuild: 0.24.2
-      fast-glob: 3.3.3
-      https-proxy-agent: 7.0.6
-      istanbul-lib-instrument: 6.0.3
-      listr2: 8.2.5
-      magic-string: 0.30.17
-      mrmime: 2.0.0
-      parse5-html-rewriting-stream: 7.0.0
-      picomatch: 4.0.2
-      piscina: 4.8.0
-      rollup: 4.30.1
-      sass: 1.83.1
-      semver: 7.6.3
-      typescript: 5.7.3
-      vite: 6.0.11(@types/node@22.13.17)(jiti@1.21.0)(less@4.2.1)(sass@1.83.1)(terser@5.37.0)(yaml@2.4.5)
-      watchpack: 2.4.2
-    optionalDependencies:
-      less: 4.2.1
-      lmdb: 3.2.2
-      ng-packagr: 16.2.3(@angular/compiler-cli@19.1.4(@angular/compiler@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.7.3))(tslib@2.8.1)(typescript@5.7.3)
       postcss: 8.4.49
     transitivePeerDependencies:
       - '@types/node'
@@ -16308,7 +16112,7 @@ snapshots:
 
   '@babel/compat-data@7.26.5': {}
 
-  '@babel/compat-data@7.27.1':
+  '@babel/compat-data@7.27.7':
     optional: true
 
   '@babel/core@7.26.0':
@@ -16335,16 +16139,16 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.27.1
-      '@babel/helper-compilation-targets': 7.27.1
-      '@babel/helper-module-transforms': 7.27.1(@babel/core@7.26.10)
-      '@babel/helpers': 7.27.1
-      '@babel/parser': 7.27.1
-      '@babel/template': 7.27.1
-      '@babel/traverse': 7.27.1
-      '@babel/types': 7.27.1
+      '@babel/generator': 7.27.5
+      '@babel/helper-compilation-targets': 7.27.2
+      '@babel/helper-module-transforms': 7.27.3(@babel/core@7.26.10)
+      '@babel/helpers': 7.27.6
+      '@babel/parser': 7.27.7
+      '@babel/template': 7.27.2
+      '@babel/traverse': 7.27.7
+      '@babel/types': 7.27.7
       convert-source-map: 2.0.0
-      debug: 4.4.0
+      debug: 4.4.1
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -16376,12 +16180,12 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 3.1.0
 
-  '@babel/generator@7.27.1':
+  '@babel/generator@7.27.5':
     dependencies:
-      '@babel/parser': 7.27.1
-      '@babel/types': 7.27.1
-      '@jridgewell/gen-mapping': 0.3.8
-      '@jridgewell/trace-mapping': 0.3.25
+      '@babel/parser': 7.27.7
+      '@babel/types': 7.27.7
+      '@jridgewell/gen-mapping': 0.3.11
+      '@jridgewell/trace-mapping': 0.3.28
       jsesc: 3.1.0
     optional: true
 
@@ -16405,9 +16209,9 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-compilation-targets@7.27.1':
+  '@babel/helper-compilation-targets@7.27.2':
     dependencies:
-      '@babel/compat-data': 7.27.1
+      '@babel/compat-data': 7.27.7
       '@babel/helper-validator-option': 7.27.1
       browserslist: 4.24.4
       lru-cache: 5.1.1
@@ -16514,8 +16318,8 @@ snapshots:
 
   '@babel/helper-module-imports@7.27.1':
     dependencies:
-      '@babel/traverse': 7.27.1
-      '@babel/types': 7.27.1
+      '@babel/traverse': 7.27.7
+      '@babel/types': 7.27.7
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -16529,12 +16333,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.27.1(@babel/core@7.26.10)':
+  '@babel/helper-module-transforms@7.27.3(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-module-imports': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
-      '@babel/traverse': 7.27.1
+      '@babel/traverse': 7.27.7
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -16633,10 +16437,10 @@ snapshots:
       '@babel/template': 7.25.9
       '@babel/types': 7.27.0
 
-  '@babel/helpers@7.27.1':
+  '@babel/helpers@7.27.6':
     dependencies:
-      '@babel/template': 7.27.1
-      '@babel/types': 7.27.1
+      '@babel/template': 7.27.2
+      '@babel/types': 7.27.7
     optional: true
 
   '@babel/highlight@7.23.4':
@@ -16664,9 +16468,9 @@ snapshots:
     dependencies:
       '@babel/types': 7.27.0
 
-  '@babel/parser@7.27.1':
+  '@babel/parser@7.27.7':
     dependencies:
-      '@babel/types': 7.27.1
+      '@babel/types': 7.27.7
 
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.25.9(@babel/core@7.26.0)':
     dependencies:
@@ -17427,11 +17231,11 @@ snapshots:
       '@babel/parser': 7.27.0
       '@babel/types': 7.27.0
 
-  '@babel/template@7.27.1':
+  '@babel/template@7.27.2':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/parser': 7.27.1
-      '@babel/types': 7.27.1
+      '@babel/parser': 7.27.7
+      '@babel/types': 7.27.7
     optional: true
 
   '@babel/traverse@7.24.8':
@@ -17461,14 +17265,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/traverse@7.27.1':
+  '@babel/traverse@7.27.7':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.27.1
-      '@babel/parser': 7.27.1
-      '@babel/template': 7.27.1
-      '@babel/types': 7.27.1
-      debug: 4.4.0
+      '@babel/generator': 7.27.5
+      '@babel/parser': 7.27.7
+      '@babel/template': 7.27.2
+      '@babel/types': 7.27.7
+      debug: 4.4.1
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -17490,7 +17294,7 @@ snapshots:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
 
-  '@babel/types@7.27.1':
+  '@babel/types@7.27.7':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
@@ -17625,99 +17429,114 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@descope-ui/common@0.0.11':
+  '@descope-ui/common@0.0.16':
     dependencies:
       color: 4.2.3
       element-internals-polyfill: 1.3.11
       lodash.debounce: 4.0.8
       lodash.merge: 4.6.2
 
-  '@descope-ui/descope-address-field@0.0.11':
+  '@descope-ui/descope-address-field@0.0.18':
     dependencies:
-      '@descope-ui/common': 0.0.11
-      '@descope-ui/descope-autocomplete-field': 0.0.12
-      '@descope-ui/theme-input-wrapper': 0.0.11
+      '@descope-ui/common': 0.0.16
+      '@descope-ui/descope-autocomplete-field': 0.0.19
+      '@descope-ui/theme-input-wrapper': 0.1.6
       '@vaadin/custom-field': 24.3.4
 
-  '@descope-ui/descope-autocomplete-field@0.0.12':
+  '@descope-ui/descope-autocomplete-field@0.0.19':
     dependencies:
-      '@descope-ui/common': 0.0.11
-      '@descope-ui/descope-combo-box': 0.0.13
-      '@descope-ui/theme-globals': 0.0.11
-      '@descope-ui/theme-input-wrapper': 0.0.11
+      '@descope-ui/common': 0.0.16
+      '@descope-ui/descope-combo-box': 0.1.6
+      '@descope-ui/theme-globals': 0.0.17
+      '@descope-ui/theme-input-wrapper': 0.1.6
       '@vaadin/custom-field': 24.3.4
 
-  '@descope-ui/descope-avatar@0.0.11':
+  '@descope-ui/descope-avatar@0.0.17':
     dependencies:
-      '@descope-ui/common': 0.0.11
-      '@descope-ui/theme-globals': 0.0.11
+      '@descope-ui/common': 0.0.16
+      '@descope-ui/theme-globals': 0.0.17
       '@vaadin/avatar': 24.3.4
       '@vaadin/icon': 24.3.4
       '@vaadin/icons': 24.3.4
 
-  '@descope-ui/descope-button@0.0.7':
+  '@descope-ui/descope-button@0.0.15':
     dependencies:
-      '@descope-ui/common': 0.0.11
-      '@descope-ui/descope-icon': 0.0.6
-      '@descope-ui/theme-globals': 0.0.11
+      '@descope-ui/common': 0.0.16
+      '@descope-ui/descope-icon': 0.0.14
+      '@descope-ui/theme-globals': 0.0.17
       '@vaadin/button': 24.3.4
 
-  '@descope-ui/descope-collapsible-container@0.0.6':
+  '@descope-ui/descope-collapsible-container@0.0.14':
     dependencies:
-      '@descope-ui/common': 0.0.11
-      '@descope-ui/descope-icon': 0.0.6
-      '@descope-ui/descope-text': 0.0.11
-      '@descope-ui/theme-globals': 0.0.11
+      '@descope-ui/common': 0.0.16
+      '@descope-ui/descope-icon': 0.0.14
+      '@descope-ui/descope-text': 0.0.17
+      '@descope-ui/theme-globals': 0.0.17
 
-  '@descope-ui/descope-combo-box@0.0.13':
+  '@descope-ui/descope-combo-box@0.1.6':
     dependencies:
-      '@descope-ui/common': 0.0.11
-      '@descope-ui/theme-globals': 0.0.11
-      '@descope-ui/theme-input-wrapper': 0.0.11
+      '@descope-ui/common': 0.0.16
+      '@descope-ui/theme-globals': 0.0.17
+      '@descope-ui/theme-input-wrapper': 0.1.6
       '@vaadin/combo-box': 24.3.4
 
-  '@descope-ui/descope-icon@0.0.6':
+  '@descope-ui/descope-icon@0.0.14':
     dependencies:
-      '@descope-ui/common': 0.0.11
-      '@descope-ui/theme-globals': 0.0.11
+      '@descope-ui/common': 0.0.16
+      '@descope-ui/descope-image': 0.0.8
+      '@descope-ui/theme-globals': 0.0.17
       '@vaadin/icon': 24.3.4
-      dompurify: 3.2.4
+      dompurify: 3.2.6
 
-  '@descope-ui/descope-password-strength@0.0.3':
+  '@descope-ui/descope-image@0.0.8':
     dependencies:
-      '@descope-ui/common': 0.0.11
-      '@descope-ui/theme-globals': 0.0.11
-      '@descope-ui/theme-input-wrapper': 0.0.11
+      '@descope-ui/common': 0.0.16
+      '@descope-ui/theme-globals': 0.0.17
+      dompurify: 3.2.6
+
+  '@descope-ui/descope-password-strength@0.0.10':
+    dependencies:
+      '@descope-ui/common': 0.0.16
+      '@descope-ui/theme-globals': 0.0.17
+      '@descope-ui/theme-input-wrapper': 0.1.6
       '@zxcvbn-ts/core': 3.0.4
       '@zxcvbn-ts/language-common': 3.0.4
       '@zxcvbn-ts/language-en': 3.0.2
 
-  '@descope-ui/descope-text@0.0.11':
+  '@descope-ui/descope-recovery-codes@0.0.3':
     dependencies:
-      '@descope-ui/common': 0.0.11
-      '@descope-ui/theme-globals': 0.0.11
+      '@descope-ui/common': 0.0.16
+      '@descope-ui/descope-text': 0.0.17
+      '@descope-ui/theme-globals': 0.0.17
+      '@vaadin/icon': 24.3.4
+      '@vaadin/icons': 24.3.4
 
-  '@descope-ui/descope-timer-button@0.0.7':
+  '@descope-ui/descope-text@0.0.17':
     dependencies:
-      '@descope-ui/common': 0.0.11
-      '@descope-ui/descope-button': 0.0.7
-      '@descope-ui/descope-timer': 0.0.5
-      '@descope-ui/theme-globals': 0.0.11
+      '@descope-ui/common': 0.0.16
+      '@descope-ui/theme-globals': 0.0.17
 
-  '@descope-ui/descope-timer@0.0.5':
+  '@descope-ui/descope-timer-button@0.0.15':
     dependencies:
-      '@descope-ui/common': 0.0.11
-      '@descope-ui/descope-icon': 0.0.6
-      '@descope-ui/theme-globals': 0.0.11
+      '@descope-ui/common': 0.0.16
+      '@descope-ui/descope-button': 0.0.15
+      '@descope-ui/descope-timer': 0.0.13
+      '@descope-ui/theme-globals': 0.0.17
 
-  '@descope-ui/theme-globals@0.0.11':
+  '@descope-ui/descope-timer@0.0.13':
     dependencies:
-      '@descope-ui/common': 0.0.11
+      '@descope-ui/common': 0.0.16
+      '@descope-ui/descope-icon': 0.0.14
+      '@descope-ui/theme-globals': 0.0.17
 
-  '@descope-ui/theme-input-wrapper@0.0.11':
+  '@descope-ui/theme-globals@0.0.17':
     dependencies:
-      '@descope-ui/common': 0.0.11
-      '@descope-ui/theme-globals': 0.0.11
+      '@descope-ui/common': 0.0.16
+
+  '@descope-ui/theme-input-wrapper@0.1.6':
+    dependencies:
+      '@descope-ui/common': 0.0.16
+      '@descope-ui/theme-globals': 0.0.17
 
   '@descope/core-js-sdk@2.31.0':
     dependencies:
@@ -17727,6 +17546,10 @@ snapshots:
     dependencies:
       jwt-decode: 4.0.0
     optional: true
+
+  '@descope/core-js-sdk@2.44.3':
+    dependencies:
+      jwt-decode: 4.0.0
 
   '@descope/nextjs-sdk@file:packages/sdks/nextjs-sdk(@types/react@19.1.0)(next@14.2.10(@babel/core@7.26.0)(@playwright/test@1.47.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.83.1))(react@18.3.1)':
     dependencies:
@@ -17756,6 +17579,15 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  '@descope/node-sdk@0.0.0-next-ef3a9371-20250701(encoding@0.1.13)':
+    dependencies:
+      '@descope/core-js-sdk': 2.44.3
+      cross-fetch: 4.0.0(encoding@0.1.13)
+      jose: 5.2.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - encoding
+
   '@descope/node-sdk@1.6.13(encoding@0.1.13)':
     dependencies:
       '@descope/core-js-sdk': 2.31.0
@@ -17765,20 +17597,22 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@descope/web-components-ui@1.76.0':
+  '@descope/web-components-ui@1.104.0':
     dependencies:
-      '@descope-ui/common': 0.0.11
-      '@descope-ui/descope-address-field': 0.0.11
-      '@descope-ui/descope-autocomplete-field': 0.0.12
-      '@descope-ui/descope-avatar': 0.0.11
-      '@descope-ui/descope-button': 0.0.7
-      '@descope-ui/descope-collapsible-container': 0.0.6
-      '@descope-ui/descope-combo-box': 0.0.13
-      '@descope-ui/descope-icon': 0.0.6
-      '@descope-ui/descope-password-strength': 0.0.3
-      '@descope-ui/descope-text': 0.0.11
-      '@descope-ui/descope-timer': 0.0.5
-      '@descope-ui/descope-timer-button': 0.0.7
+      '@descope-ui/common': 0.0.16
+      '@descope-ui/descope-address-field': 0.0.18
+      '@descope-ui/descope-autocomplete-field': 0.0.19
+      '@descope-ui/descope-avatar': 0.0.17
+      '@descope-ui/descope-button': 0.0.15
+      '@descope-ui/descope-collapsible-container': 0.0.14
+      '@descope-ui/descope-combo-box': 0.1.6
+      '@descope-ui/descope-icon': 0.0.14
+      '@descope-ui/descope-image': 0.0.8
+      '@descope-ui/descope-password-strength': 0.0.10
+      '@descope-ui/descope-recovery-codes': 0.0.3
+      '@descope-ui/descope-text': 0.0.17
+      '@descope-ui/descope-timer': 0.0.13
+      '@descope-ui/descope-timer-button': 0.0.15
       '@vaadin/checkbox': 24.3.4
       '@vaadin/custom-field': 24.3.4
       '@vaadin/dialog': 24.3.4
@@ -18204,11 +18038,6 @@ snapshots:
   '@esbuild/win32-x64@0.25.3':
     optional: true
 
-  '@eslint-community/eslint-utils@4.4.0(eslint@7.32.0)':
-    dependencies:
-      eslint: 7.32.0
-      eslint-visitor-keys: 3.4.3
-
   '@eslint-community/eslint-utils@4.4.0(eslint@8.57.0)':
     dependencies:
       eslint: 8.57.0
@@ -18229,19 +18058,9 @@ snapshots:
       eslint: 8.57.0
       eslint-visitor-keys: 3.4.3
 
-  '@eslint-community/eslint-utils@4.5.1(eslint@8.57.1)':
+  '@eslint-community/eslint-utils@4.7.0(eslint@7.32.0)':
     dependencies:
-      eslint: 8.57.1
-      eslint-visitor-keys: 3.4.3
-
-  '@eslint-community/eslint-utils@4.6.1(eslint@8.57.1)':
-    dependencies:
-      eslint: 8.57.1
-      eslint-visitor-keys: 3.4.3
-
-  '@eslint-community/eslint-utils@4.6.1(eslint@9.18.0(jiti@1.21.0))':
-    dependencies:
-      eslint: 9.18.0(jiti@1.21.0)
+      eslint: 7.32.0
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/eslint-utils@4.7.0(eslint@8.57.0)':
@@ -18252,6 +18071,11 @@ snapshots:
   '@eslint-community/eslint-utils@4.7.0(eslint@8.57.1)':
     dependencies:
       eslint: 8.57.1
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/eslint-utils@4.7.0(eslint@9.18.0(jiti@1.21.0))':
+    dependencies:
+      eslint: 9.18.0(jiti@1.21.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.10.0': {}
@@ -19024,6 +18848,12 @@ snapshots:
       '@types/yargs': 17.0.24
       chalk: 4.1.2
 
+  '@jridgewell/gen-mapping@0.3.11':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.3
+      '@jridgewell/trace-mapping': 0.3.28
+    optional: true
+
   '@jridgewell/gen-mapping@0.3.5':
     dependencies:
       '@jridgewell/set-array': 1.2.1
@@ -19038,6 +18868,9 @@ snapshots:
 
   '@jridgewell/resolve-uri@3.1.1': {}
 
+  '@jridgewell/resolve-uri@3.1.2':
+    optional: true
+
   '@jridgewell/set-array@1.2.1': {}
 
   '@jridgewell/source-map@0.3.3':
@@ -19049,10 +18882,19 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
+  '@jridgewell/sourcemap-codec@1.5.3':
+    optional: true
+
   '@jridgewell/trace-mapping@0.3.25':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  '@jridgewell/trace-mapping@0.3.28':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.3
+    optional: true
 
   '@jridgewell/trace-mapping@0.3.9':
     dependencies:
@@ -19105,9 +18947,15 @@ snapshots:
 
   '@lit-labs/ssr-dom-shim@1.2.1': {}
 
+  '@lit-labs/ssr-dom-shim@1.3.0': {}
+
   '@lit/reactive-element@2.0.4':
     dependencies:
       '@lit-labs/ssr-dom-shim': 1.2.1
+
+  '@lit/reactive-element@2.1.0':
+    dependencies:
+      '@lit-labs/ssr-dom-shim': 1.3.0
 
   '@lmdb/lmdb-darwin-arm64@3.2.2':
     optional: true
@@ -19126,6 +18974,12 @@ snapshots:
 
   '@lmdb/lmdb-win32-x64@3.2.2':
     optional: true
+
+  '@modelcontextprotocol/sdk@0.5.0':
+    dependencies:
+      content-type: 1.0.5
+      raw-body: 3.0.0
+      zod: 3.25.67
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     optional: true
@@ -19367,7 +19221,7 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.2.4':
     optional: true
 
-  '@ngtools/webpack@19.1.6(@angular/compiler-cli@19.1.4(@angular/compiler@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.7.3))(typescript@5.7.3)(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15)))':
+  '@ngtools/webpack@19.1.6(@angular/compiler-cli@19.1.4(@angular/compiler@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.7.3))(typescript@5.7.3)(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))(esbuild@0.24.2))':
     dependencies:
       '@angular/compiler-cli': 19.1.4(@angular/compiler@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.7.3)
       typescript: 5.7.3
@@ -19470,9 +19324,9 @@ snapshots:
     transitivePeerDependencies:
       - nx
 
-  '@nrwl/eslint-plugin-nx@19.8.4(@babel/traverse@7.27.1)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@typescript-eslint/parser@7.2.0(eslint@9.18.0(jiti@1.21.0))(typescript@5.7.3))(eslint-config-prettier@9.1.0(eslint@9.18.0(jiti@1.21.0)))(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)':
+  '@nrwl/eslint-plugin-nx@19.8.4(@babel/traverse@7.27.7)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@typescript-eslint/parser@7.2.0(eslint@9.18.0(jiti@1.21.0))(typescript@5.7.3))(eslint-config-prettier@9.1.0(eslint@9.18.0(jiti@1.21.0)))(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)':
     dependencies:
-      '@nx/eslint-plugin': 19.8.4(@babel/traverse@7.27.1)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@typescript-eslint/parser@7.2.0(eslint@9.18.0(jiti@1.21.0))(typescript@5.7.3))(eslint-config-prettier@9.1.0(eslint@9.18.0(jiti@1.21.0)))(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)
+      '@nx/eslint-plugin': 19.8.4(@babel/traverse@7.27.7)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@typescript-eslint/parser@7.2.0(eslint@9.18.0(jiti@1.21.0))(typescript@5.7.3))(eslint-config-prettier@9.1.0(eslint@9.18.0(jiti@1.21.0)))(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -19488,9 +19342,9 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nrwl/jest@19.8.4(@babel/traverse@7.27.1)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3))(typescript@5.7.3)':
+  '@nrwl/jest@19.8.4(@babel/traverse@7.27.7)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3))(typescript@5.7.3)':
     dependencies:
-      '@nx/jest': 19.8.4(@babel/traverse@7.27.1)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3))(typescript@5.7.3)
+      '@nx/jest': 19.8.4(@babel/traverse@7.27.7)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3))(typescript@5.7.3)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -19506,9 +19360,9 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nrwl/js@19.8.4(@babel/traverse@7.27.1)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)':
+  '@nrwl/js@19.8.4(@babel/traverse@7.27.7)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.4.5)':
     dependencies:
-      '@nx/js': 19.8.4(@babel/traverse@7.27.1)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)
+      '@nx/js': 19.8.4(@babel/traverse@7.27.7)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.4.5)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -19521,9 +19375,24 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nrwl/linter@19.8.4(@babel/traverse@7.27.1)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@zkochan/js-yaml@0.0.7)(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))':
+  '@nrwl/js@19.8.4(@babel/traverse@7.27.7)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)':
     dependencies:
-      '@nx/eslint': 19.8.4(@babel/traverse@7.27.1)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@zkochan/js-yaml@0.0.7)(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))
+      '@nx/js': 19.8.4(@babel/traverse@7.27.7)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)
+    transitivePeerDependencies:
+      - '@babel/traverse'
+      - '@swc-node/register'
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - debug
+      - nx
+      - supports-color
+      - typescript
+      - verdaccio
+
+  '@nrwl/linter@19.8.4(@babel/traverse@7.27.7)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@zkochan/js-yaml@0.0.7)(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))':
+    dependencies:
+      '@nx/eslint': 19.8.4(@babel/traverse@7.27.7)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@zkochan/js-yaml@0.0.7)(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -19602,12 +19471,12 @@ snapshots:
       tslib: 2.8.1
       yargs-parser: 21.1.1
 
-  '@nx/eslint-plugin@19.8.4(@babel/traverse@7.27.1)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@typescript-eslint/parser@7.2.0(eslint@9.18.0(jiti@1.21.0))(typescript@5.7.3))(eslint-config-prettier@9.1.0(eslint@9.18.0(jiti@1.21.0)))(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)':
+  '@nx/eslint-plugin@19.8.4(@babel/traverse@7.27.7)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@typescript-eslint/parser@7.2.0(eslint@9.18.0(jiti@1.21.0))(typescript@5.7.3))(eslint-config-prettier@9.1.0(eslint@9.18.0(jiti@1.21.0)))(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)':
     dependencies:
       '@eslint/compat': 1.2.6(eslint@9.18.0(jiti@1.21.0))
-      '@nrwl/eslint-plugin-nx': 19.8.4(@babel/traverse@7.27.1)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@typescript-eslint/parser@7.2.0(eslint@9.18.0(jiti@1.21.0))(typescript@5.7.3))(eslint-config-prettier@9.1.0(eslint@9.18.0(jiti@1.21.0)))(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)
+      '@nrwl/eslint-plugin-nx': 19.8.4(@babel/traverse@7.27.7)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@typescript-eslint/parser@7.2.0(eslint@9.18.0(jiti@1.21.0))(typescript@5.7.3))(eslint-config-prettier@9.1.0(eslint@9.18.0(jiti@1.21.0)))(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)
       '@nx/devkit': 19.8.4(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))
-      '@nx/js': 19.8.4(@babel/traverse@7.27.1)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)
+      '@nx/js': 19.8.4(@babel/traverse@7.27.7)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)
       '@typescript-eslint/parser': 7.2.0(eslint@9.18.0(jiti@1.21.0))(typescript@5.7.3)
       '@typescript-eslint/type-utils': 8.23.0(eslint@9.18.0(jiti@1.21.0))(typescript@5.7.3)
       '@typescript-eslint/utils': 8.23.0(eslint@9.18.0(jiti@1.21.0))(typescript@5.7.3)
@@ -19632,11 +19501,11 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/eslint@19.8.4(@babel/traverse@7.27.1)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@zkochan/js-yaml@0.0.7)(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))':
+  '@nx/eslint@19.8.4(@babel/traverse@7.27.7)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@zkochan/js-yaml@0.0.7)(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))':
     dependencies:
       '@nx/devkit': 19.8.4(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))
-      '@nx/js': 19.8.4(@babel/traverse@7.27.1)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.4.5)
-      '@nx/linter': 19.8.4(@babel/traverse@7.27.1)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@zkochan/js-yaml@0.0.7)(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))
+      '@nx/js': 19.8.4(@babel/traverse@7.27.7)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.4.5)
+      '@nx/linter': 19.8.4(@babel/traverse@7.27.7)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@zkochan/js-yaml@0.0.7)(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))
       eslint: 9.18.0(jiti@1.21.0)
       semver: 7.7.1
       tslib: 2.8.1
@@ -19654,13 +19523,13 @@ snapshots:
       - supports-color
       - verdaccio
 
-  '@nx/jest@19.8.4(@babel/traverse@7.27.1)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3))(typescript@5.7.3)':
+  '@nx/jest@19.8.4(@babel/traverse@7.27.7)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3))(typescript@5.7.3)':
     dependencies:
       '@jest/reporters': 29.7.0
       '@jest/test-result': 29.7.0
-      '@nrwl/jest': 19.8.4(@babel/traverse@7.27.1)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3))(typescript@5.7.3)
+      '@nrwl/jest': 19.8.4(@babel/traverse@7.27.7)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3))(typescript@5.7.3)
       '@nx/devkit': 19.8.4(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))
-      '@nx/js': 19.8.4(@babel/traverse@7.27.1)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)
+      '@nx/js': 19.8.4(@babel/traverse@7.27.7)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.7.3)
       chalk: 4.1.2
       identity-obj-proxy: 3.0.0
@@ -19687,7 +19556,7 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/js@19.8.4(@babel/traverse@7.27.1)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.4.5)':
+  '@nx/js@19.8.4(@babel/traverse@7.27.7)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.4.5)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-proposal-decorators': 7.23.5(@babel/core@7.26.0)
@@ -19696,12 +19565,12 @@ snapshots:
       '@babel/preset-env': 7.26.0(@babel/core@7.26.0)
       '@babel/preset-typescript': 7.26.0(@babel/core@7.26.0)
       '@babel/runtime': 7.25.6
-      '@nrwl/js': 19.8.4(@babel/traverse@7.27.1)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)
+      '@nrwl/js': 19.8.4(@babel/traverse@7.27.7)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.4.5)
       '@nx/devkit': 19.8.4(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))
       '@nx/workspace': 19.8.4(@swc/core@1.7.1(@swc/helpers@0.5.15))
       babel-plugin-const-enum: 1.2.0(@babel/core@7.26.0)
       babel-plugin-macros: 2.8.0
-      babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.26.0)(@babel/traverse@7.27.1)
+      babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.26.0)(@babel/traverse@7.27.7)
       chalk: 4.1.2
       columnify: 1.6.0
       detect-port: 1.5.1
@@ -19730,7 +19599,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@nx/js@19.8.4(@babel/traverse@7.27.1)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)':
+  '@nx/js@19.8.4(@babel/traverse@7.27.7)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-proposal-decorators': 7.23.5(@babel/core@7.26.0)
@@ -19739,12 +19608,12 @@ snapshots:
       '@babel/preset-env': 7.26.0(@babel/core@7.26.0)
       '@babel/preset-typescript': 7.26.0(@babel/core@7.26.0)
       '@babel/runtime': 7.25.6
-      '@nrwl/js': 19.8.4(@babel/traverse@7.27.1)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)
+      '@nrwl/js': 19.8.4(@babel/traverse@7.27.7)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)
       '@nx/devkit': 19.8.4(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))
       '@nx/workspace': 19.8.4(@swc/core@1.7.1(@swc/helpers@0.5.15))
       babel-plugin-const-enum: 1.2.0(@babel/core@7.26.0)
       babel-plugin-macros: 2.8.0
-      babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.26.0)(@babel/traverse@7.27.1)
+      babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.26.0)(@babel/traverse@7.27.7)
       chalk: 4.1.2
       columnify: 1.6.0
       detect-port: 1.5.1
@@ -19773,9 +19642,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@nx/linter@19.8.4(@babel/traverse@7.27.1)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@zkochan/js-yaml@0.0.7)(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))':
+  '@nx/linter@19.8.4(@babel/traverse@7.27.7)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@zkochan/js-yaml@0.0.7)(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))':
     dependencies:
-      '@nx/eslint': 19.8.4(@babel/traverse@7.27.1)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@zkochan/js-yaml@0.0.7)(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))
+      '@nx/eslint': 19.8.4(@babel/traverse@7.27.7)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@zkochan/js-yaml@0.0.7)(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -19999,6 +19868,10 @@ snapshots:
     dependencies:
       '@webcomponents/shadycss': 1.11.2
 
+  '@polymer/polymer@3.5.2':
+    dependencies:
+      '@webcomponents/shadycss': 1.11.2
+
   '@reduxjs/toolkit@2.0.1(react@18.3.1)':
     dependencies:
       immer: 10.0.3
@@ -20025,6 +19898,18 @@ snapshots:
       picomatch: 4.0.2
     optionalDependencies:
       rollup: 4.22.4
+
+  '@rollup/plugin-commonjs@28.0.2(rollup@4.34.6)':
+    dependencies:
+      '@rollup/pluginutils': 5.1.0(rollup@4.34.6)
+      commondir: 1.0.1
+      estree-walker: 2.0.2
+      fdir: 6.4.3(picomatch@4.0.2)
+      is-reference: 1.2.1
+      magic-string: 0.30.17
+      picomatch: 4.0.2
+    optionalDependencies:
+      rollup: 4.34.6
 
   '@rollup/plugin-json@6.1.0(rollup@3.29.5)':
     dependencies:
@@ -20064,6 +19949,17 @@ snapshots:
       resolve: 1.22.4
     optionalDependencies:
       rollup: 4.22.4
+
+  '@rollup/plugin-node-resolve@15.2.3(rollup@4.34.6)':
+    dependencies:
+      '@rollup/pluginutils': 5.1.0(rollup@4.34.6)
+      '@types/resolve': 1.20.2
+      deepmerge: 4.3.1
+      is-builtin-module: 3.2.1
+      is-module: 1.0.0
+      resolve: 1.22.4
+    optionalDependencies:
+      rollup: 4.34.6
 
   '@rollup/plugin-replace@5.0.2(rollup@4.22.4)':
     dependencies:
@@ -20132,6 +20028,15 @@ snapshots:
       rollup: 4.22.4
       tslib: 2.8.1
 
+  '@rollup/plugin-typescript@11.1.6(rollup@4.34.6)(tslib@2.8.1)(typescript@5.7.3)':
+    dependencies:
+      '@rollup/pluginutils': 5.1.0(rollup@4.34.6)
+      resolve: 1.22.4
+      typescript: 5.7.3
+    optionalDependencies:
+      rollup: 4.34.6
+      tslib: 2.8.1
+
   '@rollup/plugin-typescript@8.5.0(rollup@4.22.4)(tslib@2.8.1)(typescript@5.4.5)':
     dependencies:
       '@rollup/pluginutils': 3.1.0(rollup@4.22.4)
@@ -20176,6 +20081,14 @@ snapshots:
       picomatch: 2.3.1
     optionalDependencies:
       rollup: 4.22.4
+
+  '@rollup/pluginutils@5.1.0(rollup@4.34.6)':
+    dependencies:
+      '@types/estree': 1.0.6
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+    optionalDependencies:
+      rollup: 4.34.6
 
   '@rollup/pluginutils@5.1.4(rollup@4.22.4)':
     dependencies:
@@ -20949,26 +20862,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.3))(eslint@8.57.1)(typescript@5.7.3)':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@5.7.3)
-      '@typescript-eslint/scope-manager': 6.21.0
-      '@typescript-eslint/type-utils': 6.21.0(eslint@8.57.1)(typescript@5.7.3)
-      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@5.7.3)
-      '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.0
-      eslint: 8.57.1
-      graphemer: 1.4.0
-      ignore: 5.3.2
-      natural-compare: 1.4.0
-      semver: 7.7.1
-      ts-api-utils: 1.3.0(typescript@5.7.3)
-    optionalDependencies:
-      typescript: 5.7.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.4.5))(eslint@8.57.1)(typescript@5.4.5)':
     dependencies:
       '@eslint-community/regexpp': 4.11.1
@@ -21084,19 +20977,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.7.3)':
-    dependencies:
-      '@typescript-eslint/scope-manager': 6.21.0
-      '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.7.3)
-      '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.0
-      eslint: 8.57.1
-    optionalDependencies:
-      typescript: 5.7.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.4.5)':
     dependencies:
       '@typescript-eslint/scope-manager': 7.18.0
@@ -21133,6 +21013,19 @@ snapshots:
       eslint: 8.57.1
     optionalDependencies:
       typescript: 5.6.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 7.18.0
+      '@typescript-eslint/types': 7.18.0
+      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.7.3)
+      '@typescript-eslint/visitor-keys': 7.18.0
+      debug: 4.3.7
+      eslint: 8.57.1
+    optionalDependencies:
+      typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
 
@@ -21210,18 +21103,6 @@ snapshots:
       '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.7.3)
       debug: 4.4.0
       eslint: 8.57.0
-      ts-api-utils: 1.3.0(typescript@5.7.3)
-    optionalDependencies:
-      typescript: 5.7.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/type-utils@6.21.0(eslint@8.57.1)(typescript@5.7.3)':
-    dependencies:
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.7.3)
-      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@5.7.3)
-      debug: 4.4.0
-      eslint: 8.57.1
       ts-api-utils: 1.3.0(typescript@5.7.3)
     optionalDependencies:
       typescript: 5.7.3
@@ -21436,11 +21317,11 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.29.0
       '@typescript-eslint/visitor-keys': 8.29.0
-      debug: 4.4.0
+      debug: 4.4.1
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
-      semver: 7.7.1
+      semver: 7.7.2
       ts-api-utils: 2.1.0(typescript@5.7.3)
       typescript: 5.7.3
     transitivePeerDependencies:
@@ -21448,7 +21329,7 @@ snapshots:
 
   '@typescript-eslint/utils@5.62.0(eslint@7.32.0)(typescript@5.4.5)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@7.32.0)
+      '@eslint-community/eslint-utils': 4.7.0(eslint@7.32.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.8
       '@typescript-eslint/scope-manager': 5.62.0
@@ -21463,7 +21344,7 @@ snapshots:
 
   '@typescript-eslint/utils@5.62.0(eslint@8.57.1)(typescript@5.4.5)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.1)
+      '@eslint-community/eslint-utils': 4.7.0(eslint@8.57.1)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.8
       '@typescript-eslint/scope-manager': 5.62.0
@@ -21485,20 +21366,6 @@ snapshots:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.7.3)
       eslint: 8.57.0
-      semver: 7.7.1
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
-  '@typescript-eslint/utils@6.21.0(eslint@8.57.1)(typescript@5.7.3)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.5.1(eslint@8.57.1)
-      '@types/json-schema': 7.0.15
-      '@types/semver': 7.5.8
-      '@typescript-eslint/scope-manager': 6.21.0
-      '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.7.3)
-      eslint: 8.57.1
       semver: 7.7.1
     transitivePeerDependencies:
       - supports-color
@@ -21550,7 +21417,7 @@ snapshots:
 
   '@typescript-eslint/utils@8.23.0(eslint@9.18.0(jiti@1.21.0))(typescript@5.7.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.6.1(eslint@9.18.0(jiti@1.21.0))
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.18.0(jiti@1.21.0))
       '@typescript-eslint/scope-manager': 8.23.0
       '@typescript-eslint/types': 8.23.0
       '@typescript-eslint/typescript-estree': 8.23.0(typescript@5.7.3)
@@ -21566,17 +21433,6 @@ snapshots:
       '@typescript-eslint/types': 8.29.0
       '@typescript-eslint/typescript-estree': 8.29.0(typescript@5.7.3)
       eslint: 8.57.0
-      typescript: 5.7.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/utils@8.29.0(eslint@8.57.1)(typescript@5.7.3)':
-    dependencies:
-      '@eslint-community/eslint-utils': 4.7.0(eslint@8.57.1)
-      '@typescript-eslint/scope-manager': 8.29.0
-      '@typescript-eslint/types': 8.29.0
-      '@typescript-eslint/typescript-estree': 8.29.0(typescript@5.7.3)
-      eslint: 8.57.1
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
@@ -21609,7 +21465,7 @@ snapshots:
   '@typescript-eslint/visitor-keys@8.29.0':
     dependencies:
       '@typescript-eslint/types': 8.29.0
-      eslint-visitor-keys: 4.2.0
+      eslint-visitor-keys: 4.2.1
 
   '@ungap/structured-clone@1.2.0': {}
 
@@ -21630,14 +21486,14 @@ snapshots:
   '@vaadin/avatar@24.3.4':
     dependencies:
       '@open-wc/dedupe-mixin': 1.4.0
-      '@polymer/polymer': 3.5.1
+      '@polymer/polymer': 3.5.2
       '@vaadin/a11y-base': 24.3.22
       '@vaadin/component-base': 24.3.22
       '@vaadin/tooltip': 24.3.22
       '@vaadin/vaadin-lumo-styles': 24.3.22
       '@vaadin/vaadin-material-styles': 24.3.22
       '@vaadin/vaadin-themable-mixin': 24.3.22
-      lit: 3.2.0
+      lit: 3.3.0
 
   '@vaadin/button@24.3.4':
     dependencies:
@@ -21928,7 +21784,7 @@ snapshots:
   '@vaadin/tooltip@24.3.22':
     dependencies:
       '@open-wc/dedupe-mixin': 1.4.0
-      '@polymer/polymer': 3.5.1
+      '@polymer/polymer': 3.5.2
       '@vaadin/a11y-base': 24.3.22
       '@vaadin/component-base': 24.3.22
       '@vaadin/overlay': 24.3.22
@@ -22352,7 +22208,7 @@ snapshots:
 
   '@vue/compiler-core@3.5.13':
     dependencies:
-      '@babel/parser': 7.27.1
+      '@babel/parser': 7.27.7
       '@vue/shared': 3.5.13
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -22382,14 +22238,14 @@ snapshots:
 
   '@vue/compiler-sfc@3.5.13':
     dependencies:
-      '@babel/parser': 7.27.1
+      '@babel/parser': 7.27.7
       '@vue/compiler-core': 3.5.13
       '@vue/compiler-dom': 3.5.13
       '@vue/compiler-ssr': 3.5.13
       '@vue/shared': 3.5.13
       estree-walker: 2.0.2
       magic-string: 0.30.17
-      postcss: 8.5.3
+      postcss: 8.5.6
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.4.31':
@@ -23098,7 +22954,7 @@ snapshots:
       schema-utils: 2.7.1
       webpack: 5.93.0(@swc/core@1.7.1(@swc/helpers@0.5.15))
 
-  babel-loader@9.2.1(@babel/core@7.26.0)(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))):
+  babel-loader@9.2.1(@babel/core@7.26.0)(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))(esbuild@0.24.2)):
     dependencies:
       '@babel/core': 7.26.0
       find-cache-dir: 4.0.0
@@ -23172,12 +23028,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-transform-typescript-metadata@0.3.2(@babel/core@7.26.0)(@babel/traverse@7.27.1):
+  babel-plugin-transform-typescript-metadata@0.3.2(@babel/core@7.26.0)(@babel/traverse@7.27.7):
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.26.5
     optionalDependencies:
-      '@babel/traverse': 7.27.1
+      '@babel/traverse': 7.27.7
 
   babel-preset-current-node-syntax@1.0.1(@babel/core@7.26.0):
     dependencies:
@@ -23894,7 +23750,7 @@ snapshots:
     dependencies:
       is-what: 3.14.1
 
-  copy-webpack-plugin@12.0.2(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))):
+  copy-webpack-plugin@12.0.2(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))(esbuild@0.24.2)):
     dependencies:
       fast-glob: 3.3.3
       glob-parent: 6.0.2
@@ -24133,7 +23989,7 @@ snapshots:
     optionalDependencies:
       webpack: 5.93.0(@swc/core@1.7.1(@swc/helpers@0.5.15))
 
-  css-loader@7.1.2(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))):
+  css-loader@7.1.2(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))(esbuild@0.24.2)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.3)
       postcss: 8.5.3
@@ -24368,6 +24224,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  debug@4.4.1:
+    dependencies:
+      ms: 2.1.3
+
   decimal.js@10.4.3: {}
 
   dedent@1.5.1: {}
@@ -24534,7 +24394,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.2.4:
+  dompurify@3.2.6:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -25671,14 +25531,6 @@ snapshots:
     optionalDependencies:
       eslint-config-prettier: 9.1.0(eslint@9.18.0(jiti@1.21.0))
 
-  eslint-plugin-prettier@4.2.1(eslint-config-prettier@9.1.0(eslint@9.18.0(jiti@1.21.0)))(eslint@8.57.1)(prettier@2.8.8):
-    dependencies:
-      eslint: 8.57.1
-      prettier: 2.8.8
-      prettier-linter-helpers: 1.0.0
-    optionalDependencies:
-      eslint-config-prettier: 9.1.0(eslint@9.18.0(jiti@1.21.0))
-
   eslint-plugin-prettier@5.1.3(@types/eslint@8.56.10)(eslint-config-prettier@9.1.0(eslint@8.57.1))(eslint@8.57.1)(prettier@3.1.0):
     dependencies:
       eslint: 8.57.1
@@ -25794,6 +25646,8 @@ snapshots:
 
   eslint-visitor-keys@4.2.0: {}
 
+  eslint-visitor-keys@4.2.1: {}
+
   eslint-webpack-plugin@3.2.0(eslint@7.32.0)(webpack@5.93.0(@swc/core@1.7.1(@swc/helpers@0.5.15))):
     dependencies:
       '@types/eslint': 8.56.10
@@ -25894,7 +25748,7 @@ snapshots:
 
   eslint@8.57.1:
     dependencies:
-      '@eslint-community/eslint-utils': 4.6.1(eslint@8.57.1)
+      '@eslint-community/eslint-utils': 4.7.0(eslint@8.57.1)
       '@eslint-community/regexpp': 4.12.1
       '@eslint/eslintrc': 2.1.4
       '@eslint/js': 8.57.1
@@ -26072,7 +25926,7 @@ snapshots:
 
   execa@7.2.0:
     dependencies:
-      cross-spawn: 7.0.3
+      cross-spawn: 7.0.6
       get-stream: 6.0.1
       human-signals: 4.3.1
       is-stream: 3.0.0
@@ -27867,6 +27721,13 @@ snapshots:
     optionalDependencies:
       jest: 29.7.0(@types/node@20.14.7)(ts-node@10.9.1(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.14.7)(typescript@5.4.5))
 
+  jest-extended@4.0.2(jest@29.7.0(@types/node@20.17.13)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3))):
+    dependencies:
+      jest-diff: 29.7.0
+      jest-get-type: 29.6.3
+    optionalDependencies:
+      jest: 29.7.0(@types/node@20.17.13)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3))
+
   jest-fetch-mock@3.0.3(encoding@0.1.13):
     dependencies:
       cross-fetch: 3.1.8(encoding@0.1.13)
@@ -27963,32 +27824,6 @@ snapshots:
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
     optionalDependencies:
       jest-resolve: 29.7.0
-
-  jest-preset-angular@13.1.6(138181bc1bf7c15203e440c2f268f646):
-    dependencies:
-      '@angular-devkit/build-angular': 19.1.6(@angular/compiler-cli@19.1.4(@angular/compiler@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.7.3))(@angular/compiler@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@22.13.17)(chokidar@4.0.3)(html-webpack-plugin@5.6.0(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))))(jest-environment-jsdom@29.7.0)(jest@29.7.0(@types/node@22.13.17)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3)))(jiti@1.21.0)(ng-packagr@16.2.3(@angular/compiler-cli@19.1.4(@angular/compiler@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.7.3))(tslib@2.8.1)(typescript@5.7.3))(typescript@5.7.3)(vite@6.0.11(@types/node@22.13.17)(jiti@1.21.0)(less@4.2.1)(sass@1.83.1)(terser@5.37.0)(yaml@2.4.5))(yaml@2.4.5)
-      '@angular/compiler-cli': 19.1.4(@angular/compiler@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.7.3)
-      '@angular/core': 19.1.4(rxjs@7.8.1)(zone.js@0.15.0)
-      '@angular/platform-browser-dynamic': 19.1.4(@angular/common@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/compiler@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0))(@angular/platform-browser@19.1.4(@angular/animations@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(@angular/common@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0))(rxjs@7.8.1))(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))
-      bs-logger: 0.2.6
-      esbuild-wasm: 0.23.0
-      jest: 29.7.0(@types/node@22.13.17)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3))
-      jest-environment-jsdom: 29.7.0
-      jest-util: 29.7.0
-      pretty-format: 29.7.0
-      ts-jest: 29.1.5(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(esbuild@0.25.2)(jest@29.7.0(@types/node@22.13.17)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3)))(typescript@5.7.3)
-      typescript: 5.7.3
-    optionalDependencies:
-      esbuild: 0.25.2
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@jest/transform'
-      - '@jest/types'
-      - babel-jest
-      - bufferutil
-      - canvas
-      - supports-color
-      - utf-8-validate
 
   jest-preset-angular@13.1.6(623ca71f3c627d14feb749afbcc881bf):
     dependencies:
@@ -28477,7 +28312,7 @@ snapshots:
       picocolors: 1.1.1
       shell-quote: 1.8.1
 
-  less-loader@12.2.0(less@4.2.1)(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))):
+  less-loader@12.2.0(less@4.2.1)(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))(esbuild@0.24.2)):
     dependencies:
       less: 4.2.1
     optionalDependencies:
@@ -28525,7 +28360,7 @@ snapshots:
 
   libphonenumber-js@1.11.17: {}
 
-  license-webpack-plugin@4.0.2(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))):
+  license-webpack-plugin@4.0.2(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))(esbuild@0.24.2)):
     dependencies:
       webpack-sources: 3.2.3
     optionalDependencies:
@@ -28635,7 +28470,17 @@ snapshots:
       '@lit/reactive-element': 2.0.4
       lit-html: 3.2.0
 
+  lit-element@4.2.0:
+    dependencies:
+      '@lit-labs/ssr-dom-shim': 1.3.0
+      '@lit/reactive-element': 2.1.0
+      lit-html: 3.3.0
+
   lit-html@3.2.0:
+    dependencies:
+      '@types/trusted-types': 2.0.7
+
+  lit-html@3.3.0:
     dependencies:
       '@types/trusted-types': 2.0.7
 
@@ -28644,6 +28489,12 @@ snapshots:
       '@lit/reactive-element': 2.0.4
       lit-element: 4.1.0
       lit-html: 3.2.0
+
+  lit@3.3.0:
+    dependencies:
+      '@lit/reactive-element': 2.1.0
+      lit-element: 4.2.0
+      lit-html: 3.3.0
 
   livereload-js@3.4.1: {}
 
@@ -28956,7 +28807,7 @@ snapshots:
       tapable: 2.2.1
       webpack: 5.93.0(@swc/core@1.7.1(@swc/helpers@0.5.15))
 
-  mini-css-extract-plugin@2.9.2(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))):
+  mini-css-extract-plugin@2.9.2(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))(esbuild@0.24.2)):
     dependencies:
       schema-utils: 4.2.0
       tapable: 2.2.1
@@ -29250,38 +29101,6 @@ snapshots:
       rxjs: 7.8.1
       sass: 1.77.8
       tslib: 2.6.3
-      typescript: 5.7.3
-    optionalDependencies:
-      esbuild: 0.19.12
-
-  ng-packagr@16.2.3(@angular/compiler-cli@19.1.4(@angular/compiler@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.7.3))(tslib@2.8.1)(typescript@5.7.3):
-    dependencies:
-      '@angular/compiler-cli': 19.1.4(@angular/compiler@19.1.4(@angular/core@19.1.4(rxjs@7.8.1)(zone.js@0.15.0)))(typescript@5.7.3)
-      '@rollup/plugin-json': 6.1.0(rollup@3.29.5)
-      '@rollup/plugin-node-resolve': 15.2.3(rollup@3.29.5)
-      ajv: 8.12.0
-      ansi-colors: 4.1.3
-      autoprefixer: 10.4.19(postcss@8.4.39)
-      browserslist: 4.23.2
-      cacache: 18.0.4
-      chokidar: 3.5.3
-      commander: 11.1.0
-      convert-source-map: 2.0.0
-      dependency-graph: 0.11.0
-      esbuild-wasm: 0.19.12
-      fast-glob: 3.3.1
-      find-cache-dir: 3.3.2
-      injection-js: 2.4.0
-      jsonc-parser: 3.2.0
-      less: 4.2.0
-      ora: 5.4.1
-      piscina: 4.6.1
-      postcss: 8.4.39
-      postcss-url: 10.1.3(postcss@8.4.39)
-      rollup: 3.29.5
-      rxjs: 7.8.1
-      sass: 1.77.8
-      tslib: 2.8.1
       typescript: 5.7.3
     optionalDependencies:
       esbuild: 0.19.12
@@ -30035,7 +29854,7 @@ snapshots:
       semver: 7.7.1
       webpack: 5.93.0(@swc/core@1.7.1(@swc/helpers@0.5.15))
 
-  postcss-loader@8.1.1(postcss@8.4.49)(typescript@5.7.3)(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))):
+  postcss-loader@8.1.1(postcss@8.4.49)(typescript@5.7.3)(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))(esbuild@0.24.2)):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.7.3)
       jiti: 1.21.0
@@ -30343,6 +30162,12 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postcss@8.5.6:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   prelude-ls@1.1.2: {}
 
   prelude-ls@1.2.1: {}
@@ -30531,6 +30356,13 @@ snapshots:
       bytes: 3.1.2
       http-errors: 2.0.0
       iconv-lite: 0.4.24
+      unpipe: 1.0.0
+
+  raw-body@3.0.0:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.0
+      iconv-lite: 0.6.3
       unpipe: 1.0.0
 
   rc@1.2.8:
@@ -30931,6 +30763,14 @@ snapshots:
     optionalDependencies:
       '@babel/code-frame': 7.26.2
 
+  rollup-plugin-dts@6.1.1(rollup@4.34.6)(typescript@5.7.3):
+    dependencies:
+      magic-string: 0.30.17
+      rollup: 4.34.6
+      typescript: 5.7.3
+    optionalDependencies:
+      '@babel/code-frame': 7.26.2
+
   rollup-plugin-esbuild@6.1.1(esbuild@0.25.0)(rollup@4.22.4):
     dependencies:
       '@rollup/pluginutils': 5.1.0(rollup@4.22.4)
@@ -31170,7 +31010,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@16.0.4(sass@1.83.1)(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))):
+  sass-loader@16.0.4(sass@1.83.1)(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))(esbuild@0.24.2)):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
@@ -31255,6 +31095,8 @@ snapshots:
   semver@7.7.0: {}
 
   semver@7.7.1: {}
+
+  semver@7.7.2: {}
 
   send@0.16.2:
     dependencies:
@@ -31592,7 +31434,7 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map-loader@5.0.0(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))):
+  source-map-loader@5.0.0(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))(esbuild@0.24.2)):
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
@@ -32170,25 +32012,6 @@ snapshots:
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.26.0)
 
-  ts-jest@29.1.5(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(esbuild@0.25.2)(jest@29.7.0(@types/node@22.13.17)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3)))(typescript@5.7.3):
-    dependencies:
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@22.13.17)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3))
-      jest-util: 29.7.0
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.6.0
-      typescript: 5.7.3
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.26.10
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.26.10)
-      esbuild: 0.25.2
-
   ts-jest@29.1.5(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(esbuild@0.25.3)(jest@29.7.0(@types/node@20.17.13)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.4.5)))(typescript@5.4.5):
     dependencies:
       bs-logger: 0.2.6
@@ -32282,6 +32105,25 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.26.0)
+
+  ts-jest@29.2.5(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(jest@29.7.0(@types/node@20.17.13)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3)))(typescript@5.7.3):
+    dependencies:
+      bs-logger: 0.2.6
+      ejs: 3.1.10
+      fast-json-stable-stringify: 2.1.0
+      jest: 29.7.0(@types/node@20.17.13)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3))
+      jest-util: 29.7.0
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.7.0
+      typescript: 5.7.3
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.26.10
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.26.10)
 
   ts-loader@9.5.1(typescript@5.4.5)(webpack@5.93.0(@swc/core@1.7.1(@swc/helpers@0.5.15))):
     dependencies:
@@ -32928,7 +32770,7 @@ snapshots:
       schema-utils: 4.2.0
       webpack: 5.93.0(@swc/core@1.7.1(@swc/helpers@0.5.15))
 
-  webpack-dev-middleware@7.4.2(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))):
+  webpack-dev-middleware@7.4.2(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))(esbuild@0.24.2)):
     dependencies:
       colorette: 2.0.20
       memfs: 4.17.0
@@ -32979,7 +32821,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  webpack-dev-server@5.2.0(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))):
+  webpack-dev-server@5.2.0(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))(esbuild@0.24.2)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -33006,7 +32848,7 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.4.2(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15)))
+      webpack-dev-middleware: 7.4.2(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))(esbuild@0.24.2))
       ws: 8.18.0
     optionalDependencies:
       webpack: 5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))(esbuild@0.24.2)
@@ -33030,7 +32872,7 @@ snapshots:
 
   webpack-sources@3.2.3: {}
 
-  webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.6.0(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))))(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))):
+  webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.6.0(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))))(webpack@5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))(esbuild@0.24.2)):
     dependencies:
       typed-assert: 1.0.9
       webpack: 5.97.1(@swc/core@1.7.1(@swc/helpers@0.5.15))(esbuild@0.24.2)
@@ -33347,5 +33189,7 @@ snapshots:
       is-ci: 1.2.1
       normalize-path: 1.0.0
       strip-indent: 2.0.0
+
+  zod@3.25.67: {}
 
   zone.js@0.15.0: {}


### PR DESCRIPTION
## Related Issues

Related https://github.com/descope/etc/issues/10563

## Description

Introduces a comprehensive Model Context Protocol (MCP) SDK with enterprise-grade Descope
  authentication, featuring:

  - Authenticated MCP tools with built-in scope checking 
  - Outbound token access via Descope for external providers (GitHub, Google, Slack, etc.)
  - Automatic OAuth 2.0 scope validation with compliant error responses
  - Protected Resource Metadata (RFC 9728) support
  - Framework examples for Express.js, Next.js App Router, and Pages Router

  The SDK simplifies building secure MCP servers by handling authentication, authorization, and OAuth
  compliance automatically.

## Must

- [x] Tests
- [ ] Documentation (if applicable)
