### PR TITLE
chore: bump nodejs to ^22.18.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 on:
   pull_request:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,14 +38,13 @@ jobs:
         with:
           node-version-file: package.json
           # cache: 'pnpm'
-          package-manager-cache: false
 
       - name: Setup Node.js (v${{ matrix.node-version }})
         if: matrix.node-version != 'default'
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: ${{ matrix.node-version }}
-          package-manager-cache: false # Cache would conflict with the node-version='default' cache
+          # cache: 'pnpm'
       # - name: Restore cached npm dependencies
       #   uses: actions/cache/restore@v4
       #   with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,14 +37,15 @@ jobs:
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version-file: package.json
-          cache: 'pnpm'
+          # cache: 'pnpm'
+          package-manager-cache: false
 
       - name: Setup Node.js (v${{ matrix.node-version }})
         if: matrix.node-version != 'default'
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'pnpm'
+          package-manager-cache: false # Cache would conflict with the node-version='default' cache
       # - name: Restore cached npm dependencies
       #   uses: actions/cache/restore@v4
       #   with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,11 @@ env:
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
 jobs:
   pr:
-    name: 👷 Build / Lint / Test
+    name: 👷 Build / Lint / Test (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ['default', '18']
     container:
       # the container version should be the same as the version of the Playwright package
       image: mcr.microsoft.com/playwright:v1.47.0-jammy
@@ -29,10 +32,18 @@ jobs:
           corepack enable
           pnpm --version
 
-      - name: Setup Node.js
+      - name: Setup Node.js (default from package.json)
+        if: matrix.node-version == 'default'
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version-file: package.json
+          cache: 'pnpm'
+
+      - name: Setup Node.js (v${{ matrix.node-version }})
+        if: matrix.node-version != 'default'
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
       # - name: Restore cached npm dependencies
       #   uses: actions/cache/restore@v4
@@ -91,5 +102,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
-          name: e2e-report
+          name: e2e-report-${{ matrix.node-version }}
           path: packages/**/playwright-report

--- a/package.json
+++ b/package.json
@@ -66,6 +66,6 @@
   },
   "packageManager": "pnpm@10.0.0",
   "engines": {
-    "node": "^18.19.0"
+    "node": "^22.18.0"
   }
 }

--- a/packages/libs/escape-markdown/rollup.config.mjs
+++ b/packages/libs/escape-markdown/rollup.config.mjs
@@ -4,7 +4,7 @@ import del from 'rollup-plugin-delete';
 import dts from 'rollup-plugin-dts';
 import terser from '@rollup/plugin-terser';
 
