### PR TITLE
feat: add oidcResource parameter to SDK start options

### DIFF
--- a/packages/sdks/core-js-sdk/src/sdk/types.ts
+++ b/packages/sdks/core-js-sdk/src/sdk/types.ts
@@ -346,6 +346,7 @@ export type Options = {
   locale?: string;
   oidcPrompt?: string;
   oidcErrorRedirectUri?: string;
+  oidcResource?: string;
   nativeOptions?: NativeOptions;
   thirdPartyAppStateId?: string;
   applicationScopes?: string; // Relevant for sso application and third party application

--- a/packages/sdks/web-component/src/lib/constants/index.ts
+++ b/packages/sdks/web-component/src/lib/constants/index.ts
@@ -27,6 +27,7 @@ export const THIRD_PARTY_APP_ID_PARAM_NAME = 'third_party_app_id';
 export const THIRD_PARTY_APP_STATE_ID_PARAM_NAME = 'third_party_app_state_id';
 export const OIDC_LOGIN_HINT_PARAM_NAME = 'oidc_login_hint';
 export const OIDC_PROMPT_PARAM_NAME = 'oidc_prompt';
+export const OIDC_RESOURCE_PARAM_NAME = 'oidc_resource';
 export const OIDC_ERROR_REDIRECT_URI_PARAM_NAME = 'oidc_error_redirect_uri';
 export const APPLICATION_SCOPES_PARAM_NAME = 'application_scopes';
 

--- a/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
+++ b/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
@@ -997,8 +997,13 @@ class DescopeWc extends BaseDescopeWc {
       readyScreenId,
     );
 
-    const { oidcLoginHint, oidcPrompt, oidcErrorRedirectUri, samlIdpUsername } =
-      ssoQueryParams;
+    const {
+      oidcLoginHint,
+      oidcPrompt,
+      oidcErrorRedirectUri,
+      oidcResource,
+      samlIdpUsername,
+    } = ssoQueryParams;
 
     // generate step state update data
     const stepStateUpdate: Partial<StepState> = {
@@ -1027,6 +1032,7 @@ class DescopeWc extends BaseDescopeWc {
       oidcLoginHint,
       oidcPrompt,
       oidcErrorRedirectUri,
+      oidcResource,
       action,
     };
 

--- a/packages/sdks/web-component/src/lib/helpers/helpers.ts
+++ b/packages/sdks/web-component/src/lib/helpers/helpers.ts
@@ -18,6 +18,7 @@ import {
   DESCOPE_IDP_INITIATED_PARAM_NAME,
   OVERRIDE_CONTENT_URL,
   OIDC_PROMPT_PARAM_NAME,
+  OIDC_RESOURCE_PARAM_NAME,
   OIDC_ERROR_REDIRECT_URI_PARAM_NAME,
   THIRD_PARTY_APP_ID_PARAM_NAME,
   THIRD_PARTY_APP_STATE_ID_PARAM_NAME,
@@ -292,6 +293,14 @@ export function clearOIDCErrorRedirectUriParamFromUrl() {
   resetUrlParam(OIDC_ERROR_REDIRECT_URI_PARAM_NAME);
 }
 
+export function getOIDCResourceParamFromUrl() {
+  return getUrlParam(OIDC_RESOURCE_PARAM_NAME);
+}
+
+export function clearOIDCResourceParamFromUrl() {
+  resetUrlParam(OIDC_RESOURCE_PARAM_NAME);
+}
+
 export const camelCase = (s: string) =>
   s.replace(/-./g, (x) => x[1].toUpperCase());
 
@@ -418,6 +427,11 @@ export const handleUrlParams = (
     clearOIDCErrorRedirectUriParamFromUrl();
   }
 
+  const oidcResource = getOIDCResourceParamFromUrl();
+  if (oidcResource) {
+    clearOIDCResourceParamFromUrl();
+  }
+
   const idpInitiatedVal = descopeIdpInitiated === 'true';
 
   return {
@@ -440,6 +454,7 @@ export const handleUrlParams = (
       oidcLoginHint,
       oidcPrompt,
       oidcErrorRedirectUri,
+      oidcResource,
       thirdPartyAppId,
       thirdPartyAppStateId,
       applicationScopes,
@@ -616,6 +631,7 @@ export const showFirstScreenOnExecutionInit = (
     oidcLoginHint,
     oidcPrompt,
     oidcErrorRedirectUri,
+    oidcResource,
     thirdPartyAppId,
     thirdPartyAppStateId,
     applicationScopes,
@@ -629,6 +645,7 @@ export const showFirstScreenOnExecutionInit = (
   !oidcLoginHint &&
   !oidcPrompt &&
   !oidcErrorRedirectUri &&
+  !oidcResource &&
   !thirdPartyAppId &&
   !thirdPartyAppStateId &&
   !applicationScopes;

--- a/packages/sdks/web-component/src/lib/types.ts
+++ b/packages/sdks/web-component/src/lib/types.ts
@@ -80,6 +80,7 @@ export type OIDCOptions = {
   oidcLoginHint?: string;
   oidcPrompt?: string;
   oidcErrorRedirectUri?: string;
+  oidcResource?: string;
 };
 
 export type Locale = {

--- a/packages/sdks/web-component/test/descope-wc.test.ts
+++ b/packages/sdks/web-component/test/descope-wc.test.ts
@@ -3975,9 +3975,7 @@ describe('web-component', () => {
     startMock.mockReturnValueOnce(generateSdkResponse());
 
     configContent = {
-      ...configContent,
       flows: {
-        ...configContent.flows,
         'sign-in': { startScreenId: 'screen-0' },
       },
     };

--- a/packages/sdks/web-component/test/descope-wc.test.ts
+++ b/packages/sdks/web-component/test/descope-wc.test.ts
@@ -53,7 +53,7 @@ jest.mock('@descope/web-js-sdk', () => ({
   ensureFingerprintIds: jest.fn(),
 }));
 
-const WAIT_TIMEOUT = 20000;
+const WAIT_TIMEOUT = 25000;
 const THEME_DEFAULT_FILENAME = `theme.json`;
 
 const abTestingKey = getABTestingKey();

--- a/packages/sdks/web-component/test/helpers/index.test.ts
+++ b/packages/sdks/web-component/test/helpers/index.test.ts
@@ -1,5 +1,8 @@
 import { waitFor } from '@testing-library/dom';
-import { URL_RUN_IDS_PARAM_NAME } from '../../src/lib/constants';
+import {
+  URL_RUN_IDS_PARAM_NAME,
+  OIDC_RESOURCE_PARAM_NAME,
+} from '../../src/lib/constants';
 import { dragElement } from '../../src/lib/helpers';
 import {
   clearRunIdsFromUrl,
@@ -10,6 +13,8 @@ import {
   isChromium,
   setRunIdsOnUrl,
   withMemCache,
+  getOIDCResourceParamFromUrl,
+  clearOIDCResourceParamFromUrl,
 } from '../../src/lib/helpers/helpers';
 
 const mockFetch = jest.fn();
@@ -117,6 +122,39 @@ describe('helpers', () => {
     window.history.replaceState = replaceState;
     clearRunIdsFromUrl();
     expect(replaceState).toHaveBeenCalledWith({}, '', `http://localhost/`);
+  });
+
+  describe('oidcResource URL params', () => {
+    it('getOIDCResourceParamFromUrl should return oidcResource param from URL', () => {
+      Object.defineProperty(window, 'location', {
+        writable: true,
+        value: new URL(
+          `http://localhost/?${OIDC_RESOURCE_PARAM_NAME}=https%3A%2F%2Fapi.example.com`,
+        ),
+      });
+      expect(getOIDCResourceParamFromUrl()).toBe('https://api.example.com');
+    });
+
+    it('getOIDCResourceParamFromUrl should return null when param is not present', () => {
+      Object.defineProperty(window, 'location', {
+        writable: true,
+        value: new URL('http://localhost/'),
+      });
+      expect(getOIDCResourceParamFromUrl()).toBe(null);
+    });
+
+    it('clearOIDCResourceParamFromUrl should remove oidcResource param from URL', () => {
+      Object.defineProperty(window, 'location', {
+        writable: true,
+        value: new URL(
+          `http://localhost/?${OIDC_RESOURCE_PARAM_NAME}=https%3A%2F%2Fapi.example.com`,
+        ),
+      });
+      const replaceState = jest.fn();
+      window.history.replaceState = replaceState;
+      clearOIDCResourceParamFromUrl();
+      expect(replaceState).toHaveBeenCalledWith({}, '', `http://localhost/`);
+    });
   });
 
   describe('isChromium', () => {

--- a/packages/sdks/web-js-sdk/src/sdk/flow.ts
+++ b/packages/sdks/web-js-sdk/src/sdk/flow.ts
@@ -19,6 +19,7 @@ type Options = Pick<
   | 'locale'
   | 'oidcPrompt'
   | 'oidcErrorRedirectUri'
+  | 'oidcResource'
   | 'nativeOptions'
   | 'thirdPartyAppStateId'
   | 'applicationScopes'

--- a/packages/sdks/web-js-sdk/test/sdk.test.ts
+++ b/packages/sdks/web-js-sdk/test/sdk.test.ts
@@ -66,6 +66,25 @@ describe('sdk', () => {
     });
   });
 
+  it('should send oidcResource in start option if provided', async () => {
+    const mockFetch = jest
+      .fn()
+      .mockReturnValue(createMockReturnValue(flowResponse));
+    global.fetch = mockFetch;
+    const sdk = createSdk({ projectId: 'pid' });
+    await sdk.flow.start('id', { oidcResource: 'https://api.example.com' });
+    expect(mockFetch).toBeCalledWith(
+      'https://api.descope.com/v1/flow/start',
+      expect.any(Object),
+    );
+    expect(JSON.parse(mockFetch.mock.calls[0][1].body)).toMatchObject({
+      options: {
+        oidcResource: 'https://api.example.com',
+        startOptionsVersion: 1,
+      },
+    });
+  });
+
   it('should set dcs and dcr query params to false on refresh when the refresh and session token do not exist', async () => {
     localStorage.removeItem('DS'); // no session token
     localStorage.removeItem('DSR'); // no refresh token


### PR DESCRIPTION
## Related Issues

Related https://github.com/descope/etc/issues/11683

## Description

Adds oidcResource parameter support across Descope JS SDK packages for OIDC resource specification in authentication flows.
