### PR TITLE
feat: add auto refresh config to web-framework sdks

### DIFF
--- a/packages/sdks/angular-sdk/README.md
+++ b/packages/sdks/angular-sdk/README.md
@@ -410,6 +410,53 @@ Descope SDK is automatically refreshes the session token when it is about to exp
 If the Descope project settings are configured to manage tokens in cookies.
 you must also configure a custom domain, and set it as the `baseUrl` in `DescopeAuthModule`.
 
+### Auto refresh session token
+
+Descope SDK automatically refreshes the session token when it is about to expire. This is done in the background using the refresh token, without any additional configuration.
+If you want to disable this behavior, you can pass `autoRefresh: false` to the `DescopeAuthModule` module. This will prevent the SDK from automatically refreshing the session token.
+
+#### NgModule Example:
+
+```ts
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { AppComponent } from './app.component';
+import { DescopeAuthModule } from '@descope/angular-sdk';
+
+@NgModule({
+  declarations: [AppComponent],
+  imports: [
+    BrowserModule,
+    DescopeAuthModule.forRoot({
+      projectId: '<your_project_id>',
+      autoRefresh: false
+    })
+  ],
+  bootstrap: [AppComponent]
+})
+export class AppModule {}
+```
+
+#### Standalone Mode Example:
+
+```ts
+import { bootstrapApplication } from '@angular/platform-browser';
+import { AppComponent } from './app/app.component';
+import { DescopeAuthConfig } from '@descope/angular-sdk';
+
+bootstrapApplication(AppComponent, {
+  providers: [
+    {
+      provide: DescopeAuthConfig,
+      useValue: {
+        projectId: '<your_project_id>',
+        autoRefresh: false
+      }
+    }
+  ]
+}).catch((err) => console.error(err));
+```
+
 ### Descope Guard
 
 `angular-sdk` provides a convenient route guard that prevents from accessing given route for users that are not authenticated:

--- a/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/services/descope-auth.service.spec.ts
+++ b/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/services/descope-auth.service.spec.ts
@@ -74,6 +74,41 @@ describe('DescopeAuthService', () => {
     expect(onUserChangeSpy).toHaveBeenCalled();
   });
 