-import packageJson from './package.json' assert { type: 'json' };
+import packageJson from './package.json' with { type: 'json' };
 
 const plugins = [
   typescript({

--- a/packages/libs/sdk-component-drivers/rollup.config.mjs
+++ b/packages/libs/sdk-component-drivers/rollup.config.mjs
@@ -7,7 +7,7 @@ import dts from 'rollup-plugin-dts';
 import terser from '@rollup/plugin-terser';
 import replace from '@rollup/plugin-replace';
 
-import packageJson from './package.json' assert { type: 'json' };
+import packageJson from './package.json' with { type: 'json' };
 
 const plugins = [
   replace({

--- a/packages/libs/sdk-helpers/rollup.config.mjs
+++ b/packages/libs/sdk-helpers/rollup.config.mjs
@@ -7,7 +7,7 @@ import dts from 'rollup-plugin-dts';
 import terser from '@rollup/plugin-terser';
 import replace from '@rollup/plugin-replace';
 
-import packageJson from './package.json' assert { type: 'json' };
+import packageJson from './package.json' with { type: 'json' };
 
 const plugins = [
   replace({

--- a/packages/libs/sdk-mixins/rollup.config.mjs
+++ b/packages/libs/sdk-mixins/rollup.config.mjs
@@ -8,7 +8,7 @@ import terser from '@rollup/plugin-terser';
 import replace from '@rollup/plugin-replace';
 import noEmit from 'rollup-plugin-no-emit';
 
-import packageJson from './package.json' assert { type: 'json' };
+import packageJson from './package.json' with { type: 'json' };
 
 const input = [
   './src/index.ts',

--- a/packages/sdks/core-js-sdk/rollup.config.js
+++ b/packages/sdks/core-js-sdk/rollup.config.js
@@ -7,7 +7,7 @@ import fs from 'fs';
 import del from 'rollup-plugin-delete';
 import dts from 'rollup-plugin-dts';
 
-import packageJson from './package.json' assert { type: 'json' };
+import packageJson from './package.json' with { type: 'json' };
 
 const plugins = [
   replace({

--- a/packages/sdks/nextjs-sdk/rollup.config.mjs
+++ b/packages/sdks/nextjs-sdk/rollup.config.mjs
@@ -6,7 +6,7 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import alias from '@rollup/plugin-alias';
 import noEmit from 'rollup-plugin-no-emit';
 
-import packageJson from './package.json' assert { type: 'json' };
+import packageJson from './package.json' with { type: 'json' };
 
 const nextSubPackages = [
 	'next/server',

--- a/packages/sdks/react-sdk/rollup.config.app.mjs
+++ b/packages/sdks/react-sdk/rollup.config.app.mjs
@@ -8,7 +8,7 @@ import del from 'rollup-plugin-delete';
 import dotenv from 'rollup-plugin-dotenv';
 import autoExternal from 'rollup-plugin-auto-external';
 
-import packageJson from './package.json' assert { type: 'json' };
+import packageJson from './package.json' with { type: 'json' };
 
 export default {
   preserveSymlinks: true,

--- a/packages/sdks/react-sdk/rollup.config.mjs
+++ b/packages/sdks/react-sdk/rollup.config.mjs
@@ -9,7 +9,7 @@ import commonjs from '@rollup/plugin-commonjs';
 import nodeResolve from '@rollup/plugin-node-resolve';
 import noEmit from 'rollup-plugin-no-emit';
 
-import packageJson from './package.json' assert { type: 'json' };
+import packageJson from './package.json' with { type: 'json' };
 
 export default [
   {

--- a/packages/sdks/vue-sdk/rollup.config.mjs
+++ b/packages/sdks/vue-sdk/rollup.config.mjs
@@ -6,7 +6,7 @@ import define from 'rollup-plugin-define';
 import del from 'rollup-plugin-delete';
 import dts from 'rollup-plugin-dts';
 
-import packageJson from './package.json' assert { type: 'json' };
+import packageJson from './package.json' with { type: 'json' };
 
 export default [
   {

--- a/packages/sdks/web-component/rollup.config.app.mjs
+++ b/packages/sdks/web-component/rollup.config.app.mjs
@@ -7,7 +7,7 @@ import replace from '@rollup/plugin-replace';
 import dotenv from 'dotenv';
 import define from 'rollup-plugin-define';
 
-import packageJson from './package.json' assert { type: 'json' };
+import packageJson from './package.json' with { type: 'json' };
 
 dotenv.config();
 

--- a/packages/sdks/web-component/rollup.config.mjs
+++ b/packages/sdks/web-component/rollup.config.mjs
@@ -7,7 +7,7 @@ import commonjs from '@rollup/plugin-commonjs';
 import define from 'rollup-plugin-define';
 import replace from '@rollup/plugin-replace';
 
-import packageJson from './package.json' assert { type: 'json' };
+import packageJson from './package.json' with { type: 'json' };
 
 const input = './src/lib/descope-wc/index.ts';
 const external = (id) =>

--- a/packages/sdks/web-js-sdk/rollup.config.mjs
+++ b/packages/sdks/web-js-sdk/rollup.config.mjs
@@ -7,7 +7,7 @@ import dts from 'rollup-plugin-dts';
 import terser from '@rollup/plugin-terser';
 import replace from '@rollup/plugin-replace';
 
-import packageJson from './package.json' assert { type: 'json' };
+import packageJson from './package.json' with { type: 'json' };
 
 const plugins = [
   replace({

--- a/packages/widgets/access-key-management-widget/playwright.config.ts
+++ b/packages/widgets/access-key-management-widget/playwright.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 4 : undefined,
+  workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: process.env.CI ? 'html' : 'line',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/packages/widgets/access-key-management-widget/rollup.config.app.mjs
+++ b/packages/widgets/access-key-management-widget/rollup.config.app.mjs
@@ -8,7 +8,7 @@ import dotenv from 'dotenv';
 import define from 'rollup-plugin-define';
 import svg from 'rollup-plugin-svg-import';
 
-import packageJson from './package.json' assert { type: 'json' };
+import packageJson from './package.json' with { type: 'json' };
 
 dotenv.config();
 

--- a/packages/widgets/access-key-management-widget/rollup.config.mjs
+++ b/packages/widgets/access-key-management-widget/rollup.config.mjs
@@ -8,7 +8,7 @@ import dts from 'rollup-plugin-dts';
 import svg from 'rollup-plugin-svg-import';
 import { terser } from 'rollup-plugin-terser';
 
-import packageJson from './package.json' assert { type: 'json' };
+import packageJson from './package.json' with { type: 'json' };
 
 const input = './src/lib/index.ts';
 const external = (id) =>

--- a/packages/widgets/applications-portal-widget/rollup.config.app.mjs
+++ b/packages/widgets/applications-portal-widget/rollup.config.app.mjs
@@ -8,7 +8,7 @@ import dotenv from 'dotenv';
 import define from 'rollup-plugin-define';
 import svg from 'rollup-plugin-svg-import';
 
-import packageJson from './package.json' assert { type: 'json' };
+import packageJson from './package.json' with { type: 'json' };
 
 dotenv.config();
 

--- a/packages/widgets/applications-portal-widget/rollup.config.mjs
+++ b/packages/widgets/applications-portal-widget/rollup.config.mjs
@@ -8,7 +8,7 @@ import dts from 'rollup-plugin-dts';
 import svg from 'rollup-plugin-svg-import';
 import { terser } from 'rollup-plugin-terser';
 
-import packageJson from './package.json' assert { type: 'json' };
+import packageJson from './package.json' with { type: 'json' };
 
 const input = './src/lib/index.ts';
 const external = (id) =>

--- a/packages/widgets/audit-management-widget/playwright.config.ts
+++ b/packages/widgets/audit-management-widget/playwright.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 4 : undefined,
+  workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: process.env.CI ? 'html' : 'line',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/packages/widgets/audit-management-widget/rollup.config.app.mjs
+++ b/packages/widgets/audit-management-widget/rollup.config.app.mjs
@@ -8,7 +8,7 @@ import dotenv from 'dotenv';
 import define from 'rollup-plugin-define';
 import svg from 'rollup-plugin-svg-import';
 
-import packageJson from './package.json' assert { type: 'json' };
+import packageJson from './package.json' with { type: 'json' };
 
 dotenv.config();
 

--- a/packages/widgets/audit-management-widget/rollup.config.mjs
+++ b/packages/widgets/audit-management-widget/rollup.config.mjs
@@ -8,7 +8,7 @@ import dts from 'rollup-plugin-dts';
 import svg from 'rollup-plugin-svg-import';
 import { terser } from 'rollup-plugin-terser';
 
-import packageJson from './package.json' assert { type: 'json' };
+import packageJson from './package.json' with { type: 'json' };
 
 const input = './src/lib/index.ts';
 const external = (id) =>

--- a/packages/widgets/outbound-applications-widget/rollup.config.app.mjs
+++ b/packages/widgets/outbound-applications-widget/rollup.config.app.mjs
@@ -8,7 +8,7 @@ import dotenv from 'dotenv';
 import define from 'rollup-plugin-define';
 import svg from 'rollup-plugin-svg-import';
 
-import packageJson from './package.json' assert { type: 'json' };
+import packageJson from './package.json' with { type: 'json' };
 
 dotenv.config();
 

--- a/packages/widgets/outbound-applications-widget/rollup.config.mjs
+++ b/packages/widgets/outbound-applications-widget/rollup.config.mjs
@@ -8,7 +8,7 @@ import dts from 'rollup-plugin-dts';
 import svg from 'rollup-plugin-svg-import';
 import { terser } from 'rollup-plugin-terser';
 
-import packageJson from './package.json' assert { type: 'json' };
+import packageJson from './package.json' with { type: 'json' };
 
 const input = './src/lib/index.ts';
 const external = (id) =>

--- a/packages/widgets/role-management-widget/playwright.config.ts
+++ b/packages/widgets/role-management-widget/playwright.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
   /* Retry on CI only */
   retries: process.env.CI ? 4 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 4 : undefined,
+  workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: process.env.CI ? 'html' : 'line',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/packages/widgets/role-management-widget/rollup.config.app.mjs
+++ b/packages/widgets/role-management-widget/rollup.config.app.mjs
@@ -8,7 +8,7 @@ import dotenv from 'dotenv';
 import define from 'rollup-plugin-define';
 import svg from 'rollup-plugin-svg-import';
 
-import packageJson from './package.json' assert { type: 'json' };
+import packageJson from './package.json' with { type: 'json' };
 
 dotenv.config();
 

--- a/packages/widgets/role-management-widget/rollup.config.mjs
+++ b/packages/widgets/role-management-widget/rollup.config.mjs
@@ -8,7 +8,7 @@ import dts from 'rollup-plugin-dts';
 import svg from 'rollup-plugin-svg-import';
 import { terser } from 'rollup-plugin-terser';
 
-import packageJson from './package.json' assert { type: 'json' };
+import packageJson from './package.json' with { type: 'json' };
 
 const input = './src/lib/index.ts';
 const external = (id) =>

--- a/packages/widgets/tenant-profile-widget/rollup.config.app.mjs
+++ b/packages/widgets/tenant-profile-widget/rollup.config.app.mjs
@@ -8,7 +8,7 @@ import define from 'rollup-plugin-define';
 import del from 'rollup-plugin-delete';
 import svg from 'rollup-plugin-svg-import';
 
-import packageJson from './package.json' assert { type: 'json' };
+import packageJson from './package.json' with { type: 'json' };
 
 dotenv.config();
 

--- a/packages/widgets/tenant-profile-widget/rollup.config.mjs
+++ b/packages/widgets/tenant-profile-widget/rollup.config.mjs
@@ -8,7 +8,7 @@ import dts from 'rollup-plugin-dts';
 import svg from 'rollup-plugin-svg-import';
 import { terser } from 'rollup-plugin-terser';
 
-import packageJson from './package.json' assert { type: 'json' };
+import packageJson from './package.json' with { type: 'json' };
 
 const input = './src/lib/index.ts';
 const external = (id) =>

--- a/packages/widgets/user-management-widget/rollup.config.app.mjs
+++ b/packages/widgets/user-management-widget/rollup.config.app.mjs
@@ -8,7 +8,7 @@ import dotenv from 'dotenv';
 import define from 'rollup-plugin-define';
 import svg from 'rollup-plugin-svg-import';
 
-import packageJson from './package.json' assert { type: 'json' };
+import packageJson from './package.json' with { type: 'json' };
 
 dotenv.config();
 

--- a/packages/widgets/user-management-widget/rollup.config.mjs
+++ b/packages/widgets/user-management-widget/rollup.config.mjs
@@ -8,7 +8,7 @@ import dts from 'rollup-plugin-dts';
 import svg from 'rollup-plugin-svg-import';
 import { terser } from 'rollup-plugin-terser';
 
-import packageJson from './package.json' assert { type: 'json' };
+import packageJson from './package.json' with { type: 'json' };
 
 const input = './src/lib/index.ts';
 const external = (id) =>

--- a/packages/widgets/user-profile-widget/rollup.config.app.mjs
+++ b/packages/widgets/user-profile-widget/rollup.config.app.mjs
@@ -8,7 +8,7 @@ import dotenv from 'dotenv';
 import define from 'rollup-plugin-define';
 import svg from 'rollup-plugin-svg-import';
 
-import packageJson from './package.json' assert { type: 'json' };
+import packageJson from './package.json' with { type: 'json' };
 
 dotenv.config();
 

--- a/packages/widgets/user-profile-widget/rollup.config.mjs
+++ b/packages/widgets/user-profile-widget/rollup.config.mjs
@@ -8,7 +8,7 @@ import dts from 'rollup-plugin-dts';
 import svg from 'rollup-plugin-svg-import';
 import { terser } from 'rollup-plugin-terser';
 
-import packageJson from './package.json' assert { type: 'json' };
+import packageJson from './package.json' with { type: 'json' };
 
 const input = './src/lib/index.ts';
 const external = (id) =>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,16 +26,16 @@ importers:
         version: 19.1.0(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))
       '@nrwl/eslint-plugin-nx':
         specifier: 19.8.4
-        version: 19.8.4(@babel/traverse@7.28.3)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@typescript-eslint/parser@7.2.0(eslint@9.18.0(jiti@1.21.0))(typescript@5.7.3))(eslint-config-prettier@9.1.0(eslint@9.18.0(jiti@1.21.0)))(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)
+        version: 19.8.4(@babel/traverse@7.28.4)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@typescript-eslint/parser@7.2.0(eslint@9.18.0(jiti@1.21.0))(typescript@5.7.3))(eslint-config-prettier@9.1.0(eslint@9.18.0(jiti@1.21.0)))(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)
       '@nrwl/jest':
         specifier: 19.8.4
-        version: 19.8.4(@babel/traverse@7.28.3)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3))(typescript@5.7.3)
+        version: 19.8.4(@babel/traverse@7.28.4)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3))(typescript@5.7.3)
       '@nrwl/js':
         specifier: 19.8.4
-        version: 19.8.4(@babel/traverse@7.28.3)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)
+        version: 19.8.4(@babel/traverse@7.28.4)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)
       '@nrwl/linter':
         specifier: 19.8.4
-        version: 19.8.4(@babel/traverse@7.28.3)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@zkochan/js-yaml@0.0.7)(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))
+        version: 19.8.4(@babel/traverse@7.28.4)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@zkochan/js-yaml@0.0.7)(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))
       '@nrwl/workspace':
         specifier: 19.8.4
         version: 19.8.4(@swc/core@1.7.1(@swc/helpers@0.5.15))
@@ -87,8 +87,6 @@ importers:
       ts-node:
         specifier: 10.9.2
         version: 10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3)
-
-  packages/core-js-sdk/dist/cjs: {}
 
   packages/libs/e2e-helpers:
     dependencies:
@@ -1584,7 +1582,7 @@ importers:
     devDependencies:
       '@descope/web-components-ui':
         specifier: latest
-        version: 1.127.0
+        version: 1.132.0
       '@open-wc/rollup-plugin-html':
         specifier: 1.2.5
         version: 1.2.5
@@ -1871,8 +1869,6 @@ importers:
 
   packages/sdks/web-js-sdk/dist/cjs: {}
 
-  packages/web-js-sdk/dist/cjs: {}
-
   packages/widgets/access-key-management-widget:
     dependencies:
       '@descope/sdk-component-drivers':
@@ -1911,7 +1907,7 @@ importers:
         version: link:../../libs/e2e-helpers
       '@descope/web-components-ui':
         specifier: latest
-        version: 1.127.0
+        version: 1.132.0
       '@open-wc/rollup-plugin-html':
         specifier: 1.2.5
         version: 1.2.5
@@ -2092,7 +2088,7 @@ importers:
         version: link:../../libs/e2e-helpers
       '@descope/web-components-ui':
         specifier: latest
-        version: 1.127.0
+        version: 1.132.0
       '@open-wc/rollup-plugin-html':
         specifier: 1.2.5
         version: 1.2.5
@@ -2273,7 +2269,7 @@ importers:
         version: link:../../libs/e2e-helpers
       '@descope/web-components-ui':
         specifier: latest
-        version: 1.127.0
+        version: 1.132.0
       '@open-wc/rollup-plugin-html':
         specifier: 1.2.5
         version: 1.2.5
@@ -2457,7 +2453,7 @@ importers:
         version: link:../../libs/e2e-helpers
       '@descope/web-components-ui':
         specifier: latest
-        version: 1.127.0
+        version: 1.132.0
       '@open-wc/rollup-plugin-html':
         specifier: 1.2.5
         version: 1.2.5
@@ -2638,7 +2634,7 @@ importers:
         version: link:../../libs/e2e-helpers
       '@descope/web-components-ui':
         specifier: latest
-        version: 1.127.0
+        version: 1.132.0
       '@open-wc/rollup-plugin-html':
         specifier: 1.2.5
         version: 1.2.5
@@ -2822,7 +2818,7 @@ importers:
         version: link:../../libs/e2e-helpers
       '@descope/web-components-ui':
         specifier: latest
-        version: 1.127.0
+        version: 1.132.0
       '@open-wc/rollup-plugin-html':
         specifier: 1.2.5
         version: 1.2.5
@@ -3013,7 +3009,7 @@ importers:
         version: link:../../libs/e2e-helpers
       '@descope/web-components-ui':
         specifier: latest
-        version: 1.127.0
+        version: 1.132.0
       '@open-wc/rollup-plugin-html':
         specifier: 1.2.5
         version: 1.2.5
@@ -3197,7 +3193,7 @@ importers:
         version: link:../../libs/e2e-helpers
       '@descope/web-components-ui':
         specifier: latest
-        version: 1.127.0
+        version: 1.132.0
       '@open-wc/rollup-plugin-html':
         specifier: 1.2.5
         version: 1.2.5
@@ -3605,8 +3601,8 @@ packages:
     resolution: {integrity: sha512-XvcZi1KWf88RVbF9wn8MN6tYFloU5qX8KjuF3E1PVBmJ9eypXfs4GRiJwLuTZL0iSnJUKn1BFPa5BPZZJyFzPg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/compat-data@7.28.0':
-    resolution: {integrity: sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==}
+  '@babel/compat-data@7.28.4':
+    resolution: {integrity: sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/core@7.26.0':
@@ -3820,8 +3816,8 @@ packages:
     resolution: {integrity: sha512-8NHiL98vsi0mbPQmYAGWwfcFaOy4j2HY49fXJCfuDcdE7fMIsH9a7GdaeXpIBsbT7307WU8KCMp5pUVDNL4f9A==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helpers@7.28.3':
-    resolution: {integrity: sha512-PTNtvUQihsAsDHMOP5pfobP8C6CM4JWXmP8DrEIt46c3r2bf87Ua1zoqevsMo9g+tWDwgWrFP5EIxuBx5RudAw==}
+  '@babel/helpers@7.28.4':
+    resolution: {integrity: sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==}
     engines: {node: '>=6.9.0'}
 
   '@babel/highlight@7.23.4':
@@ -3847,8 +3843,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/parser@7.28.3':
-    resolution: {integrity: sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==}
+  '@babel/parser@7.28.4':
+    resolution: {integrity: sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -4421,8 +4417,8 @@ packages:
     resolution: {integrity: sha512-1x1sgeyRLC3r5fQOM0/xtQKsYjyxmFjaOrLJNtZ81inNjyJHGIolTULPiSc/2qe1/qfpFLisLQYFnnZl7QoedA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/traverse@7.28.3':
-    resolution: {integrity: sha512-7w4kZYHneL3A6NP2nxzHvT3HCZ7puDZZjFMqDpBPECub79sTtSO5CGXDkKrTQq8ksAwfD/XI2MRFX23njdDaIQ==}
+  '@babel/traverse@7.28.4':
+    resolution: {integrity: sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.24.8':
@@ -4437,8 +4433,8 @@ packages:
     resolution: {integrity: sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.28.2':
-    resolution: {integrity: sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==}
+  '@babel/types@7.28.4':
+    resolution: {integrity: sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@0.2.3':
@@ -4526,74 +4522,80 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
-  '@descope-ui/common@0.0.18':
-    resolution: {integrity: sha512-uLC9oIGGxGM9kbSWbWqikgTgiNuZ6FdDxKzBsdJqkKTwVeuLFKR8czTAoLFgio/AU0yyc93Y8JjDTcZJOghgpw==}
+  '@descope-ui/common@0.1.0':
+    resolution: {integrity: sha512-V9AV7flNy7a9glwCekHYRqS4dPiEsURnB3WWAZRe3vCe1NJ0KMTFgSUN8femEcFrnLVpQGb2U5No9xAiw4mX6Q==}
 
-  '@descope-ui/descope-address-field@0.0.23':
-    resolution: {integrity: sha512-V/GZ1i3hcQrpJdVwtZqwkEumhlQaF7xtavu9nNxaxUYM7DPNOpqbzaZhpYMM0BueC6oZn8TS59FNJeDCqhhVPQ==}
+  '@descope-ui/descope-address-field@0.0.24':
+    resolution: {integrity: sha512-kc439rZc5viG26drznR6Hw7FXBOabynv2Bihv/tHGgwfXhHzQ/F0Y//fsVBcJdd7SIvr9fWhbsUyBD2zIWvlEQ==}
 
-  '@descope-ui/descope-apps-list@0.0.1':
-    resolution: {integrity: sha512-YffJlYztj/63+j7qpLr4KEhniTV8NY+bDmpcg92/+w7dbs7hQvqtG6OJ3np211TlGGthUX0jxtVRntukm80kJw==}
+  '@descope-ui/descope-apps-list@0.0.2':
+    resolution: {integrity: sha512-XUfvdZ1ixUsaWoiX7X4z/2myKhZoczoZ9r0KUbIyA4RY53Ro3NcWuWlV7/M9vPl3TMzgJSHspl2BFY2MBMB57w==}
 
-  '@descope-ui/descope-autocomplete-field@0.0.24':
-    resolution: {integrity: sha512-2WasNdp73STkfC0NeRBqnDn9zshnJOy7/Gyu9nOZXikrONpQ95PnD7OhA0ai6bAQIhPCYIJ7d7DgLhjZLw9YrA==}
+  '@descope-ui/descope-autocomplete-field@0.0.25':
+    resolution: {integrity: sha512-bm0MYzTeeYlilcJEzClMgzyV2taFKVbclT2EbjJtGl2/V9l5KUJ2p1QUPiMbt3qbGPcgG8E4f0lYed9movm6KQ==}
 
-  '@descope-ui/descope-avatar@0.0.19':
-    resolution: {integrity: sha512-lF19qJwYHn0TR9F0JOXV0uWZIEGcNmAZsaJlIYp24dhvRHJDa5CuVADVWJjZmXi4lziqecCaH2+Kw9gUQ2WWVw==}
+  '@descope-ui/descope-avatar@0.1.0':
+    resolution: {integrity: sha512-Ata1EpXSnKiNmgI7SCrikHTw8BvfQjGPOxo0qVO9Ht97cX7muzZ8HgksaYO4ebqBv2tDz/TvB2LTvi3s1VILeg==}
 
-  '@descope-ui/descope-button@0.0.19':
-    resolution: {integrity: sha512-aGyn72IWJSbSJ098wf5A7AFkewJgFBVKqe496cks7xb199C+uGxxbYVqE/NMwsnR6GAXG59550m7k3Knt1IaFA==}
+  '@descope-ui/descope-badge@0.1.0':
+    resolution: {integrity: sha512-2VB8hpv1FD8HIRgiq5naulFhwIJi9Kp0Lgwqv+J9qdQCn9RZD6gVVLbn55CivegrWQO14u//5odW965cLQNvyw==}
 
-  '@descope-ui/descope-collapsible-container@0.0.18':
-    resolution: {integrity: sha512-iBet7rSVzI7KXWrZH1I0oakukPMc7EM6jyZly6mY5kaWZl+HZGSgc9gt18ov0Wv+C4RqkLLn/9M9ZF7OnONmJQ==}
+  '@descope-ui/descope-button@0.0.20':
+    resolution: {integrity: sha512-o0gZmWjE0OCqI9qzOYrwBCTSjJEMEB3JUrXoEAvebf4WBcFz5ae/Oo6uDd58YDUanQA4Q0DZRvfocsD9fCUqSg==}
 
-  '@descope-ui/descope-combo-box@0.1.11':
-    resolution: {integrity: sha512-AmLCpWgcdSdqhqDi2D6t7532mHW4Ojsn7dDjNTJ/uVXJrb6zIMS59OICWWHs3DaehFb4WrwGNhWECwVSXQO4hg==}
+  '@descope-ui/descope-collapsible-container@0.0.19':
+    resolution: {integrity: sha512-KpjsVQBlkuMCnrr8B3jhUJXdZBN4d+tCXxXY1vepDktB2fL2K0tOEX1yDItfPClhsbmFrYFMzQlrUWRribn4KA==}
 
-  '@descope-ui/descope-enriched-text@0.0.3':
-    resolution: {integrity: sha512-mNd/jbPLNgt2DOxusWzBhGdGksjwVV9HNAjeNh//cIuHKJf9wW+Xx/I0rTa9vcCEqJKsB7DWIlebjbq1oDJQFA==}
+  '@descope-ui/descope-combo-box@0.1.12':
+    resolution: {integrity: sha512-B+XHUb1AWfoHarErDLTwgQkPkCndeS54a2679MZJJZmDmFK/Mb8GxHhwiK1CiQKrhMkPvifKKJhJ1snaLYxCDQ==}
 
-  '@descope-ui/descope-icon@0.0.17':
-    resolution: {integrity: sha512-auxK65qRu/fi9prWjpqiND7AAmV9L22D7ccGn9zT/nhai4D7tP25iH0/wOsLCYjjqiKLuycbz7u9WBrzJM8bxA==}
+  '@descope-ui/descope-enriched-text@0.0.4':
+    resolution: {integrity: sha512-2HcjlfDORRUqnJNA+5YSpwoIh+9iaUr93x+R4hOvCvVCG1rjx/HYKNrpAINzZdNbtd0/AYGFD2D0zxs2CdsHLA==}
 
-  '@descope-ui/descope-image@0.0.10':
-    resolution: {integrity: sha512-SdFxcfAdCzB97vb8YUdCz9cnRaWV20LnbBE9599LheuZwkcW45VN5fkHJvwvwoQypopNa5JGouo1h14nBFijHQ==}
+  '@descope-ui/descope-icon@0.0.18':
+    resolution: {integrity: sha512-EvkCrtIdKCFydjUQGhuMTxJg251tC34AkdnkfiFfjbzIYNK4jWRSPuvHtcxzAuhKBvELAm4GYKAmUU8FVQ7ecA==}
 
-  '@descope-ui/descope-link@0.0.3':
-    resolution: {integrity: sha512-rUCG2kcgj+ugSSwpF2W/ItPaAvMAkt2cuU3wrxYnDelwBfxe6sMm3F6TfTqY4pmE5tY04BOIEnkD+OVArKl8wQ==}
+  '@descope-ui/descope-image@0.0.11':
+    resolution: {integrity: sha512-4TT8t+O+K4rsVQwExNZTRLSU4aUMiDG/cmkiycKWNyU1K5GK3/qbuQiWGb8e756jehVze7fLCgBDSIe1SEOEAQ==}
 
-  '@descope-ui/descope-list-item@0.0.1':
-    resolution: {integrity: sha512-X1eMtAuMysp/6GAPgLqJ4xgfaC36Y8LkQJ9rI/f2TA1JkcwSJVaTvKcb6oto1S9H2w3FCaXSZPreIwqr1hW5wQ==}
+  '@descope-ui/descope-link@0.1.0':
+    resolution: {integrity: sha512-+d0SfvZfBUPOQkh7YX5AqbT9SK0/yyT8iFmDx/4gvshNvFNqDzNLeO4YwX7PCM5ZvxT1ZWZ2cYcyOwi+h4348Q==}
 
-  '@descope-ui/descope-list@0.0.1':
-    resolution: {integrity: sha512-k4wmnHAIQ5Z+jCvlJbGKDCJfIPA6KP8qJrYgYmQbJ4zeVwJCaPMjvCX5diW5CIiMwSOYmDat69JLo071WAYIVA==}
+  '@descope-ui/descope-list-item@0.1.0':
+    resolution: {integrity: sha512-wjoQCIe/NVKphHzFnGCEIGi9i9oX12/yHwI8yVqGUKxJSVAHHNFA6LSbah35BxpqN/pbppbrQlRFh1TGtUUpzw==}
 
-  '@descope-ui/descope-outbound-app-button@0.0.4':
-    resolution: {integrity: sha512-rK6ojhXn/kwUMR+jd2mvjAE8py/F7G9EZ1/p04iTSlFQJX7qxer4io+CQI6tK1gg/QY29amMGMiMDjfnIF2+zw==}
+  '@descope-ui/descope-list@0.1.0':
+    resolution: {integrity: sha512-RIk4IlnLhojzcYJdMw7gSUhC/Oyzit4CIgdTEwlx3oAj30WeLn8Azmb/S2Rb9yosrjedTSrnqrpGXR2RkrSujw==}
 
-  '@descope-ui/descope-outbound-apps@0.0.5':
-    resolution: {integrity: sha512-UAvhcpq8jQy3C69eezAOjVAfXnCYQvET0jD9s9yjtRU5umSaZt0jnOi0P0SqMdAOabaYB/sNXk9YFo4GFtxbvg==}
+  '@descope-ui/descope-outbound-app-button@0.0.5':
+    resolution: {integrity: sha512-r3tqvObeUH1O4RCBwKE0uRJCrwvOwKtJCAmzrwh+hfPuW74LzYcz+ZjC4OaOXccj5npo8f2FAxcT5wsRMvKQmg==}
 
-  '@descope-ui/descope-password-strength@0.0.13':
-    resolution: {integrity: sha512-WvEvq8tzVDTaH0UqXvr367VDyy4wWWoEHSODuGcR9HBnN4XAvXOiddZn4TvojsucHygJg+Vml1TJLfBHWc1ISw==}
+  '@descope-ui/descope-outbound-apps@0.1.0':
+    resolution: {integrity: sha512-dNwFVOT3Ai6sbbUL4OsLa5QcdXimYrJUdTQ4ofvY27nUeOEVbpVS2aL8Iz6gLhEco3xTG8YuG5FhiI9SBmOGqw==}
 
-  '@descope-ui/descope-recovery-codes@0.0.6':
-    resolution: {integrity: sha512-pouTMRwL1Fmjm7fzy2zWGJP6x0CFrJTf7ZL14heChk8q7MivkZJGQ8A7wlmoXlh1xVyfyjaPwd6Vh1O67Tsl6w==}
+  '@descope-ui/descope-password-strength@0.0.14':
+    resolution: {integrity: sha512-IFm/qEwH8lnlwL/sktncr3yEHVOZNrqhOR6RHrxx0/dWHQcsae6Isa7ZRXEIxhXOjJBwIQJl+7P1sdXspDJAYg==}
 
-  '@descope-ui/descope-text@0.0.19':
-    resolution: {integrity: sha512-k5sPyL7B2DVBVqP+OhezSY/rnzVrTbT8uIzaLPr+su/zB/vvKRwsjb8JoB7rfZ8QCsLLGzQkAaqGxLAlXehrCQ==}
+  '@descope-ui/descope-recovery-codes@0.0.7':
+    resolution: {integrity: sha512-pBAC2UOlOMEG9rx3J7Vjq6jxKyNTDZpDrfBQKK3t2QSrFtlWKruY/5/TUikXXzmmiDoFtVCUGWixEHbsQez8Tg==}
 
-  '@descope-ui/descope-timer-button@0.0.20':
-    resolution: {integrity: sha512-yg5FXSXXugHi+L8nrf5kT48qC606OYrUF0xqAssN0Unp4wyksGJ0jA0cGOZ8kHbmvBHh7oQIui3GbyGAhUxinw==}
+  '@descope-ui/descope-text@0.0.20':
+    resolution: {integrity: sha512-e4HifktNpUKm8ohkdK/YaBEPYyIiFe3BVv0iwe0ANfNl+KYEDvP1Lb/AyuaXLl2I0tOi/vjky/HnDxXo2kRySw==}
 
-  '@descope-ui/descope-timer@0.0.17':
-    resolution: {integrity: sha512-hFfQWj4NX57P8R4NdGlyZJtXpRspJ9v3dS2rMPg/kcwepj+k1xwjY2y4Y4iW6P62ZdZ8+eg28uwCCaaVHQ3fXg==}
+  '@descope-ui/descope-timer-button@0.0.21':
+    resolution: {integrity: sha512-JYYTU6wLg1q+amFZMZSwEISamTAaJ4C+0Gc4YgqyRHQ2Q++Z1OExVAnAECuXce3LBx/aAncdiOjrGKUZ+bgp3A==}
 
-  '@descope-ui/theme-globals@0.0.19':
-    resolution: {integrity: sha512-5ZZisXgwJ3wUix9frGmTUyuhyhnxeSotKiujHvSHzXUhrHNiM1oXt9K0xb1tg7ObaTYVCJbK1hdNK3Ed3GNkHQ==}
+  '@descope-ui/descope-timer@0.0.18':
+    resolution: {integrity: sha512-5cJSEhwzN3kR4HhgvELfruxoKL+3WMpjN7h8tsfkdOKlWWETgKqAw+g5k+OJloLeJ421N+5rraDbxCe7OQx/aQ==}
 
-  '@descope-ui/theme-input-wrapper@0.1.8':
-    resolution: {integrity: sha512-vHTR9NYKlyMICsgeCEcR5wpiZvwxmc25I3GmFZV1KBQbYeqPs72DE9xOKLyN278kSkaaQNSxTTRTCq2MjiNX0A==}
+  '@descope-ui/descope-trusted-devices@0.1.0':
+    resolution: {integrity: sha512-cNK36YrI8CK+UZu8K0lV0KPB9Z5WrbvoX2LVaffN8HJMAaCIwdaRFGz0ZtNG7KpuvW+jXFYF0Kv9f7aYKAF/YA==}
+
+  '@descope-ui/theme-globals@0.0.20':
+    resolution: {integrity: sha512-hSD3Q233IJLwRnLOnzE+1MUOXqr5sTlQ0tXInlpizWnAgvBLBEkiX/Hm7efwYre8HmzZweBRvZew/3XEOIXGTg==}
+
+  '@descope-ui/theme-input-wrapper@0.1.9':
+    resolution: {integrity: sha512-HEVOAqeh+BfcozPcfAUp8dsXQESCAT6SzodC0BEsATnbQNbuf0IPeg+R1RaC7hGaJMOgUXF+9kPBELiUdGH9yg==}
 
   '@descope/core-js-sdk@2.31.0':
     resolution: {integrity: sha512-y5Z8wQwmOt4IEt67XwS006jbtSVGumbcXDx6k+1/e3jHFzSLZdVnt9sgKKU0biQQl5jAi3GVNsilWVNIC4D2Ww==}
@@ -4612,8 +4614,8 @@ packages:
     resolution: {integrity: sha512-6r0ArtJkkky67wQR0J1cS5WRNcrE3dgMDE0wqWdmq/OZPIYVwLf950I24I4wPVh97Ya40TAqm8kt7VP1zJFfKw==}
     engines: {node: '>= 12.0.0'}
 
-  '@descope/web-components-ui@1.127.0':
-    resolution: {integrity: sha512-RbhmlQnOcN5Wq/Zd/8QfDzGBSK+nhbcw5WXGE9RB6952kKr23OWbFCkB4fy4UbgH+ZGM/u6d1hDu1UVQ6jwZ8Q==}
+  '@descope/web-components-ui@1.132.0':
+    resolution: {integrity: sha512-MaMPrXLiRD8MoS3Q9qjQ6R+Jdy/lVpxFYM04okKr4zk9HmjdkZheQWkI/RcBVx4hymQVBABVQG//PIAMcsulbA==}
 
   '@descope/web-js-sdk@1.29.1':
     resolution: {integrity: sha512-YUMJQ9TrEhp8SDtOcERF4tr7IguBt5//0sm8k8/tFc/9qb1uZ9Hz1z2+1NX8cnni+tMpOUH7tRFEoprpKayPEw==}
@@ -16483,7 +16485,7 @@ snapshots:
 
   '@babel/compat-data@7.26.5': {}
 
-  '@babel/compat-data@7.28.0':
+  '@babel/compat-data@7.28.4':
     optional: true
 
   '@babel/core@7.26.0':
@@ -16513,11 +16515,11 @@ snapshots:
       '@babel/generator': 7.28.3
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-module-transforms': 7.28.3(@babel/core@7.26.10)
-      '@babel/helpers': 7.28.3
-      '@babel/parser': 7.28.3
+      '@babel/helpers': 7.28.4
+      '@babel/parser': 7.28.4
       '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.3
-      '@babel/types': 7.28.2
+      '@babel/traverse': 7.28.4
+      '@babel/types': 7.28.4
       convert-source-map: 2.0.0
       debug: 4.4.1
       gensync: 1.0.0-beta.2
@@ -16553,8 +16555,8 @@ snapshots:
 
   '@babel/generator@7.28.3':
     dependencies:
-      '@babel/parser': 7.28.3
-      '@babel/types': 7.28.2
+      '@babel/parser': 7.28.4
+      '@babel/types': 7.28.4
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.30
       jsesc: 3.1.0
@@ -16582,7 +16584,7 @@ snapshots:
 
   '@babel/helper-compilation-targets@7.27.2':
     dependencies:
-      '@babel/compat-data': 7.28.0
+      '@babel/compat-data': 7.28.4
       '@babel/helper-validator-option': 7.27.1
       browserslist: 4.24.4
       lru-cache: 5.1.1
@@ -16692,8 +16694,8 @@ snapshots:
 
   '@babel/helper-module-imports@7.27.1':
     dependencies:
-      '@babel/traverse': 7.28.3
-      '@babel/types': 7.28.2
+      '@babel/traverse': 7.28.4
+      '@babel/types': 7.28.4
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -16712,7 +16714,7 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-module-imports': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
-      '@babel/traverse': 7.28.3
+      '@babel/traverse': 7.28.4
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -16811,10 +16813,10 @@ snapshots:
       '@babel/template': 7.25.9
       '@babel/types': 7.27.0
 
-  '@babel/helpers@7.28.3':
+  '@babel/helpers@7.28.4':
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/types': 7.28.2
+      '@babel/types': 7.28.4
     optional: true
 
   '@babel/highlight@7.23.4':
@@ -16842,9 +16844,9 @@ snapshots:
     dependencies:
       '@babel/types': 7.27.0
 
-  '@babel/parser@7.28.3':
+  '@babel/parser@7.28.4':
     dependencies:
-      '@babel/types': 7.28.2
+      '@babel/types': 7.28.4
 
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.25.9(@babel/core@7.26.0)':
     dependencies:
@@ -17608,8 +17610,8 @@ snapshots:
   '@babel/template@7.27.2':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/parser': 7.28.3
-      '@babel/types': 7.28.2
+      '@babel/parser': 7.28.4
+      '@babel/types': 7.28.4
     optional: true
 
   '@babel/traverse@7.24.8':
@@ -17639,14 +17641,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/traverse@7.28.3':
+  '@babel/traverse@7.28.4':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/generator': 7.28.3
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.28.3
+      '@babel/parser': 7.28.4
       '@babel/template': 7.27.2
-      '@babel/types': 7.28.2
+      '@babel/types': 7.28.4
       debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
@@ -17668,7 +17670,7 @@ snapshots:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
 
-  '@babel/types@7.28.2':
+  '@babel/types@7.28.4':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
@@ -17803,164 +17805,179 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@descope-ui/common@0.0.18':
+  '@descope-ui/common@0.1.0':
     dependencies:
       color: 4.2.3
       element-internals-polyfill: 1.3.11
       lodash.debounce: 4.0.8
       lodash.merge: 4.6.2
 
-  '@descope-ui/descope-address-field@0.0.23':
+  '@descope-ui/descope-address-field@0.0.24':
     dependencies:
-      '@descope-ui/common': 0.0.18
-      '@descope-ui/descope-autocomplete-field': 0.0.24
-      '@descope-ui/theme-input-wrapper': 0.1.8
+      '@descope-ui/common': 0.1.0
+      '@descope-ui/descope-autocomplete-field': 0.0.25
+      '@descope-ui/theme-input-wrapper': 0.1.9
       '@vaadin/custom-field': 24.3.4
 
-  '@descope-ui/descope-apps-list@0.0.1':
+  '@descope-ui/descope-apps-list@0.0.2':
     dependencies:
-      '@descope-ui/common': 0.0.18
-      '@descope-ui/descope-avatar': 0.0.19
-      '@descope-ui/descope-list': 0.0.1
-      '@descope-ui/descope-text': 0.0.19
-      '@descope-ui/theme-globals': 0.0.19
+      '@descope-ui/common': 0.1.0
+      '@descope-ui/descope-avatar': 0.1.0
+      '@descope-ui/descope-list': 0.1.0
+      '@descope-ui/descope-text': 0.0.20
+      '@descope-ui/theme-globals': 0.0.20
 
-  '@descope-ui/descope-autocomplete-field@0.0.24':
+  '@descope-ui/descope-autocomplete-field@0.0.25':
     dependencies:
-      '@descope-ui/common': 0.0.18
-      '@descope-ui/descope-combo-box': 0.1.11
-      '@descope-ui/theme-globals': 0.0.19
-      '@descope-ui/theme-input-wrapper': 0.1.8
+      '@descope-ui/common': 0.1.0
+      '@descope-ui/descope-combo-box': 0.1.12
+      '@descope-ui/theme-globals': 0.0.20
+      '@descope-ui/theme-input-wrapper': 0.1.9
       '@vaadin/custom-field': 24.3.4
 
-  '@descope-ui/descope-avatar@0.0.19':
+  '@descope-ui/descope-avatar@0.1.0':
     dependencies:
-      '@descope-ui/common': 0.0.18
-      '@descope-ui/theme-globals': 0.0.19
+      '@descope-ui/common': 0.1.0
+      '@descope-ui/theme-globals': 0.0.20
       '@vaadin/avatar': 24.3.4
       '@vaadin/icon': 24.3.4
       '@vaadin/icons': 24.3.4
 
-  '@descope-ui/descope-button@0.0.19':
+  '@descope-ui/descope-badge@0.1.0':
     dependencies:
-      '@descope-ui/common': 0.0.18
-      '@descope-ui/descope-icon': 0.0.17
-      '@descope-ui/theme-globals': 0.0.19
+      '@descope-ui/common': 0.1.0
+      '@descope-ui/theme-globals': 0.0.20
+
+  '@descope-ui/descope-button@0.0.20':
+    dependencies:
+      '@descope-ui/common': 0.1.0
+      '@descope-ui/descope-icon': 0.0.18
+      '@descope-ui/theme-globals': 0.0.20
       '@vaadin/button': 24.3.4
 
-  '@descope-ui/descope-collapsible-container@0.0.18':
+  '@descope-ui/descope-collapsible-container@0.0.19':
     dependencies:
-      '@descope-ui/common': 0.0.18
-      '@descope-ui/descope-icon': 0.0.17
-      '@descope-ui/descope-text': 0.0.19
-      '@descope-ui/theme-globals': 0.0.19
+      '@descope-ui/common': 0.1.0
+      '@descope-ui/descope-icon': 0.0.18
+      '@descope-ui/descope-text': 0.0.20
+      '@descope-ui/theme-globals': 0.0.20
 
-  '@descope-ui/descope-combo-box@0.1.11':
+  '@descope-ui/descope-combo-box@0.1.12':
     dependencies:
-      '@descope-ui/common': 0.0.18
-      '@descope-ui/theme-globals': 0.0.19
-      '@descope-ui/theme-input-wrapper': 0.1.8
+      '@descope-ui/common': 0.1.0
+      '@descope-ui/theme-globals': 0.0.20
+      '@descope-ui/theme-input-wrapper': 0.1.9
       '@vaadin/combo-box': 24.3.4
 
-  '@descope-ui/descope-enriched-text@0.0.3':
+  '@descope-ui/descope-enriched-text@0.0.4':
     dependencies:
-      '@descope-ui/common': 0.0.18
-      '@descope-ui/descope-link': 0.0.3
-      '@descope-ui/descope-text': 0.0.19
-      '@descope-ui/theme-globals': 0.0.19
+      '@descope-ui/common': 0.1.0
+      '@descope-ui/descope-link': 0.1.0
+      '@descope-ui/descope-text': 0.0.20
+      '@descope-ui/theme-globals': 0.0.20
       markdown-it: 14.1.0
 
-  '@descope-ui/descope-icon@0.0.17':
+  '@descope-ui/descope-icon@0.0.18':
     dependencies:
-      '@descope-ui/common': 0.0.18
-      '@descope-ui/descope-image': 0.0.10
-      '@descope-ui/theme-globals': 0.0.19
+      '@descope-ui/common': 0.1.0
+      '@descope-ui/descope-image': 0.0.11
+      '@descope-ui/theme-globals': 0.0.20
       '@vaadin/icon': 24.3.4
       dompurify: 3.2.6
 
-  '@descope-ui/descope-image@0.0.10':
+  '@descope-ui/descope-image@0.0.11':
     dependencies:
-      '@descope-ui/common': 0.0.18
-      '@descope-ui/theme-globals': 0.0.19
+      '@descope-ui/common': 0.1.0
+      '@descope-ui/theme-globals': 0.0.20
       dompurify: 3.2.6
 
-  '@descope-ui/descope-link@0.0.3':
+  '@descope-ui/descope-link@0.1.0':
     dependencies:
-      '@descope-ui/common': 0.0.18
-      '@descope-ui/theme-globals': 0.0.19
+      '@descope-ui/common': 0.1.0
+      '@descope-ui/theme-globals': 0.0.20
 
-  '@descope-ui/descope-list-item@0.0.1':
+  '@descope-ui/descope-list-item@0.1.0':
     dependencies:
-      '@descope-ui/common': 0.0.18
-      '@descope-ui/theme-globals': 0.0.19
+      '@descope-ui/common': 0.1.0
+      '@descope-ui/theme-globals': 0.0.20
 
-  '@descope-ui/descope-list@0.0.1':
+  '@descope-ui/descope-list@0.1.0':
     dependencies:
-      '@descope-ui/common': 0.0.18
-      '@descope-ui/descope-list-item': 0.0.1
-      '@descope-ui/theme-globals': 0.0.19
+      '@descope-ui/common': 0.1.0
+      '@descope-ui/descope-list-item': 0.1.0
+      '@descope-ui/theme-globals': 0.0.20
 
-  '@descope-ui/descope-outbound-app-button@0.0.4':
+  '@descope-ui/descope-outbound-app-button@0.0.5':
     dependencies:
-      '@descope-ui/common': 0.0.18
-      '@descope-ui/descope-button': 0.0.19
-      '@descope-ui/descope-icon': 0.0.17
-      '@descope-ui/theme-globals': 0.0.19
+      '@descope-ui/common': 0.1.0
+      '@descope-ui/descope-button': 0.0.20
+      '@descope-ui/descope-icon': 0.0.18
+      '@descope-ui/theme-globals': 0.0.20
 
-  '@descope-ui/descope-outbound-apps@0.0.5':
+  '@descope-ui/descope-outbound-apps@0.1.0':
     dependencies:
-      '@descope-ui/common': 0.0.18
-      '@descope-ui/descope-avatar': 0.0.19
-      '@descope-ui/descope-button': 0.0.19
-      '@descope-ui/descope-icon': 0.0.17
-      '@descope-ui/descope-list': 0.0.1
-      '@descope-ui/descope-list-item': 0.0.1
-      '@descope-ui/descope-text': 0.0.19
-      '@descope-ui/theme-globals': 0.0.19
+      '@descope-ui/common': 0.1.0
+      '@descope-ui/descope-avatar': 0.1.0
+      '@descope-ui/descope-button': 0.0.20
+      '@descope-ui/descope-icon': 0.0.18
+      '@descope-ui/descope-list': 0.1.0
+      '@descope-ui/descope-list-item': 0.1.0
+      '@descope-ui/descope-text': 0.0.20
+      '@descope-ui/theme-globals': 0.0.20
 
-  '@descope-ui/descope-password-strength@0.0.13':
+  '@descope-ui/descope-password-strength@0.0.14':
     dependencies:
-      '@descope-ui/common': 0.0.18
-      '@descope-ui/theme-globals': 0.0.19
-      '@descope-ui/theme-input-wrapper': 0.1.8
+      '@descope-ui/common': 0.1.0
+      '@descope-ui/theme-globals': 0.0.20
+      '@descope-ui/theme-input-wrapper': 0.1.9
       '@zxcvbn-ts/core': 3.0.4
       '@zxcvbn-ts/language-common': 3.0.4
       '@zxcvbn-ts/language-en': 3.0.2
 
-  '@descope-ui/descope-recovery-codes@0.0.6':
+  '@descope-ui/descope-recovery-codes@0.0.7':
     dependencies:
-      '@descope-ui/common': 0.0.18
-      '@descope-ui/descope-text': 0.0.19
-      '@descope-ui/theme-globals': 0.0.19
+      '@descope-ui/common': 0.1.0
+      '@descope-ui/descope-text': 0.0.20
+      '@descope-ui/theme-globals': 0.0.20
       '@vaadin/icon': 24.3.4
       '@vaadin/icons': 24.3.4
 
-  '@descope-ui/descope-text@0.0.19':
+  '@descope-ui/descope-text@0.0.20':
     dependencies:
-      '@descope-ui/common': 0.0.18
-      '@descope-ui/theme-globals': 0.0.19
+      '@descope-ui/common': 0.1.0
+      '@descope-ui/theme-globals': 0.0.20
 
-  '@descope-ui/descope-timer-button@0.0.20':
+  '@descope-ui/descope-timer-button@0.0.21':
     dependencies:
-      '@descope-ui/common': 0.0.18
-      '@descope-ui/descope-button': 0.0.19
-      '@descope-ui/descope-timer': 0.0.17
-      '@descope-ui/theme-globals': 0.0.19
+      '@descope-ui/common': 0.1.0
+      '@descope-ui/descope-button': 0.0.20
+      '@descope-ui/descope-timer': 0.0.18
+      '@descope-ui/theme-globals': 0.0.20
 
-  '@descope-ui/descope-timer@0.0.17':
+  '@descope-ui/descope-timer@0.0.18':
     dependencies:
-      '@descope-ui/common': 0.0.18
-      '@descope-ui/descope-icon': 0.0.17
-      '@descope-ui/theme-globals': 0.0.19
+      '@descope-ui/common': 0.1.0
+      '@descope-ui/descope-icon': 0.0.18
+      '@descope-ui/theme-globals': 0.0.20
 
-  '@descope-ui/theme-globals@0.0.19':
+  '@descope-ui/descope-trusted-devices@0.1.0':
     dependencies:
-      '@descope-ui/common': 0.0.18
+      '@descope-ui/common': 0.1.0
+      '@descope-ui/descope-badge': 0.1.0
+      '@descope-ui/descope-link': 0.1.0
+      '@descope-ui/descope-list': 0.1.0
+      '@descope-ui/descope-list-item': 0.1.0
+      '@descope-ui/descope-text': 0.0.20
+      '@descope-ui/theme-globals': 0.0.20
 
-  '@descope-ui/theme-input-wrapper@0.1.8':
+  '@descope-ui/theme-globals@0.0.20':
     dependencies:
-      '@descope-ui/common': 0.0.18
-      '@descope-ui/theme-globals': 0.0.19
+      '@descope-ui/common': 0.1.0
+
+  '@descope-ui/theme-input-wrapper@0.1.9':
+    dependencies:
+      '@descope-ui/common': 0.1.0
+      '@descope-ui/theme-globals': 0.0.20
 
   '@descope/core-js-sdk@2.31.0':
     dependencies:
@@ -18008,29 +18025,31 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@descope/web-components-ui@1.127.0':
+  '@descope/web-components-ui@1.132.0':
     dependencies:
-      '@descope-ui/common': 0.0.18
-      '@descope-ui/descope-address-field': 0.0.23
-      '@descope-ui/descope-apps-list': 0.0.1
-      '@descope-ui/descope-autocomplete-field': 0.0.24
-      '@descope-ui/descope-avatar': 0.0.19
-      '@descope-ui/descope-button': 0.0.19
-      '@descope-ui/descope-collapsible-container': 0.0.18
-      '@descope-ui/descope-combo-box': 0.1.11
-      '@descope-ui/descope-enriched-text': 0.0.3
-      '@descope-ui/descope-icon': 0.0.17
-      '@descope-ui/descope-image': 0.0.10
-      '@descope-ui/descope-link': 0.0.3
-      '@descope-ui/descope-list': 0.0.1
-      '@descope-ui/descope-list-item': 0.0.1
-      '@descope-ui/descope-outbound-app-button': 0.0.4
-      '@descope-ui/descope-outbound-apps': 0.0.5
-      '@descope-ui/descope-password-strength': 0.0.13
-      '@descope-ui/descope-recovery-codes': 0.0.6
-      '@descope-ui/descope-text': 0.0.19
-      '@descope-ui/descope-timer': 0.0.17
-      '@descope-ui/descope-timer-button': 0.0.20
+      '@descope-ui/common': 0.1.0
+      '@descope-ui/descope-address-field': 0.0.24
+      '@descope-ui/descope-apps-list': 0.0.2
+      '@descope-ui/descope-autocomplete-field': 0.0.25
+      '@descope-ui/descope-avatar': 0.1.0
+      '@descope-ui/descope-badge': 0.1.0
+      '@descope-ui/descope-button': 0.0.20
+      '@descope-ui/descope-collapsible-container': 0.0.19
+      '@descope-ui/descope-combo-box': 0.1.12
+      '@descope-ui/descope-enriched-text': 0.0.4
+      '@descope-ui/descope-icon': 0.0.18
+      '@descope-ui/descope-image': 0.0.11
+      '@descope-ui/descope-link': 0.1.0
+      '@descope-ui/descope-list': 0.1.0
+      '@descope-ui/descope-list-item': 0.1.0
+      '@descope-ui/descope-outbound-app-button': 0.0.5
+      '@descope-ui/descope-outbound-apps': 0.1.0
+      '@descope-ui/descope-password-strength': 0.0.14
+      '@descope-ui/descope-recovery-codes': 0.0.7
+      '@descope-ui/descope-text': 0.0.20
+      '@descope-ui/descope-timer': 0.0.18
+      '@descope-ui/descope-timer-button': 0.0.21
+      '@descope-ui/descope-trusted-devices': 0.1.0
       '@vaadin/checkbox': 24.3.4
       '@vaadin/custom-field': 24.3.4
       '@vaadin/dialog': 24.3.4
@@ -19723,9 +19742,9 @@ snapshots:
     transitivePeerDependencies:
       - nx
 
-  '@nrwl/eslint-plugin-nx@19.8.4(@babel/traverse@7.28.3)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@typescript-eslint/parser@7.2.0(eslint@9.18.0(jiti@1.21.0))(typescript@5.7.3))(eslint-config-prettier@9.1.0(eslint@9.18.0(jiti@1.21.0)))(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)':
+  '@nrwl/eslint-plugin-nx@19.8.4(@babel/traverse@7.28.4)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@typescript-eslint/parser@7.2.0(eslint@9.18.0(jiti@1.21.0))(typescript@5.7.3))(eslint-config-prettier@9.1.0(eslint@9.18.0(jiti@1.21.0)))(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)':
     dependencies:
-      '@nx/eslint-plugin': 19.8.4(@babel/traverse@7.28.3)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@typescript-eslint/parser@7.2.0(eslint@9.18.0(jiti@1.21.0))(typescript@5.7.3))(eslint-config-prettier@9.1.0(eslint@9.18.0(jiti@1.21.0)))(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)
+      '@nx/eslint-plugin': 19.8.4(@babel/traverse@7.28.4)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@typescript-eslint/parser@7.2.0(eslint@9.18.0(jiti@1.21.0))(typescript@5.7.3))(eslint-config-prettier@9.1.0(eslint@9.18.0(jiti@1.21.0)))(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -19741,9 +19760,9 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nrwl/jest@19.8.4(@babel/traverse@7.28.3)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3))(typescript@5.7.3)':
+  '@nrwl/jest@19.8.4(@babel/traverse@7.28.4)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3))(typescript@5.7.3)':
     dependencies:
-      '@nx/jest': 19.8.4(@babel/traverse@7.28.3)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3))(typescript@5.7.3)
+      '@nx/jest': 19.8.4(@babel/traverse@7.28.4)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3))(typescript@5.7.3)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -19759,9 +19778,9 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nrwl/js@19.8.4(@babel/traverse@7.28.3)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.4.5)':
+  '@nrwl/js@19.8.4(@babel/traverse@7.28.4)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.4.5)':
     dependencies:
-      '@nx/js': 19.8.4(@babel/traverse@7.28.3)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.4.5)
+      '@nx/js': 19.8.4(@babel/traverse@7.28.4)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.4.5)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -19774,9 +19793,9 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nrwl/js@19.8.4(@babel/traverse@7.28.3)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)':
+  '@nrwl/js@19.8.4(@babel/traverse@7.28.4)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)':
     dependencies:
-      '@nx/js': 19.8.4(@babel/traverse@7.28.3)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)
+      '@nx/js': 19.8.4(@babel/traverse@7.28.4)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -19789,9 +19808,9 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nrwl/linter@19.8.4(@babel/traverse@7.28.3)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@zkochan/js-yaml@0.0.7)(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))':
+  '@nrwl/linter@19.8.4(@babel/traverse@7.28.4)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@zkochan/js-yaml@0.0.7)(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))':
     dependencies:
-      '@nx/eslint': 19.8.4(@babel/traverse@7.28.3)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@zkochan/js-yaml@0.0.7)(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))
+      '@nx/eslint': 19.8.4(@babel/traverse@7.28.4)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@zkochan/js-yaml@0.0.7)(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -19870,12 +19889,12 @@ snapshots:
       tslib: 2.8.1
       yargs-parser: 21.1.1
 
-  '@nx/eslint-plugin@19.8.4(@babel/traverse@7.28.3)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@typescript-eslint/parser@7.2.0(eslint@9.18.0(jiti@1.21.0))(typescript@5.7.3))(eslint-config-prettier@9.1.0(eslint@9.18.0(jiti@1.21.0)))(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)':
+  '@nx/eslint-plugin@19.8.4(@babel/traverse@7.28.4)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@typescript-eslint/parser@7.2.0(eslint@9.18.0(jiti@1.21.0))(typescript@5.7.3))(eslint-config-prettier@9.1.0(eslint@9.18.0(jiti@1.21.0)))(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)':
     dependencies:
       '@eslint/compat': 1.2.6(eslint@9.18.0(jiti@1.21.0))
-      '@nrwl/eslint-plugin-nx': 19.8.4(@babel/traverse@7.28.3)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@typescript-eslint/parser@7.2.0(eslint@9.18.0(jiti@1.21.0))(typescript@5.7.3))(eslint-config-prettier@9.1.0(eslint@9.18.0(jiti@1.21.0)))(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)
+      '@nrwl/eslint-plugin-nx': 19.8.4(@babel/traverse@7.28.4)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@typescript-eslint/parser@7.2.0(eslint@9.18.0(jiti@1.21.0))(typescript@5.7.3))(eslint-config-prettier@9.1.0(eslint@9.18.0(jiti@1.21.0)))(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)
       '@nx/devkit': 19.8.4(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))
-      '@nx/js': 19.8.4(@babel/traverse@7.28.3)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)
+      '@nx/js': 19.8.4(@babel/traverse@7.28.4)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)
       '@typescript-eslint/parser': 7.2.0(eslint@9.18.0(jiti@1.21.0))(typescript@5.7.3)
       '@typescript-eslint/type-utils': 8.23.0(eslint@9.18.0(jiti@1.21.0))(typescript@5.7.3)
       '@typescript-eslint/utils': 8.23.0(eslint@9.18.0(jiti@1.21.0))(typescript@5.7.3)
