### PR TITLE
multi project sample

### DIFF
--- a/packages/sdks/nextjs-sdk/CHANGELOG.md
+++ b/packages/sdks/nextjs-sdk/CHANGELOG.md
@@ -6,55 +6,48 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ### Dependency Updates
 
-- `react-sdk` updated to version `2.14.25`
-- `web-component` updated to version `3.43.18`
-
+* `react-sdk` updated to version `2.14.25`
+* `web-component` updated to version `3.43.18`
 ## [0.13.19](https://github.com/descope/descope-js/compare/nextjs-sdk-0.13.18...nextjs-sdk-0.13.19) (2025-06-24)
 
 ### Dependency Updates
 
-- `react-sdk` updated to version `2.14.24`
-
+* `react-sdk` updated to version `2.14.24`
 ## [0.13.18](https://github.com/descope/descope-js/compare/nextjs-sdk-0.13.17...nextjs-sdk-0.13.18) (2025-06-13)
 
 ### Dependency Updates
 
-- `react-sdk` updated to version `2.14.23`
-- `web-component` updated to version `3.43.17`
-
+* `react-sdk` updated to version `2.14.23`
+* `web-component` updated to version `3.43.17`
 ## [0.13.17](https://github.com/descope/descope-js/compare/nextjs-sdk-0.13.16...nextjs-sdk-0.13.17) (2025-06-11)
 
 ### Dependency Updates
 
-- `web-js-sdk` updated to version `1.33.4`
-- `react-sdk` updated to version `2.14.22`
-- `core-js-sdk` updated to version `2.44.3`
-- `web-component` updated to version `3.43.16`
-
+* `web-js-sdk` updated to version `1.33.4`
+* `react-sdk` updated to version `2.14.22`
+* `core-js-sdk` updated to version `2.44.3`
+* `web-component` updated to version `3.43.16`
 ## [0.13.16](https://github.com/descope/descope-js/compare/nextjs-sdk-0.13.15...nextjs-sdk-0.13.16) (2025-06-11)
 
 ### Dependency Updates
 
-- `web-js-sdk` updated to version `1.33.3`
-- `react-sdk` updated to version `2.14.21`
-- `core-js-sdk` updated to version `2.44.2`
-- `web-component` updated to version `3.43.15`
-
+* `web-js-sdk` updated to version `1.33.3`
+* `react-sdk` updated to version `2.14.21`
+* `core-js-sdk` updated to version `2.44.2`
+* `web-component` updated to version `3.43.15`
 ## [0.13.15](https://github.com/descope/descope-js/compare/nextjs-sdk-0.13.14...nextjs-sdk-0.13.15) (2025-05-22)
 
 ### Dependency Updates
 
-- `web-js-sdk` updated to version `1.33.2`
-- `react-sdk` updated to version `2.14.20`
-- `web-component` updated to version `3.43.14`
-
+* `web-js-sdk` updated to version `1.33.2`
+* `react-sdk` updated to version `2.14.20`
+* `web-component` updated to version `3.43.14`
 ## [0.13.14](https://github.com/descope/descope-js/compare/nextjs-sdk-0.13.13...nextjs-sdk-0.13.14) (2025-05-20)
 
 ### Dependency Updates
 
-- `react-sdk` updated to version `2.14.19`
-- `web-component` updated to version `3.43.13`
-
+* `react-sdk` updated to version `2.14.19`
+* `web-component` updated to version `3.43.13`
 ## [0.13.13](https://github.com/descope/descope-js/compare/nextjs-sdk-0.13.12...nextjs-sdk-0.13.13) (2025-05-18)
 
 ### Dependency Updates

--- a/packages/sdks/nextjs-sdk/CHANGELOG.md
+++ b/packages/sdks/nextjs-sdk/CHANGELOG.md
@@ -6,48 +6,55 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.14.25`
-* `web-component` updated to version `3.43.18`
+- `react-sdk` updated to version `2.14.25`
+- `web-component` updated to version `3.43.18`
+
 ## [0.13.19](https://github.com/descope/descope-js/compare/nextjs-sdk-0.13.18...nextjs-sdk-0.13.19) (2025-06-24)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.14.24`
+- `react-sdk` updated to version `2.14.24`
+
 ## [0.13.18](https://github.com/descope/descope-js/compare/nextjs-sdk-0.13.17...nextjs-sdk-0.13.18) (2025-06-13)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.14.23`
-* `web-component` updated to version `3.43.17`
+- `react-sdk` updated to version `2.14.23`
+- `web-component` updated to version `3.43.17`
+
 ## [0.13.17](https://github.com/descope/descope-js/compare/nextjs-sdk-0.13.16...nextjs-sdk-0.13.17) (2025-06-11)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.33.4`
