### PR TITLE
feat: Support multiple global sdks in next sdk

### DIFF
--- a/packages/sdks/nextjs-sdk/CHANGELOG.md
+++ b/packages/sdks/nextjs-sdk/CHANGELOG.md
@@ -6,55 +6,48 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ### Dependency Updates
 
-- `react-sdk` updated to version `2.14.25`
-- `web-component` updated to version `3.43.18`
-
+* `react-sdk` updated to version `2.14.25`
+* `web-component` updated to version `3.43.18`
 ## [0.13.19](https://github.com/descope/descope-js/compare/nextjs-sdk-0.13.18...nextjs-sdk-0.13.19) (2025-06-24)
 
 ### Dependency Updates
 
-- `react-sdk` updated to version `2.14.24`
-
+* `react-sdk` updated to version `2.14.24`
 ## [0.13.18](https://github.com/descope/descope-js/compare/nextjs-sdk-0.13.17...nextjs-sdk-0.13.18) (2025-06-13)
 
 ### Dependency Updates
 
-- `react-sdk` updated to version `2.14.23`
-- `web-component` updated to version `3.43.17`
-
+* `react-sdk` updated to version `2.14.23`
+* `web-component` updated to version `3.43.17`
 ## [0.13.17](https://github.com/descope/descope-js/compare/nextjs-sdk-0.13.16...nextjs-sdk-0.13.17) (2025-06-11)
 
 ### Dependency Updates
 
-- `web-js-sdk` updated to version `1.33.4`
-- `react-sdk` updated to version `2.14.22`
-- `core-js-sdk` updated to version `2.44.3`
-- `web-component` updated to version `3.43.16`
-
+* `web-js-sdk` updated to version `1.33.4`
+* `react-sdk` updated to version `2.14.22`
+* `core-js-sdk` updated to version `2.44.3`
+* `web-component` updated to version `3.43.16`
 ## [0.13.16](https://github.com/descope/descope-js/compare/nextjs-sdk-0.13.15...nextjs-sdk-0.13.16) (2025-06-11)
 
 ### Dependency Updates
 
-- `web-js-sdk` updated to version `1.33.3`
-- `react-sdk` updated to version `2.14.21`
-- `core-js-sdk` updated to version `2.44.2`
-- `web-component` updated to version `3.43.15`
-
+* `web-js-sdk` updated to version `1.33.3`
+* `react-sdk` updated to version `2.14.21`
+* `core-js-sdk` updated to version `2.44.2`
+* `web-component` updated to version `3.43.15`
 ## [0.13.15](https://github.com/descope/descope-js/compare/nextjs-sdk-0.13.14...nextjs-sdk-0.13.15) (2025-05-22)
 
 ### Dependency Updates
 
-- `web-js-sdk` updated to version `1.33.2`
-- `react-sdk` updated to version `2.14.20`
-- `web-component` updated to version `3.43.14`
-
+* `web-js-sdk` updated to version `1.33.2`
+* `react-sdk` updated to version `2.14.20`
+* `web-component` updated to version `3.43.14`
 ## [0.13.14](https://github.com/descope/descope-js/compare/nextjs-sdk-0.13.13...nextjs-sdk-0.13.14) (2025-05-20)
 
 ### Dependency Updates
 
-- `react-sdk` updated to version `2.14.19`
-- `web-component` updated to version `3.43.13`
-
+* `react-sdk` updated to version `2.14.19`
+* `web-component` updated to version `3.43.13`
 ## [0.13.13](https://github.com/descope/descope-js/compare/nextjs-sdk-0.13.12...nextjs-sdk-0.13.13) (2025-05-18)
 
 ### Dependency Updates

--- a/packages/sdks/nextjs-sdk/CHANGELOG.md
+++ b/packages/sdks/nextjs-sdk/CHANGELOG.md
@@ -6,48 +6,55 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.14.25`
-* `web-component` updated to version `3.43.18`
+- `react-sdk` updated to version `2.14.25`
+- `web-component` updated to version `3.43.18`
+
 ## [0.13.19](https://github.com/descope/descope-js/compare/nextjs-sdk-0.13.18...nextjs-sdk-0.13.19) (2025-06-24)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.14.24`
+- `react-sdk` updated to version `2.14.24`
+
 ## [0.13.18](https://github.com/descope/descope-js/compare/nextjs-sdk-0.13.17...nextjs-sdk-0.13.18) (2025-06-13)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.14.23`
-* `web-component` updated to version `3.43.17`
+- `react-sdk` updated to version `2.14.23`
+- `web-component` updated to version `3.43.17`
+
 ## [0.13.17](https://github.com/descope/descope-js/compare/nextjs-sdk-0.13.16...nextjs-sdk-0.13.17) (2025-06-11)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.33.4`