@@ -19900,11 +19919,11 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/eslint@19.8.4(@babel/traverse@7.28.3)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@zkochan/js-yaml@0.0.7)(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))':
+  '@nx/eslint@19.8.4(@babel/traverse@7.28.4)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@zkochan/js-yaml@0.0.7)(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))':
     dependencies:
       '@nx/devkit': 19.8.4(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))
-      '@nx/js': 19.8.4(@babel/traverse@7.28.3)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.4.5)
-      '@nx/linter': 19.8.4(@babel/traverse@7.28.3)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@zkochan/js-yaml@0.0.7)(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))
+      '@nx/js': 19.8.4(@babel/traverse@7.28.4)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.4.5)
+      '@nx/linter': 19.8.4(@babel/traverse@7.28.4)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@zkochan/js-yaml@0.0.7)(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))
       eslint: 9.18.0(jiti@1.21.0)
       semver: 7.7.1
       tslib: 2.8.1
@@ -19922,13 +19941,13 @@ snapshots:
       - supports-color
       - verdaccio
 
-  '@nx/jest@19.8.4(@babel/traverse@7.28.3)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3))(typescript@5.7.3)':
+  '@nx/jest@19.8.4(@babel/traverse@7.28.4)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3))(typescript@5.7.3)':
     dependencies:
       '@jest/reporters': 29.7.0
       '@jest/test-result': 29.7.0