-* `react-sdk` updated to version `2.14.22`
-* `core-js-sdk` updated to version `2.44.3`
-* `web-component` updated to version `3.43.16`
+- `web-js-sdk` updated to version `1.33.4`
+- `react-sdk` updated to version `2.14.22`
+- `core-js-sdk` updated to version `2.44.3`
+- `web-component` updated to version `3.43.16`
+
 ## [0.13.16](https://github.com/descope/descope-js/compare/nextjs-sdk-0.13.15...nextjs-sdk-0.13.16) (2025-06-11)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.33.3`
-* `react-sdk` updated to version `2.14.21`
-* `core-js-sdk` updated to version `2.44.2`
-* `web-component` updated to version `3.43.15`
+- `web-js-sdk` updated to version `1.33.3`
+- `react-sdk` updated to version `2.14.21`
+- `core-js-sdk` updated to version `2.44.2`
+- `web-component` updated to version `3.43.15`
+
 ## [0.13.15](https://github.com/descope/descope-js/compare/nextjs-sdk-0.13.14...nextjs-sdk-0.13.15) (2025-05-22)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.33.2`
-* `react-sdk` updated to version `2.14.20`
-* `web-component` updated to version `3.43.14`
+- `web-js-sdk` updated to version `1.33.2`
+- `react-sdk` updated to version `2.14.20`
+- `web-component` updated to version `3.43.14`
+
 ## [0.13.14](https://github.com/descope/descope-js/compare/nextjs-sdk-0.13.13...nextjs-sdk-0.13.14) (2025-05-20)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.14.19`
-* `web-component` updated to version `3.43.13`
+- `react-sdk` updated to version `2.14.19`
+- `web-component` updated to version `3.43.13`
+
 ## [0.13.13](https://github.com/descope/descope-js/compare/nextjs-sdk-0.13.12...nextjs-sdk-0.13.13) (2025-05-18)
 
 ### Dependency Updates

--- a/packages/sdks/nextjs-sdk/examples/app-router/app/api/echo-session/route.ts
+++ b/packages/sdks/nextjs-sdk/examples/app-router/app/api/echo-session/route.ts
@@ -1,0 +1,18 @@
+import { session } from '@descope/nextjs-sdk/server';
+import { headers } from 'next/headers';
+
+export const GET = async () => {
+	const allHeaders = await headers();
+	const projectId =
+		allHeaders.get('x-descope-project-id') ||
+		process.env.NEXT_PUBLIC_DESCOPE_PROJECT_ID;
+	const currentSession = await session({
+		projectId,
+		logLevel: process.env.DESCOPE_LOG_LEVEL as any
+	});
+	if (!currentSession) {
+		return new Response('Unauthorized', { status: 401 });
+	}
+
+	return new Response(JSON.stringify(currentSession, null, 2), { status: 200 });
+};