-* `react-sdk` updated to version `2.14.22`
-* `core-js-sdk` updated to version `2.44.3`
-* `web-component` updated to version `3.43.16`
+- `web-js-sdk` updated to version `1.33.4`
+- `react-sdk` updated to version `2.14.22`
+- `core-js-sdk` updated to version `2.44.3`
+- `web-component` updated to version `3.43.16`
+
 ## [0.13.16](https://github.com/descope/descope-js/compare/nextjs-sdk-0.13.15...nextjs-sdk-0.13.16) (2025-06-11)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.33.3`
-* `react-sdk` updated to version `2.14.21`
-* `core-js-sdk` updated to version `2.44.2`
-* `web-component` updated to version `3.43.15`
+- `web-js-sdk` updated to version `1.33.3`
+- `react-sdk` updated to version `2.14.21`
+- `core-js-sdk` updated to version `2.44.2`
+- `web-component` updated to version `3.43.15`
+
 ## [0.13.15](https://github.com/descope/descope-js/compare/nextjs-sdk-0.13.14...nextjs-sdk-0.13.15) (2025-05-22)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.33.2`
-* `react-sdk` updated to version `2.14.20`
-* `web-component` updated to version `3.43.14`
+- `web-js-sdk` updated to version `1.33.2`
+- `react-sdk` updated to version `2.14.20`
+- `web-component` updated to version `3.43.14`
+
 ## [0.13.14](https://github.com/descope/descope-js/compare/nextjs-sdk-0.13.13...nextjs-sdk-0.13.14) (2025-05-20)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.14.19`
-* `web-component` updated to version `3.43.13`
+- `react-sdk` updated to version `2.14.19`
+- `web-component` updated to version `3.43.13`
+
 ## [0.13.13](https://github.com/descope/descope-js/compare/nextjs-sdk-0.13.12...nextjs-sdk-0.13.13) (2025-05-18)
 
 ### Dependency Updates

--- a/packages/sdks/nextjs-sdk/src/server/sdk.ts
+++ b/packages/sdks/nextjs-sdk/src/server/sdk.ts
@@ -13,13 +13,15 @@ type CreateSdkParams = Pick<CreateServerSdkParams, 'projectId' | 'baseUrl'>;
 
 let globalSdk: Sdk;
 
+const getProjectId = (config?: CreateSdkParams): string =>
+	config?.projectId ||
+	process.env.NEXT_PUBLIC_DESCOPE_PROJECT_ID ||
+	process.env.DESCOPE_PROJECT_ID; // the last one for backward compatibility
+
 export const createSdk = (config?: CreateServerSdkParams): Sdk =>
 	descopeSdk({
 		...config,
-		projectId:
-			config?.projectId ||
-			process.env.NEXT_PUBLIC_DESCOPE_PROJECT_ID ||
-			process.env.DESCOPE_PROJECT_ID, // the last one for backward compatibility
+		projectId: getProjectId(config),
 		managementKey: config?.managementKey || process.env.DESCOPE_MANAGEMENT_KEY,
 		baseUrl:
 			config?.baseUrl ||
@@ -32,12 +34,9 @@ export const createSdk = (config?: CreateServerSdkParams): Sdk =>
 	});
 
 export const getGlobalSdk = (config?: CreateSdkParams): Sdk => {
+	const projectId = getProjectId(config);
 	if (!globalSdk) {
-		if (
-			!config?.projectId &&
-			!process.env.DESCOPE_PROJECT_ID &&
-			!process.env.NEXT_PUBLIC_DESCOPE_PROJECT_ID
-		) {
+		if (!projectId) {
 			throw new Error('Descope project ID is required to create the SDK');
 		}
 		globalSdk = createSdk(config);

--- a/packages/sdks/nextjs-sdk/src/server/sdk.ts
+++ b/packages/sdks/nextjs-sdk/src/server/sdk.ts
@@ -11,7 +11,8 @@ type CreateServerSdkParams = Omit<
 
 type CreateSdkParams = Pick<CreateServerSdkParams, 'projectId' | 'baseUrl'>;
 
-let globalSdk: Sdk;
+// we support multiple sdks, so the developer can work with multiple projects
+const globalSdks: Record<string, Sdk> = {};
 
 const getProjectId = (config?: CreateSdkParams): string =>
 	config?.projectId ||
@@ -33,12 +34,14 @@ export const createSdk = (config?: CreateServerSdkParams): Sdk =>
 		}
 	});
 