-      '@nrwl/jest': 19.8.4(@babel/traverse@7.28.3)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3))(typescript@5.7.3)
+      '@nrwl/jest': 19.8.4(@babel/traverse@7.28.4)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3))(typescript@5.7.3)
       '@nx/devkit': 19.8.4(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))
-      '@nx/js': 19.8.4(@babel/traverse@7.28.3)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)
+      '@nx/js': 19.8.4(@babel/traverse@7.28.4)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.7.3)
       chalk: 4.1.2
       identity-obj-proxy: 3.0.0
@@ -19955,7 +19974,7 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/js@19.8.4(@babel/traverse@7.28.3)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.4.5)':
+  '@nx/js@19.8.4(@babel/traverse@7.28.4)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.4.5)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-proposal-decorators': 7.23.5(@babel/core@7.26.0)
@@ -19964,12 +19983,12 @@ snapshots:
       '@babel/preset-env': 7.26.0(@babel/core@7.26.0)
       '@babel/preset-typescript': 7.26.0(@babel/core@7.26.0)
       '@babel/runtime': 7.25.6
-      '@nrwl/js': 19.8.4(@babel/traverse@7.28.3)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.4.5)
+      '@nrwl/js': 19.8.4(@babel/traverse@7.28.4)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.4.5)
       '@nx/devkit': 19.8.4(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))
       '@nx/workspace': 19.8.4(@swc/core@1.7.1(@swc/helpers@0.5.15))
       babel-plugin-const-enum: 1.2.0(@babel/core@7.26.0)
       babel-plugin-macros: 2.8.0