+  it('should be created with default autoRefresh option', () => {
+    expect(service).toBeTruthy();
+    expect(mockedCreateSdk).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ...mockConfig,
+        autoRefresh: true
+      })
+    );
+    expect(onSessionTokenChangeSpy).toHaveBeenCalled();
+    expect(onIsAuthenticatedChangeSpy).toHaveBeenCalled();
+    expect(onUserChangeSpy).toHaveBeenCalled();
+  });
+
+  it('should be created with custom autoRefresh option', () => {
+    const customConfig = { ...mockConfig, autoRefresh: false };
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        DescopeAuthConfig,
+        { provide: DescopeAuthConfig, useValue: customConfig }
+      ]
+    });
+
+    const customService = TestBed.inject(DescopeAuthService);
+
+    expect(customService).toBeTruthy();
+    expect(mockedCreateSdk).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ...customConfig,
+        autoRefresh: false
+      })
+    );
+  });
+
   describe('getSessionToken', () => {
     it('should call getSessionToken from sdk', () => {
       const token = 'abcd';

--- a/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/services/descope-auth.service.ts
+++ b/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/services/descope-auth.service.ts
@@ -39,9 +39,9 @@ export class DescopeAuthService {
     this.descopeSdk = observabilify<DescopeSDK>(
       createSdk({
         persistTokens: isBrowser() as true,
-        ...config,
         storeLastAuthenticatedUser: isBrowser() as true,
         autoRefresh: isBrowser() as true,
+        ...config,
         baseHeaders
       })
     );

--- a/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/types/types.ts
+++ b/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/types/types.ts
@@ -7,6 +7,8 @@ export class DescopeAuthConfig {
   baseCdnUrl?: string;
   // If true, tokens will be stored on local storage
   persistTokens?: boolean;
+  // If true, the SDK will automatically refresh the session token when it is about to expire
+  autoRefresh?: boolean;
   sessionTokenViaCookie?: CookieConfig;
   // If true, last authenticated user will be stored on local storage and can accessed with getUser function
   storeLastAuthenticatedUser?: boolean;

--- a/packages/sdks/react-sdk/README.md
+++ b/packages/sdks/react-sdk/README.md
@@ -293,6 +293,11 @@ useEffect(() => {
 }, [refresh]);
 ```
 
+
+### Auto refresh session token
+Descope SDK automatically refreshes the session token when it is about to expire. This is done in the background using the refresh token, without any additional configuration.
+If you want to disable this behavior, you can pass `autoRefresh={false}` to the `AuthProvider` component. This will prevent the SDK from automatically refreshing the session token.
+
 **For more SDK usage examples refer to [docs](https://docs.descope.com/build/guides/client_sdks/)**
 
 ### Session token server validation (pass session token to server API)

--- a/packages/sdks/react-sdk/src/components/AuthProvider/AuthProvider.tsx
+++ b/packages/sdks/react-sdk/src/components/AuthProvider/AuthProvider.tsx
@@ -21,6 +21,8 @@ interface IAuthProviderProps {
   baseCdnUrl?: string;
   // If true, tokens will be stored on local storage and can accessed with getToken function
   persistTokens?: boolean;
+  // If true, the SDK will automatically refresh the session token when it is about to expire
+  autoRefresh?: boolean;
   // If true, session token (jwt) will be stored on cookie. Otherwise, the session token will be
   // stored on local storage and can accessed with getSessionToken function
   // Use this option if session token will stay small (less than 1k)
@@ -48,6 +50,7 @@ const AuthProvider: FC<IAuthProviderProps> = ({
   baseCdnUrl = '',
   sessionTokenViaCookie = false,
   persistTokens = true,
+  autoRefresh = true,
   oidcConfig = undefined,
   storeLastAuthenticatedUser = true,
   keepLastAuthenticatedUserAfterLogout = false,
@@ -70,6 +73,7 @@ const AuthProvider: FC<IAuthProviderProps> = ({
     projectId,
     baseUrl,
     persistTokens,
+    autoRefresh,
     sessionTokenViaCookie,
     oidcConfig,
     storeLastAuthenticatedUser,

--- a/packages/sdks/react-sdk/src/components/AuthProvider/useSdk.ts
+++ b/packages/sdks/react-sdk/src/components/AuthProvider/useSdk.ts
@@ -7,6 +7,7 @@ type Config = Pick<
   | 'projectId'
   | 'baseUrl'
   | 'persistTokens'
+  | 'autoRefresh'
   | 'sessionTokenViaCookie'
   | 'storeLastAuthenticatedUser'
   | 'oidcConfig'
@@ -19,6 +20,7 @@ export default ({
   projectId,
   baseUrl,
   persistTokens,
+  autoRefresh,
   sessionTokenViaCookie,
   refreshCookieName,
   oidcConfig,
@@ -36,11 +38,11 @@ export default ({
       sessionTokenViaCookie,
       baseHeaders,
       persistTokens,
+      autoRefresh,
       refreshCookieName,
       oidcConfig,
       storeLastAuthenticatedUser,
       keepLastAuthenticatedUserAfterLogout,
-      autoRefresh: true,
       getExternalToken,
     });
   }, [projectId, baseUrl, sessionTokenViaCookie, getExternalToken]);

--- a/packages/sdks/react-sdk/test/components/AuthProvider.test.tsx
+++ b/packages/sdks/react-sdk/test/components/AuthProvider.test.tsx
@@ -23,11 +23,12 @@ describe('AuthProvider', () => {
         expect.objectContaining({
           projectId: 'pr1',
           persistTokens: true,
+          autoRefresh: true,
         }),
       );
     });
   });
-  it('Should init sdk config with customized options', async () => {
+  it('Should init sdk config with customized persist tokens option', async () => {
     render(
       <AuthProvider
         projectId="pr1"
@@ -43,7 +44,30 @@ describe('AuthProvider', () => {
         expect.objectContaining({
           projectId: 'pr1',
           persistTokens: false,
+          autoRefresh: true,
           storeLastAuthenticatedUser: false,
+        }),
+      );
+    });
+  });
+
+   it('Should init sdk config with customized auto refresh option', async () => {
+    render(
+      <AuthProvider
+        projectId="pr1"
+        autoRefresh={false}
+      >
+        <div>hello</div>
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(createSdk).toHaveBeenCalledWith(
+        expect.objectContaining({
+          projectId: 'pr1',
+          persistTokens: true,
+          autoRefresh: false,
+          storeLastAuthenticatedUser: true,
         }),
       );
     });

--- a/packages/sdks/vue-sdk/README.md
+++ b/packages/sdks/vue-sdk/README.md
@@ -264,6 +264,26 @@ Descope SDK is automatically refreshes the session token when it is about to exp
 If the Descope project settings are configured to manage tokens in cookies.
 you must also configure a custom domain, and set it as the `baseUrl` to the `descope` plugin. See the above [`plugin` usage](#add-descope-plugin-to-your-application) for usage example.
 
+### Auto refresh session token
+
+Descope SDK automatically refreshes the session token when it is about to expire. This is done in the background using the refresh token, without any additional configuration.
+If you want to disable this behavior, you can pass `autoRefresh: false` to the Descope plugin. This will prevent the SDK from automatically refreshing the session token.
+
+Example:
+
+```js
+import { createApp } from 'vue';
+import App from './App.vue';
+import descope from '@descope/vue-sdk';
+
+const app = createApp(App);
+app.use(descope, {
+  projectId: 'my-project-id',
+  autoRefresh: false,
+});
+app.mount('#app');
+```
+
 ### Token Persistence
 
 Descope stores two tokens: the session token and the refresh token.

--- a/packages/sdks/vue-sdk/src/plugin.ts
+++ b/packages/sdks/vue-sdk/src/plugin.ts
@@ -21,8 +21,8 @@ export default {
   install: function (app: App, options: Options) {
     const sdk = createSdk({
       persistTokens: true,
-      ...options,
       autoRefresh: true,
+      ...options,
       baseHeaders,
     });
 

--- a/packages/sdks/vue-sdk/src/sdk.ts
+++ b/packages/sdks/vue-sdk/src/sdk.ts
@@ -15,8 +15,8 @@ const createSdkWrapper = <P extends Parameters<typeof createSdk>[0]>(
   const sdk = createSdk({
     persistTokens: IS_BROWSER as true,
     storeLastAuthenticatedUser: IS_BROWSER as true,
-    ...config,
     autoRefresh: IS_BROWSER as true,
+    ...config,
   });
   globalSdk = sdk;
 

--- a/packages/sdks/vue-sdk/src/types.ts
+++ b/packages/sdks/vue-sdk/src/types.ts
@@ -8,6 +8,8 @@ export type Options = {
   baseCdnUrl?: string;
   // If true, tokens will be stored on local storage
   persistTokens?: boolean;
+  // If true, the SDK will automatically refresh the session token when it is about to expire
+  autoRefresh?: boolean;
   sessionTokenViaCookie?: CookieConfig;
   // If true, last authenticated user will be stored on local storage and can accessed with getUser function
   storeLastAuthenticatedUser?: boolean;

--- a/packages/sdks/vue-sdk/tests/plugin.test.ts
+++ b/packages/sdks/vue-sdk/tests/plugin.test.ts
@@ -50,6 +50,51 @@ describe('plugin', () => {
     expect(createSdk).toHaveBeenCalledWith(expect.objectContaining(options));
   });
 
+  it('should create sdk instance with default autoRefresh option', () => {
+    const provide = jest.fn();
+    const app = { provide } as any;
+    const options = {
+      projectId: 'pid',
+      baseUrl: 'burl',
+      sessionTokenViaCookie: false,
+    };
+
+    plugin.install(app, options);
+
+    expect(createSdk).toHaveBeenCalledWith(
+      expect.objectContaining({
+        persistTokens: true,
+        autoRefresh: true,
+        storeLastAuthenticatedUser: true,
+        ...options,
+      }),
+    );
+  });
+
+  it('should create sdk instance with custom autoRefresh option', () => {
+    const provide = jest.fn();
+    const app = { provide } as any;
+    const options = {
+      projectId: 'pid',
+      baseUrl: 'burl',
+      sessionTokenViaCookie: false,
+      autoRefresh: false,
+    };
+
+    plugin.install(app, options);
+
+    expect(createSdk).toHaveBeenCalledWith(
+      expect.objectContaining({
+        persistTokens: true,
+        autoRefresh: false,
+        storeLastAuthenticatedUser: true,
+        projectId: 'pid',
+        baseUrl: 'burl',
+        sessionTokenViaCookie: false,
+      }),
+    );
+  });
+
   it('should update the context when new session is received from sdk hook', () => {
     const provide = jest.fn();
     const app = { provide } as any;


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/11249


## Description
add auto refresh config to web-framework sdks
 - React (this includes support to NextJS)
 - Vue
 - Angular