+// caches the SDK for each project ID
 export const getGlobalSdk = (config?: CreateSdkParams): Sdk => {
 	const projectId = getProjectId(config);
+	if (!projectId) {
+		throw new Error('Descope project ID is required to create the SDK');
+	}
+	let globalSdk = globalSdks[projectId];
 	if (!globalSdk) {
-		if (!projectId) {
-			throw new Error('Descope project ID is required to create the SDK');
-		}
 		globalSdk = createSdk(config);
 	}
 

--- a/packages/sdks/nextjs-sdk/src/server/sdk.ts
+++ b/packages/sdks/nextjs-sdk/src/server/sdk.ts
@@ -43,6 +43,7 @@ export const getGlobalSdk = (config?: CreateSdkParams): Sdk => {
 	let globalSdk = globalSdks[projectId];
 	if (!globalSdk) {
 		globalSdk = createSdk(config);
+		globalSdks[projectId] = globalSdk;
 	}
 
 	return globalSdk;

--- a/packages/sdks/nextjs-sdk/test/server/sdk.test.ts
+++ b/packages/sdks/nextjs-sdk/test/server/sdk.test.ts
@@ -2,7 +2,15 @@ import descopeSdk from '@descope/node-sdk';
 import { baseHeaders } from '../../src/shared/constants';
 import { createSdk, getGlobalSdk } from '../../src/server/sdk';
 
-jest.mock('@descope/node-sdk', () => jest.fn());
+jest.mock('@descope/node-sdk', () =>
+	jest.fn().mockImplementation((...args) => {
+		// we want to use the original implementation of descopeSdk
+		// but we need to mock it to ensure it is called with the correct parameters
+		const mockOriginalDescopeSdk =
+			jest.requireActual('@descope/node-sdk').default;
+		return mockOriginalDescopeSdk(...args);
+	})
+);
 
 describe('sdk', () => {
 	beforeEach(() => {
@@ -89,6 +97,53 @@ describe('sdk', () => {
 			const sdk2 = getGlobalSdk({ projectId: 'project1' });
 
 			expect(sdk1).toBe(sdk2); // Verify that the same SDK instance is returned
+		});
+
+		it('should handle multiple project IDs in the same scope', () => {
+			// Set up environment variable for second test
+			process.env.NEXT_PUBLIC_DESCOPE_PROJECT_ID = 'envProjectId';
+
+			// 1. Custom project id
+			const sdk1 = getGlobalSdk({ projectId: 'customProject1' });
+
+			// 2. Project id from env var
+			const sdk2 = getGlobalSdk(); // Uses env var
+
+			// 3. Another custom project id
+			const sdk3 = getGlobalSdk({ projectId: 'customProject2' });
+
+			// ensure there are 3 calls with different project IDs
+			expect(descopeSdk).toHaveBeenCalledTimes(3);
+			// Verify that descopeSdk was called with correct project IDs
+			expect(descopeSdk).toHaveBeenCalledWith(
+				expect.objectContaining({ projectId: 'customProject1' })
+			);
+			expect(descopeSdk).toHaveBeenCalledWith(
+				expect.objectContaining({ projectId: 'envProjectId' })
+			);
+			expect(descopeSdk).toHaveBeenCalledWith(
+				expect.objectContaining({ projectId: 'customProject2' })
+			);
+
+			// Verify that each SDK is different (different project IDs)
+			expect(sdk1).not.toEqual(sdk2);
+			expect(sdk1).not.toEqual(sdk3);
+			expect(sdk2).not.toEqual(sdk3);
+
+			// Verify that calling with the same project ID returns the same SDK instance
+			const sdk1Again = getGlobalSdk({ projectId: 'customProject1' });
+			const sdk2Again = getGlobalSdk(); // Uses env var again
+			const sdk3Again = getGlobalSdk({ projectId: 'customProject2' });
+
+			expect(sdk1).toBe(sdk1Again);
+			expect(sdk2).toBe(sdk2Again);
+			expect(sdk3).toBe(sdk3Again);
+
+			// ensure that the descopeSdk was not called again
+			expect(descopeSdk).toHaveBeenCalledTimes(3);
+
+			// Clean up environment variable
+			delete process.env.NEXT_PUBLIC_DESCOPE_PROJECT_ID;
 		});
 
 		it("should throw an error if no projectId is provided and it's not in env", () => {


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/11294

## Description

some context
the `getGlobalSdk` is used in 2 places
 - in middleware - for session validation
 - in `session` function - for session validation as well
 
 we want to enable developer to pass different global sdks in this context
 
 
 noting that at the moment, we don't let changing the base URL, I don't think there is such use case at the moment, but we can add this easily after this
 
this PR is still missing:
 - tests
 - maybe add a note in readme