-      babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.26.0)(@babel/traverse@7.28.3)
+      babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.26.0)(@babel/traverse@7.28.4)
       chalk: 4.1.2
       columnify: 1.6.0
       detect-port: 1.5.1
@@ -19998,7 +20017,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@nx/js@19.8.4(@babel/traverse@7.28.3)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)':
+  '@nx/js@19.8.4(@babel/traverse@7.28.4)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-proposal-decorators': 7.23.5(@babel/core@7.26.0)
@@ -20007,12 +20026,12 @@ snapshots:
       '@babel/preset-env': 7.26.0(@babel/core@7.26.0)
       '@babel/preset-typescript': 7.26.0(@babel/core@7.26.0)
       '@babel/runtime': 7.25.6
-      '@nrwl/js': 19.8.4(@babel/traverse@7.28.3)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)
+      '@nrwl/js': 19.8.4(@babel/traverse@7.28.4)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)
       '@nx/devkit': 19.8.4(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))
       '@nx/workspace': 19.8.4(@swc/core@1.7.1(@swc/helpers@0.5.15))
       babel-plugin-const-enum: 1.2.0(@babel/core@7.26.0)
       babel-plugin-macros: 2.8.0
-      babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.26.0)(@babel/traverse@7.28.3)
+      babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.26.0)(@babel/traverse@7.28.4)
       chalk: 4.1.2
       columnify: 1.6.0
       detect-port: 1.5.1
