### PR TITLE
feat: Disable explicit refresh calls when running in native flows

### DIFF
--- a/packages/sdks/web-js-sdk/src/constants.ts
+++ b/packages/sdks/web-js-sdk/src/constants.ts
@@ -15,3 +15,5 @@ export const OIDC_CLIENT_TS_JSDELIVR_CDN_URL = `https://cdn.jsdelivr.net/npm/oid
 
 export const OIDC_LOGOUT_ERROR_CODE = 'J161000';
 export const OIDC_REFRESH_ERROR_CODE = 'J161001';
+
+export const REFRESH_DISABLED = 'J171000';


### PR DESCRIPTION
## Related Issues
Fixes https://github.com/descope/etc/issues/13113

## Description
- Disable explicit refresh calls when running in native flows

## Must
- [ ] Tests
- [X] Documentation (if applicable)
