### PR TITLE
fix(react-sdk/AuthProvider): workaround Next.js serialization when sessionTokenViaCookie = {} RELEASE

### DIFF
--- a/packages/sdks/react-sdk/README.md
+++ b/packages/sdks/react-sdk/README.md
@@ -464,13 +464,12 @@ If you are migrating from an external authentication provider to Descope, you ca
 import { AuthProvider } from '@descope/react-sdk';
 
 const AppRoot = () => {
+  const externalToken = useCallback(async () => "test", []);
+
   return (
     <AuthProvider
       projectId="my-project-id"
-      getExternalToken={async () => {
-        // Bring token from external provider (e.g. get access token from another auth provider)
-        return 'my-external-token';
-      }}
+      getExternalToken={externalToken}
     >
       <App />
     </AuthProvider>

--- a/packages/sdks/react-sdk/README.md
+++ b/packages/sdks/react-sdk/README.md
@@ -464,7 +464,10 @@ If you are migrating from an external authentication provider to Descope, you ca
 import { AuthProvider } from '@descope/react-sdk';
 
 const AppRoot = () => {
-  const externalToken = useCallback(async () => "test", []);
+  const externalToken = useCallback(async () => {
+    // Bring token from external provider (e.g. get access token from another auth provider)
+    return 'my-external-token';
+  }, []);
 
   return (
     <AuthProvider

--- a/packages/sdks/react-sdk/src/components/AuthProvider/useSdk.ts
+++ b/packages/sdks/react-sdk/src/components/AuthProvider/useSdk.ts
@@ -45,4 +45,15 @@ export default ({
       keepLastAuthenticatedUserAfterLogout,
       getExternalToken,
     });
-  }, [projectId, baseUrl, sessionTokenViaCookie, getExternalToken]);
+  }, [
+    projectId,
+    baseUrl,
+    // HACK: Avoid creating another instance of the SDK if the consumer of this
+    // component forgot to `useMemo` the object.
+    // This is also necessary for a workaround with Next.js SSR when including AuthProvider
+    // in RootLayout with another component that forces rerenders.
+    //
+    // See: https://github.com/descope/etc/issues/11965
+    JSON.stringify(sessionTokenViaCookie),
+    getExternalToken,
+  ]);

--- a/packages/sdks/react-sdk/src/components/AuthProvider/useSdk.ts
+++ b/packages/sdks/react-sdk/src/components/AuthProvider/useSdk.ts
@@ -48,7 +48,7 @@ export default ({
   }, [
     projectId,
     baseUrl,
-    // HACK: Avoid creating another instance of the SDK if the consumer of this
+    // NOTE: Avoid creating another instance of the SDK if the consumer of this
     // component forgot to `useMemo` the object.
     // This is also necessary for a workaround with Next.js SSR when including AuthProvider
     // in RootLayout with another component that forces rerenders.

--- a/packages/sdks/react-sdk/test/components/AuthProvider.test.tsx
+++ b/packages/sdks/react-sdk/test/components/AuthProvider.test.tsx
@@ -69,4 +69,53 @@ describe('AuthProvider', () => {
       );
     });
   });
+
+  it('Should init sdk config only once with identical seperate instances of object props', async () => {
+    const opts = JSON.stringify(`{"secure":"false"}`);
+
+    const { rerender } = render(
+      <AuthProvider projectId="pr1" sessionTokenViaCookie={JSON.parse(opts)} />,
+    );
+
+    rerender(
+      <AuthProvider projectId="pr1" sessionTokenViaCookie={JSON.parse(opts)} />,
+    );
+
+    await waitFor(() => {
+      expect(createSdk).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('Should init sdk config twice with different prop objects', async () => {
+    const { rerender } = render(
+      <AuthProvider
+        projectId="pr1"
+        sessionTokenViaCookie={{ secure: false }}
+      />,
+    );
+
+    rerender(
+      <AuthProvider projectId="pr1" sessionTokenViaCookie={{ secure: true }} />,
+    );
+
+    await waitFor(() => {
+      expect(createSdk).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('Should init sdk config twice with mutated prop object', async () => {
+    const opt = { secure: false };
+
+    const { rerender } = render(
+      <AuthProvider projectId="pr1" sessionTokenViaCookie={opt} />,
+    );
+
+    opt.secure = true;
+
+    rerender(<AuthProvider projectId="pr1" sessionTokenViaCookie={opt} />);
+
+    await waitFor(() => {
+      expect(createSdk).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/packages/sdks/react-sdk/test/components/AuthProvider.test.tsx
+++ b/packages/sdks/react-sdk/test/components/AuthProvider.test.tsx
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { createSdk } from '@descope/web-js-sdk';
 import { render, waitFor } from '@testing-library/react';
-import React from 'react';
+import React, { useCallback } from 'react';
 import AuthProvider from '../../src/components/AuthProvider';
 
 jest.mock('@descope/web-js-sdk', () => ({ createSdk: jest.fn(() => {}) }));
@@ -116,6 +116,40 @@ describe('AuthProvider', () => {
 
     await waitFor(() => {
       expect(createSdk).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('Should init sdk config twice when getExternalToken redeclared (wrong usage)', async () => {
+    const TestComponent = () => {
+      const getExternalToken = async () => 'meow';
+      return (
+        <AuthProvider projectId="pr1" getExternalToken={getExternalToken} />
+      );
+    };
+
+    const { rerender } = render(<TestComponent />);
+
+    rerender(<TestComponent />);
+
+    await waitFor(() => {
+      expect(createSdk).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('Should init sdk config once when getExternalToken wrapped in useCallback', async () => {
+    const TestComponent = () => {
+      const getExternalToken = useCallback(async () => 'meow', []);
+      return (
+        <AuthProvider projectId="pr1" getExternalToken={getExternalToken} />
+      );
+    };
+
+    const { rerender } = render(<TestComponent />);
+
+    rerender(<TestComponent />);
+
+    await waitFor(() => {
+      expect(createSdk).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/11965

## Description
When using the React SDK through Next.js there's an edge case that can
cause the `useMemo` in packages/sdks/react-sdk/src/components/AuthProvider/useSdk.ts 
to fail and create another SDK instance mid-operation, losing state.

## Must

- [ ] Tests
- [ ] Documentation (if applicable)