@@ -20041,9 +20060,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@nx/linter@19.8.4(@babel/traverse@7.28.3)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@zkochan/js-yaml@0.0.7)(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))':
+  '@nx/linter@19.8.4(@babel/traverse@7.28.4)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@zkochan/js-yaml@0.0.7)(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))':
     dependencies:
-      '@nx/eslint': 19.8.4(@babel/traverse@7.28.3)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@zkochan/js-yaml@0.0.7)(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))
+      '@nx/eslint': 19.8.4(@babel/traverse@7.28.4)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(@zkochan/js-yaml@0.0.7)(eslint@9.18.0(jiti@1.21.0))(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -22745,7 +22764,7 @@ snapshots:
 
   '@vue/compiler-core@3.5.13':
     dependencies:
-      '@babel/parser': 7.28.3
+      '@babel/parser': 7.28.4
       '@vue/shared': 3.5.13
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -22775,7 +22794,7 @@ snapshots:
 
   '@vue/compiler-sfc@3.5.13':
     dependencies:
-      '@babel/parser': 7.28.3
+      '@babel/parser': 7.28.4
       '@vue/compiler-core': 3.5.13
       '@vue/compiler-dom': 3.5.13
       '@vue/compiler-ssr': 3.5.13
@@ -23565,12 +23584,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-transform-typescript-metadata@0.3.2(@babel/core@7.26.0)(@babel/traverse@7.28.3):
+  babel-plugin-transform-typescript-metadata@0.3.2(@babel/core@7.26.0)(@babel/traverse@7.28.4):
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-plugin-utils': 7.26.5
     optionalDependencies:
-      '@babel/traverse': 7.28.3
+      '@babel/traverse': 7.28.4
 
   babel-preset-current-node-syntax@1.0.1(@babel/core@7.26.0):
     dependencies:


### PR DESCRIPTION
## Related Issues
Continuation of #1200 which was closed for technical reasons

## Description

To fix the vercel deploys.

> Node.js Version "18.x" is discontinued and must be upgraded. Please set "engines": { "node": "22.x" } in your `package.json` file to use Node.js 22.

Precommit hook also added pnpm lockfile changes, seemingly unrelated

TODO:
- [ ] Verify: NX Cloud is keyed on node ver / disabled in CI
- [ ] Post-merge: `npm i` a package with node v18; ensure no warnings.