--- a/packages/sdks/nextjs-sdk/examples/app-router/app/page.tsx
+++ b/packages/sdks/nextjs-sdk/examples/app-router/app/page.tsx
@@ -4,7 +4,9 @@ import Link from 'next/link';
 import UserDetails from './UserDetails';
 
 const Page = async () => {
-	const sessionRes = await session();
+	const sessionRes = await session({
+		logLevel: process.env.DESCOPE_LOG_LEVEL as any
+	});
 	return (
 		<div>
 			<h1>App Router Home</h1>

--- a/packages/sdks/nextjs-sdk/examples/app-router/middleware.ts
+++ b/packages/sdks/nextjs-sdk/examples/app-router/middleware.ts
@@ -1,9 +1,25 @@
 import { authMiddleware } from '@descope/nextjs-sdk/server';
+import { NextRequest } from 'next/server';
 
-export default authMiddleware({
-	projectId: process.env.NEXT_PUBLIC_DESCOPE_PROJECT_ID,
-	baseUrl: process.env.NEXT_PUBLIC_DESCOPE_BASE_URL
-});
+export const middleware = async (request: NextRequest) => {
+	// get `x-descope-project-id header` from the request
+	const projectId =
+		request.headers.get('x-descope-project-id') ||
+		process.env.NEXT_PUBLIC_DESCOPE_PROJECT_ID;
+	console.debug('middleware project-id:', projectId);
+	const auth = authMiddleware({
+		projectId,
+		baseUrl: process.env.NEXT_PUBLIC_DESCOPE_BASE_URL,
+		logLevel: process.env.DESCOPE_LOG_LEVEL as any
+	});
+
+	const response = await auth(request);
+	// set the `x-descope-project-id` header in the response
+	if (projectId) {
+		response.headers.set('x-descope-project-id', projectId);
+	}
+	return response;
+};
 
 export const config = {
 	matcher: ['/((?!.+\\.[\\w]+$|_next).*)', '/', '/(api|trpc)(.*)']

--- a/packages/sdks/nextjs-sdk/src/server/authMiddleware.ts
+++ b/packages/sdks/nextjs-sdk/src/server/authMiddleware.ts
@@ -113,7 +113,7 @@ const createAuthMiddleware =
 	(options: MiddlewareOptions = {}) =>
 	async (req: NextRequest) => {
 		setLogger(options.logLevel);
-		logger.debug('Auth middleware starts');
+		logger.debug(`Auth middleware starts for route ${req.nextUrl.pathname}`);
 
 		const jwt = getSessionJwt(req);
 
@@ -140,12 +140,14 @@ const createAuthMiddleware =
 				if (searchParams) {
 					url.search = searchParams;
 				}
-				logger.debug(`Auth middleware, Redirecting to ${redirectUrl}`);
+				logger.debug(
+					`Auth middleware, Redirecting to ${redirectUrl} for route ${req.nextUrl.pathname}`
+				);
 				return NextResponse.redirect(url);
 			}
 		}
 
-		logger.debug('Auth middleware finishes');
+		logger.debug(`Auth middleware finishes for route ${req.nextUrl.pathname}`);
 		// add the session to the request, if it exists
 		const headers = addSessionToHeadersIfExists(req.headers, session);
 		return NextResponse.next({

--- a/packages/sdks/nextjs-sdk/src/server/sdk.ts
+++ b/packages/sdks/nextjs-sdk/src/server/sdk.ts
@@ -13,13 +13,15 @@ type CreateSdkParams = Pick<CreateServerSdkParams, 'projectId' | 'baseUrl'>;
 
 let globalSdk: Sdk;
 
+const getProjectId = (config?: CreateSdkParams): string =>
+	config?.projectId ||
+	process.env.NEXT_PUBLIC_DESCOPE_PROJECT_ID ||
+	process.env.DESCOPE_PROJECT_ID; // the last one for backward compatibility
+
 export const createSdk = (config?: CreateServerSdkParams): Sdk =>
 	descopeSdk({
 		...config,
-		projectId:
-			config?.projectId ||
-			process.env.NEXT_PUBLIC_DESCOPE_PROJECT_ID ||
-			process.env.DESCOPE_PROJECT_ID, // the last one for backward compatibility
+		projectId: getProjectId(config),
 		managementKey: config?.managementKey || process.env.DESCOPE_MANAGEMENT_KEY,
 		baseUrl:
 			config?.baseUrl ||
@@ -32,12 +34,9 @@ export const createSdk = (config?: CreateServerSdkParams): Sdk =>
 	});
 
 export const getGlobalSdk = (config?: CreateSdkParams): Sdk => {
+	const projectId = getProjectId(config);
 	if (!globalSdk) {
-		if (
-			!config?.projectId &&
-			!process.env.DESCOPE_PROJECT_ID &&
-			!process.env.NEXT_PUBLIC_DESCOPE_PROJECT_ID
-		) {
+		if (!projectId) {
 			throw new Error('Descope project ID is required to create the SDK');
 		}
 		globalSdk = createSdk(config);

--- a/packages/sdks/nextjs-sdk/src/server/sdk.ts
+++ b/packages/sdks/nextjs-sdk/src/server/sdk.ts
@@ -11,7 +11,8 @@ type CreateServerSdkParams = Omit<
 
 type CreateSdkParams = Pick<CreateServerSdkParams, 'projectId' | 'baseUrl'>;
 
-let globalSdk: Sdk;
+// we support multiple sdks, so the developer can work with multiple projects
+const globalSdks: Record<string, Sdk> = {};
 
 const getProjectId = (config?: CreateSdkParams): string =>
 	config?.projectId ||
@@ -33,12 +34,14 @@ export const createSdk = (config?: CreateServerSdkParams): Sdk =>
 		}
 	});
 
+// caches the SDK for each project ID
 export const getGlobalSdk = (config?: CreateSdkParams): Sdk => {
 	const projectId = getProjectId(config);
+	if (!projectId) {
+		throw new Error('Descope project ID is required to create the SDK');
+	}
+	let globalSdk = globalSdks[projectId];
 	if (!globalSdk) {
-		if (!projectId) {
-			throw new Error('Descope project ID is required to create the SDK');
-		}
 		globalSdk = createSdk(config);
 	}
 

--- a/packages/sdks/nextjs-sdk/src/server/sdk.ts
+++ b/packages/sdks/nextjs-sdk/src/server/sdk.ts
@@ -43,6 +43,7 @@ export const getGlobalSdk = (config?: CreateSdkParams): Sdk => {
 	let globalSdk = globalSdks[projectId];
 	if (!globalSdk) {
 		globalSdk = createSdk(config);
+		globalSdks[projectId] = globalSdk;
 	}
 
 	return globalSdk;


### PR DESCRIPTION

## Description

related to https://github.com/descope/descope-js/pull/1154

These changes sample how to work with multiple demo
you could 
 - work with the sample app with the "main" project
 - use curl to work with different demo using a dedicated header
 ```
 curl http://localhost:3000/api/echo-session  -H "Accept: application/json"  -H "Authorization: Bearer $token" -H "x-descope-project-id: <token-project-id>"
 ``` 
 