### PR TITLE
feat: try refresh API on init

### DIFF
--- a/packages/sdks/core-js-sdk/src/constants/apiPaths.ts
+++ b/packages/sdks/core-js-sdk/src/constants/apiPaths.ts
@@ -88,6 +88,7 @@ export default {
     policy: '/v1/auth/password/policy',
   },
   refresh: '/v1/auth/refresh',
+  tryRefresh: '/v1/auth/try-refresh',
   selectTenant: '/v1/auth/tenant/select',
   logout: '/v1/auth/logout',
   logoutAll: '/v1/auth/logoutall',

--- a/packages/sdks/core-js-sdk/src/sdk/index.ts
+++ b/packages/sdks/core-js-sdk/src/sdk/index.ts
@@ -61,6 +61,8 @@ export default (httpClient: HttpClient) => ({
    * Should be called when a session has expired (failed validation) to renew it
    * @param token A valid refresh token
    * @param queryParams Additional query parameters to send with the request.
+   * @param externalToken An external token to exchange for a new session token
+   * @param tryRefresh If true, will use the tryRefresh endpoint, which will not fail if token is missing, invalid or expired.
    *    NOTE - queryParams is used internally and should NOT be used by other consumers, this is subject to change and may be removed in the near future.
    * @returns The updated authentication info (JWTs)
    */
@@ -69,13 +71,15 @@ export default (httpClient: HttpClient) => ({
       token?: string,
       queryParams?: { [key: string]: string },
       externalToken?: string,
+      tryRefresh?: boolean,
     ) => {
       const body = {};
       if (externalToken) {
         body['externalToken'] = externalToken;
       }
+      const path = tryRefresh ? apiPaths.tryRefresh : apiPaths.refresh;
       return transformResponse<JWTResponse>(
-        httpClient.post(apiPaths.refresh, body, { token, queryParams }),
+        httpClient.post(path, body, { token, queryParams }),
       );
     },
   ),

--- a/packages/sdks/react-sdk/src/components/AuthProvider/AuthProvider.tsx
+++ b/packages/sdks/react-sdk/src/components/AuthProvider/AuthProvider.tsx
@@ -120,7 +120,7 @@ const AuthProvider: FC<IAuthProviderProps> = ({
     isSessionFetched.current = true;
 
     setIsSessionLoading(true);
-    withValidation(sdk?.refresh)().then(() => {
+    withValidation(sdk?.refresh)(undefined, true).then(() => {
       setIsSessionLoading(false);
     });
   }, [sdk]);

--- a/packages/sdks/web-js-sdk/src/sdk/index.ts
+++ b/packages/sdks/web-js-sdk/src/sdk/index.ts
@@ -18,7 +18,10 @@ const createSdk = (config: WebSdkConfig) => {
 
   return {
     ...coreSdk,
-    refresh: async (token?: string): ReturnType<CoreSdk['refresh']> => {
+    refresh: async (
+      token?: string,
+      tryRefresh?: boolean,
+    ): ReturnType<CoreSdk['refresh']> => {
       if (config.oidcConfig) {
         try {
           await oidc.refreshToken(token);
@@ -55,6 +58,7 @@ const createSdk = (config: WebSdkConfig) => {
           dcr: currentRefreshToken ? 't' : 'f',
         },
         externalToken,
+        tryRefresh,
       );
     },
     // Call the logout function according to the oidcConfig


### PR DESCRIPTION
## Related Issues
https://github.com/descope/etc/issues/2862


## Description
This pull request introduces support for a new "try refresh" authentication endpoint across the JS SDKs, allowing for more flexible session refresh logic that does not fail when the token is missing, invalid, or expired. The main changes include updating the API paths, enhancing the `refresh` method across SDK layers to optionally use the new endpoint, and updating the React AuthProvider to leverage this behavior.

**Authentication refresh enhancements:**

* Added a new `tryRefresh` endpoint to `apiPaths`, enabling a non-failing session refresh option.
* Updated the core SDK's `refresh` method to accept a `tryRefresh` boolean parameter, which determines whether to use the standard or new endpoint. The method now also documents the new parameter in its JSDoc. [[1]](diffhunk://#diff-b54ba820e510c7d454f01a60518f72e5733d0b0080845ca8876fec6f13747c41R64-R65) [[2]](diffhunk://#diff-b54ba820e510c7d454f01a60518f72e5733d0b0080845ca8876fec6f13747c41R74-R82)
* Updated the web SDK's `refresh` method to accept and forward the `tryRefresh` parameter to the core SDK, ensuring consistent behavior across SDK layers. [[1]](diffhunk://#diff-ae711197d7d2a9a89b857b679df66e4ac741a0f52dac4da7e49240f7fc40d03fL21-R24) [[2]](diffhunk://#diff-ae711197d7d2a9a89b857b679df66e4ac741a0f52dac4da7e49240f7fc40d03fR61)

