### PR TITLE
feat: Add usersAndRoles to flow data from user mgmt widget

### DIFF
--- a/packages/widgets/user-management-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initGenericFlowButtonMixin.ts
+++ b/packages/widgets/user-management-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initGenericFlowButtonMixin.ts
@@ -16,6 +16,7 @@ import { createFlowTemplate } from '../../../../helpers';
 import {
   getSelectedUsersAllIds,
   getSelectedUsersLoginIds,
+  getSelectedUsersRolesList,
   getSelectedUsersUserIds,
 } from '../../../state/selectors';
 
@@ -103,6 +104,7 @@ export const initGenericFlowButtonMixin = createSingletonMixin(
             client: JSON.stringify({
               userIds: getSelectedUsersUserIds(this.state),
               loginIds: getSelectedUsersAllIds(this.state),
+              usersAndRoles: getSelectedUsersRolesList(this.state),
             }),
             tenant: this.tenantId,
           }),

--- a/packages/widgets/user-management-widget/src/lib/widget/state/selectors.ts
+++ b/packages/widgets/user-management-widget/src/lib/widget/state/selectors.ts
@@ -65,6 +65,14 @@ export const getSelectedUsersAllIds = createSelector(
       loginIds,
     })),
 );
+export const getSelectedUsersRolesList = createSelector(
+  getSelectedUsers,
+  (users) =>
+    users.map((user) => ({
+      userId: user.userId,
+      roles: user.roles,
+    })),
+);
 
 export const getSelectedUsersStatus = createSelector(
   getSelectedUsers,


### PR DESCRIPTION
## Related Issues

https://github.com/descope/etc/issues/12598

## Related PRs
https://github.com/descope/orchestrationservice/pull/4714

## Description

Send a map of userIds to roles in generic flow button - user management widget
