### PR TITLE
fix: Ensure popup for Apple OAuth on Mac Safari RELEASE

### DIFF
--- a/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
+++ b/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
@@ -870,7 +870,6 @@ class DescopeWc extends BaseDescopeWc {
         }, 1000);
 
         this.loggerWrapper.debug('Listening for postMessage on channel');
-
         const onPostMessage = (event: MessageEvent) => {
           this.loggerWrapper.debug(
             'Received postMessage on channel',

--- a/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
+++ b/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
@@ -847,14 +847,7 @@ class DescopeWc extends BaseDescopeWc {
       if (redirectIsPopup) {
         // this width is below the breakpoint of most providers
         this.loggerWrapper.debug('Opening redirect in popup');
-        const popup = openCenteredPopup(
-          redirectTo,
-          '?',
-          598,
-          700,
-          2000,
-          this.loggerWrapper,
-        );
+        const popup = openCenteredPopup(redirectTo, '?', 598, 700);
 
         this.loggerWrapper.debug('Creating broadcast channel');
         const channel = new BroadcastChannel(executionId);

--- a/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
+++ b/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
@@ -847,7 +847,14 @@ class DescopeWc extends BaseDescopeWc {
       if (redirectIsPopup) {
         // this width is below the breakpoint of most providers
         this.loggerWrapper.debug('Opening redirect in popup');
-        const popup = openCenteredPopup(redirectTo, '?', 598, 700);
+        const popup = openCenteredPopup(
+          redirectTo,
+          '?',
+          598,
+          700,
+          2000,
+          this.loggerWrapper,
+        );
 
         this.loggerWrapper.debug('Creating broadcast channel');
         const channel = new BroadcastChannel(executionId);

--- a/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
+++ b/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
@@ -870,6 +870,7 @@ class DescopeWc extends BaseDescopeWc {
         }, 1000);
 
         this.loggerWrapper.debug('Listening for postMessage on channel');
+
         const onPostMessage = (event: MessageEvent) => {
           this.loggerWrapper.debug(
             'Received postMessage on channel',

--- a/packages/sdks/web-component/src/lib/helpers/helpers.ts
+++ b/packages/sdks/web-component/src/lib/helpers/helpers.ts
@@ -808,10 +808,8 @@ export const openCenteredPopup = (
     `width=${w},height=${h},top=${top},left=${left},scrollbars=yes,resizable=yes`,
   );
 
-  if (popup) {
-    popup.location.href = url;
-    popup.focus();
-  }
+  popup.location.href = url;
+  popup.focus();
 
   return popup;
 };

--- a/packages/sdks/web-component/src/lib/helpers/helpers.ts
+++ b/packages/sdks/web-component/src/lib/helpers/helpers.ts
@@ -772,6 +772,10 @@ export function getScriptResultPath(scriptId: string, resultKey?: string) {
   return `${SDK_SCRIPT_RESULTS_KEY}.${path}`;
 }
 
+function isWindowEmpty(w: Window) {
+  return !w.document.body.textContent?.trim();
+}
+
 export const openCenteredPopup = (
   url: string,
   title: string,
@@ -815,6 +819,28 @@ export const openCenteredPopup = (
 
   if (popup) {
     popup.location.href = url;
+    popup.focus();
+
+    // Poll to check if the popup document is empty and the popup is focused
+    const pollInterval = setInterval(() => {
+      try {
+        if (popup.closed) {
+          clearInterval(pollInterval);
+          return;
+        }
+        if (
+          popup.document.hasFocus &&
+          popup.document.hasFocus() &&
+          isWindowEmpty(popup)
+        ) {
+          popup.close();
+          clearInterval(pollInterval);
+        }
+      } catch (e) {
+        clearInterval(pollInterval);
+      }
+    }, 1000);
+
     popup.focus();
   }
 

--- a/packages/sdks/web-component/src/lib/helpers/helpers.ts
+++ b/packages/sdks/web-component/src/lib/helpers/helpers.ts
@@ -785,7 +785,7 @@ export const openCenteredPopup = (
   title: string,
   w: number,
   h: number,
-  intervalId: number,
+  intervalMs: number,
   logger: { debug: (...data: any[]) => void },
 ) => {
   const dualScreenLeft =
@@ -850,7 +850,7 @@ export const openCenteredPopup = (
         logger.debug('Popup: Polling error - clearing interval', e);
         clearInterval(closePopupInterval);
       }
-    }, intervalId);
+    }, intervalMs);
 
     popup.onclose = () => {
       logger.debug('Popup: Closing and clearing interval');

--- a/packages/sdks/web-component/src/lib/helpers/helpers.ts
+++ b/packages/sdks/web-component/src/lib/helpers/helpers.ts
@@ -772,10 +772,8 @@ export function getScriptResultPath(scriptId: string, resultKey?: string) {
   return `${SDK_SCRIPT_RESULTS_KEY}.${path}`;
 }
 
-function closePopup(popup) {
-  if (!popup.document.body.textContent?.trim()) {
-    popup.close();
-  }
+function isWindowEmpty(w: Window) {
+  return !w.document.body.textContent?.trim();
 }
 
 export const openCenteredPopup = (
@@ -824,9 +822,13 @@ export const openCenteredPopup = (
     popup.focus();
 
     // Handle the "Cancel" scenario for macOS native auth dialog.
-    // The native dialog doesn't emit JavaScript events when cancelled, leaving the popup blank.
-    // If the popup remains empty after 1 second, assume the user cancelled and close it automatically.
-    setTimeout(() => closePopup(popup), 1000);
+    // When users cancel the native dialog, no JavaScript events are emitted and the popup remains blank.
+    // If the popup is still empty after 1 second, assume cancellation and close it automatically.
+    setTimeout(() => {
+      if (isWindowEmpty(popup)) {
+        popup.close();
+      }
+    }, 1000);
   }
 
   return popup;

--- a/packages/sdks/web-component/src/lib/helpers/helpers.ts
+++ b/packages/sdks/web-component/src/lib/helpers/helpers.ts
@@ -839,6 +839,7 @@ export const openCenteredPopup = (
           logger.debug('Popup: Empty, closing and clearing interval');
           popup.close();
           clearInterval(closePopupInterval);
+          return;
         }
         if (popup.closed) {
           logger.debug('Popup: Already closed, clearing interval');

--- a/packages/sdks/web-component/src/lib/helpers/helpers.ts
+++ b/packages/sdks/web-component/src/lib/helpers/helpers.ts
@@ -777,7 +777,7 @@ function isPopupEmpty(popup: Window) {
 }
 
 function isPopupFocused(popup: Window) {
-  return popup.document.hasFocus && popup.document.hasFocus?.();
+  return popup.document.hasFocus?.();
 }
 
 export const openCenteredPopup = (

--- a/packages/sdks/web-component/src/lib/helpers/helpers.ts
+++ b/packages/sdks/web-component/src/lib/helpers/helpers.ts
@@ -777,7 +777,7 @@ function isPopupEmpty(popup: Window) {
 }
 
 function isPopupFocused(popup: Window) {
-  return popup.document.hasFocus && popup.document.hasFocus();
+  return popup.document.hasFocus && popup.document.hasFocus?.();
 }
 
 export const openCenteredPopup = (

--- a/packages/sdks/web-component/src/lib/helpers/helpers.ts
+++ b/packages/sdks/web-component/src/lib/helpers/helpers.ts
@@ -808,6 +808,12 @@ export const openCenteredPopup = (
   if (popup) {
     popup.location.href = url;
     popup.focus();
+
+    setTimeout(() => {
+      if (!popup.document.body.textContent) {
+        popup.close();
+      }
+    }, 1000);
   }
 
   return popup;

--- a/packages/sdks/web-component/src/lib/helpers/helpers.ts
+++ b/packages/sdks/web-component/src/lib/helpers/helpers.ts
@@ -800,10 +800,12 @@ export const openCenteredPopup = (
   const top = (height - h) / 2 + dualScreenTop;
 
   const popup = window.open(
-    url,
+    'about:blank',
     title,
     `width=${w},height=${h},top=${top},left=${left},scrollbars=yes,resizable=yes`,
   );
+
+  popup.location.href = url;
 
   popup.focus();
 

--- a/packages/sdks/web-component/src/lib/helpers/helpers.ts
+++ b/packages/sdks/web-component/src/lib/helpers/helpers.ts
@@ -772,10 +772,6 @@ export function getScriptResultPath(scriptId: string, resultKey?: string) {
   return `${SDK_SCRIPT_RESULTS_KEY}.${path}`;
 }
 
-function isWindowEmpty(w: Window) {
-  return !w.document.body.textContent?.trim();
-}
-
 export const openCenteredPopup = (
   url: string,
   title: string,
@@ -820,15 +816,6 @@ export const openCenteredPopup = (
   if (popup) {
     popup.location.href = url;
     popup.focus();
-
-    // Handle the "Cancel" scenario for macOS native auth dialog.
-    // When users cancel the native dialog, no JavaScript events are emitted and the popup remains blank.
-    // If the popup is still empty after 1 second, assume cancellation and close it automatically.
-    setTimeout(() => {
-      if (isWindowEmpty(popup)) {
-        popup.close();
-      }
-    }, 1000);
   }
 
   return popup;

--- a/packages/sdks/web-component/src/lib/helpers/helpers.ts
+++ b/packages/sdks/web-component/src/lib/helpers/helpers.ts
@@ -842,7 +842,7 @@ export const openCenteredPopup = (
           return;
         }
       } catch (e) {
-        logger.debug('Popup: Polling error - clearing interval', e);
+        logger.debug('Popup: Polling error, clearing interval', e);
         clearInterval(closePopupInterval);
       }
     }, intervalMs);

--- a/packages/sdks/web-component/src/lib/helpers/helpers.ts
+++ b/packages/sdks/web-component/src/lib/helpers/helpers.ts
@@ -773,7 +773,7 @@ export function getScriptResultPath(scriptId: string, resultKey?: string) {
 }
 
 function closePopup(popup) {
-  if (!popup.document.body.textContent) {
+  if (!popup.document.body.textContent?.trim()) {
     popup.close();
   }
 }

--- a/packages/sdks/web-component/src/lib/helpers/helpers.ts
+++ b/packages/sdks/web-component/src/lib/helpers/helpers.ts
@@ -777,8 +777,6 @@ export const openCenteredPopup = (
   title: string,
   w: number,
   h: number,
-  intervalMs: number,
-  logger: { debug: (...data: any[]) => void },
 ) => {
   const dualScreenLeft =
     window.screenLeft !== undefined

--- a/packages/sdks/web-component/src/lib/helpers/helpers.ts
+++ b/packages/sdks/web-component/src/lib/helpers/helpers.ts
@@ -805,9 +805,10 @@ export const openCenteredPopup = (
     `width=${w},height=${h},top=${top},left=${left},scrollbars=yes,resizable=yes`,
   );
 
-  popup.location.href = url;
-
-  popup.focus();
+  if (popup) {
+    popup.location.href = url;
+    popup.focus();
+  }
 
   return popup;
 };

--- a/packages/sdks/web-component/src/lib/helpers/helpers.ts
+++ b/packages/sdks/web-component/src/lib/helpers/helpers.ts
@@ -772,14 +772,6 @@ export function getScriptResultPath(scriptId: string, resultKey?: string) {
   return `${SDK_SCRIPT_RESULTS_KEY}.${path}`;
 }
 
-function isPopupEmpty(popup: Window) {
-  return !popup.document.body.textContent?.trim();
-}
-
-function isPopupFocused(popup: Window) {
-  return popup.document.hasFocus?.();
-}
-
 export const openCenteredPopup = (
   url: string,
   title: string,
@@ -830,12 +822,15 @@ export const openCenteredPopup = (
     // Poll to check if the popup document is empty and the popup is focused
     const closePopupInterval = setInterval(() => {
       try {
-        if (!isPopupEmpty(popup)) {
+        const isFocused = popup.document.hasFocus?.();
+        const isEmpty = !popup.document.body.textContent?.trim();
+
+        if (!isEmpty) {
           logger.debug('Popup: Has content, clearing interval');
           clearInterval(closePopupInterval);
           return;
         }
-        if (isPopupEmpty(popup) && isPopupFocused(popup)) {
+        if (isEmpty && isFocused) {
           logger.debug('Popup: Empty, closing and clearing interval');
           popup.close();
           clearInterval(closePopupInterval);


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/12037

https://github.com/user-attachments/assets/7e93e85b-98b2-4a38-93b8-0e645e9e7f5b

## Description

Ensure popup is opened to communicate with broadcast channel, and the inject URL to it.
In case of inactivity (e.g. Cancel from the native UI) - poll to see if popup should be closed.

## Must

- [ ] Tests
- [ ] Documentation (if applicable)
