### PR TITLE
feat: do not refresh session if tab is in bg

### DIFF
--- a/packages/sdks/web-js-sdk/src/enhancers/withAutoRefresh/types.ts
+++ b/packages/sdks/web-js-sdk/src/enhancers/withAutoRefresh/types.ts
@@ -1,4 +1,10 @@
 export type AutoRefreshOptions = {
   // If true, sdk object will trigger refresh on init, and in intervals manner, in order to to retain a valid session token
-  autoRefresh?: boolean;
+  // If an object, allows fine-grained control over refresh behavior
+  autoRefresh?:
+    | boolean
+    | {
+        // If true, refresh will happen regardless of window visibility (legacy behavior)
+        ignoreVisibility?: boolean;
+      };
 };

--- a/packages/sdks/web-js-sdk/test/autoRefresh.test.ts
+++ b/packages/sdks/web-js-sdk/test/autoRefresh.test.ts
@@ -325,7 +325,7 @@ describe('autoRefresh', () => {
   });
 
   it('should refresh token when visibilitychange event and session expired', async () => {
-    const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+    const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
     const loggerDebugMock = logger.debug as jest.Mock;
 
     const sessionExpiration = Math.floor(Date.now() / 1000) - 10 * 60; // 10 minutes ago now
@@ -339,7 +339,7 @@ describe('autoRefresh', () => {
 
     const sdk = createSdk({
       projectId: 'pid',
-      autoRefresh: { ignoreVisibility: true },
+      autoRefresh: true,
     });
     const refreshSpy = jest
       .spyOn(sdk, 'refresh')
@@ -351,10 +351,11 @@ describe('autoRefresh', () => {
     // trigger visibilitychange event and ensure refresh called
     const event = new Event('visibilitychange');
     document.dispatchEvent(event);
+    expect(clearTimeoutSpy).toHaveBeenCalled();
     expect(refreshSpy).toHaveBeenCalledWith(authInfo.refreshJwt);
 
     expect(loggerDebugMock).toHaveBeenCalledWith(
-      'Expiration time passed or refresh needed, refreshing session',
+      'Session expired or close to expiration, refreshing session',
     );
     loggerDebugMock.mockClear();
   });

--- a/packages/sdks/web-js-sdk/test/autoRefresh.test.ts
+++ b/packages/sdks/web-js-sdk/test/autoRefresh.test.ts
@@ -337,7 +337,10 @@ describe('autoRefresh', () => {
     );
     global.fetch = mockFetch;
 
-    const sdk = createSdk({ projectId: 'pid', autoRefresh: true });
+    const sdk = createSdk({
+      projectId: 'pid',
+      autoRefresh: { ignoreVisibility: true },
+    });
     const refreshSpy = jest
       .spyOn(sdk, 'refresh')
       .mockReturnValue(new Promise(() => {}));
@@ -351,7 +354,7 @@ describe('autoRefresh', () => {
     expect(refreshSpy).toHaveBeenCalledWith(authInfo.refreshJwt);
 
     expect(loggerDebugMock).toHaveBeenCalledWith(
-      'Expiration time passed, refreshing session',
+      'Expiration time passed or refresh needed, refreshing session',
     );
     loggerDebugMock.mockClear();
   });

--- a/packages/sdks/web-js-sdk/test/autoRefresh.test.ts
+++ b/packages/sdks/web-js-sdk/test/autoRefresh.test.ts
@@ -325,7 +325,6 @@ describe('autoRefresh', () => {
   });
 
   it('should refresh token when visibilitychange event and session expired', async () => {
-    const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
     const loggerDebugMock = logger.debug as jest.Mock;
 
     const sessionExpiration = Math.floor(Date.now() / 1000) - 10 * 60; // 10 minutes ago now
@@ -351,7 +350,6 @@ describe('autoRefresh', () => {
     // trigger visibilitychange event and ensure refresh called
     const event = new Event('visibilitychange');
     document.dispatchEvent(event);
-    expect(clearTimeoutSpy).toHaveBeenCalled();
     expect(refreshSpy).toHaveBeenCalledWith(authInfo.refreshJwt);
 
     expect(loggerDebugMock).toHaveBeenCalledWith(


### PR DESCRIPTION
## Related Issues
Fixes https://github.com/descope/etc/issues/13001

## Description
 - by default, do not do refresh if document is not visible (this is required for session inactivity) but instead mark refresh as needed so when the document visibility changes - do the refresh
  - this may have some subtle bc, so for now I added an option to do pas `autoRefresh: { ignoreVisibility: true }` to preserve old behavior 
  
  still required tests