### PR TITLE
feat: Add Descope prefix to default logger

### DIFF
--- a/packages/sdks/core-js-sdk/src/sdk/types.ts
+++ b/packages/sdks/core-js-sdk/src/sdk/types.ts
@@ -138,6 +138,7 @@ export type JWTResponse = {
   firstSeen?: boolean;
   sessionExpiration: number;
   claims: Claims;
+  trustedDeviceJwt?: string;
 };
 
 /** Authentication info result from exchanging access keys for a session */

--- a/packages/sdks/web-js-sdk/src/enhancers/withPersistTokens/constants.ts
+++ b/packages/sdks/web-js-sdk/src/enhancers/withPersistTokens/constants.ts
@@ -4,3 +4,5 @@ export const SESSION_TOKEN_KEY = 'DS';
 export const REFRESH_TOKEN_KEY = 'DSR';
 /* Default name for the id token local storage key */
 export const ID_TOKEN_KEY = 'DSI';
+/* Default name for the trusted device token (DTD) local storage key */
+export const TRUSTED_DEVICE_TOKEN_KEY = 'DTD';

--- a/packages/sdks/web-js-sdk/test/beforeRequest-dtd.test.ts
+++ b/packages/sdks/web-js-sdk/test/beforeRequest-dtd.test.ts
@@ -1,0 +1,119 @@
+import Cookies from 'js-cookie';
+import { beforeRequest } from '../src/enhancers/withPersistTokens/helpers';
+import { TRUSTED_DEVICE_TOKEN_KEY } from '../src/enhancers/withPersistTokens/constants';
+import { HTTPMethods } from '@descope/core-js-sdk';
+
+jest.mock('js-cookie', () => ({
+  set: jest.fn(),
+  get: jest.fn(),
+  remove: jest.fn(),
+}));
+
+describe('beforeRequest hook - DTD header', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  describe('Populating Descope Trusted Device header', () => {
+    it('should add x-descope-trusted-device-token header when DTD exists in localStorage', () => {
+      localStorage.setItem(TRUSTED_DEVICE_TOKEN_KEY, 'my-dtd-token');
+
+      const config = {
+        path: '/v1/flow/start',
+        method: 'POST' as HTTPMethods,
+        body: { flowId: 'test-flow' },
+      };
+
+      const hook = beforeRequest('', false);
+      const result = hook(config);
+
+      expect(result.headers).toEqual({
+        'x-descope-trusted-device-token': 'my-dtd-token',
+      });
+    });
+
+    it('should add x-descope-trusted-device-token header with storage prefix', () => {
+      const prefix = 'myprefix-';
+      localStorage.setItem(
+        prefix + TRUSTED_DEVICE_TOKEN_KEY,
+        'prefixed-dtd-token',
+      );
+
+      const config = {
+        path: '/v1/flow/start',
+        method: 'POST' as HTTPMethods,
+        body: { flowId: 'test-flow' },
+      };
+
+      const hook = beforeRequest(prefix, false);
+      const result = hook(config);
+
+      expect(result.headers).toEqual({
+        'x-descope-trusted-device-token': 'prefixed-dtd-token',
+      });
+    });
+
+    it('should not add x-descope-trusted-device-token header when DTD does not exist', () => {
+      const config = {
+        path: '/v1/flow/start',
+        method: 'POST' as HTTPMethods,
+        body: { flowId: 'test-flow' },
+      };
+
+      const hook = beforeRequest('', false);
+      const result = hook(config);
+
+      expect(result.headers).toBeUndefined();
+    });
+
+    it('should preserve existing headers when adding DTD header', () => {
+      localStorage.setItem(TRUSTED_DEVICE_TOKEN_KEY, 'my-dtd-token');
+
+      const config = {
+        path: '/v1/flow/start',
+        method: 'POST' as HTTPMethods,
+        body: { flowId: 'test-flow' },
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Custom-Header': 'custom-value',
+        },
+      };
+
+      const hook = beforeRequest('', false);
+      const result = hook(config);
+
+      expect(result.headers).toEqual({
+        'Content-Type': 'application/json',
+        'X-Custom-Header': 'custom-value',
+        'x-descope-trusted-device-token': 'my-dtd-token',
+      });
+    });
+  });
+
+  describe('token handling', () => {
+    beforeEach(() => {
+      // Reset cookie mock to return undefined by default for localStorage tests
+      (Cookies.get as jest.Mock).mockReturnValue(undefined);
+    });
+
+    it('should still add refresh token when DTD is also present (localStorage mode)', () => {
+      localStorage.setItem(TRUSTED_DEVICE_TOKEN_KEY, 'dtd-token');
+      localStorage.setItem('DSR', 'refresh-token');
+
+      const config = {
+        path: '/v1/flow/start',
+        method: 'POST' as HTTPMethods,
+        body: { flowId: 'test-flow' },
+      };
+
+      const hook = beforeRequest('', false);
+      const result = hook(config);
+
+      expect(result.token).toBe('refresh-token');
+      expect(result.headers).toEqual({
+        'x-descope-trusted-device-token': 'dtd-token',
+      });
+    });
+  });
+});

--- a/packages/sdks/web-js-sdk/test/trustedDevice.test.ts
+++ b/packages/sdks/web-js-sdk/test/trustedDevice.test.ts
@@ -1,0 +1,76 @@
+import { WebJWTResponse } from '../src/types';
+import {
+  persistTokens,
+  getTrustedDeviceToken,
+} from '../src/enhancers/withPersistTokens/helpers';
+import { TRUSTED_DEVICE_TOKEN_KEY } from '../src/enhancers/withPersistTokens/constants';
+
+jest.mock('js-cookie', () => ({
+  set: jest.fn(),
+  get: jest.fn(),
+  remove: jest.fn(),
+}));
+
+describe('Trusted Device Token (DTD)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  describe('DTD persistence', () => {
+    it('should store DTD with storage prefix in localStorage', () => {
+      const authInfo: Partial<WebJWTResponse> = {
+        sessionJwt: 'session-jwt',
+        refreshJwt: 'refresh-jwt',
+        trustedDeviceJwt: 'dtd-jwt-token',
+        sessionExpiration: Date.now() / 1000 + 3600,
+        cookieExpiration: Date.now() / 1000 + 86400,
+        claims: {},
+      };
+
+      persistTokens(authInfo, false, 'myprefix-', false);
+
+      expect(localStorage.getItem('myprefix-' + TRUSTED_DEVICE_TOKEN_KEY)).toBe(
+        'dtd-jwt-token',
+      );
+    });
+
+    it('should update DTD in localStorage when new value is provided', () => {
+      // First, store old DTD
+      localStorage.setItem(TRUSTED_DEVICE_TOKEN_KEY, 'old-dtd-token');
+
+      const authInfo: Partial<WebJWTResponse> = {
+        sessionJwt: 'session-jwt',
+        refreshJwt: 'refresh-jwt',
+        trustedDeviceJwt: 'new-dtd-jwt-token',
+        sessionExpiration: Date.now() / 1000 + 3600,
+        cookieExpiration: Date.now() / 1000 + 86400,
+        claims: {},
+      };
+
+      persistTokens(authInfo, false, '', false);
+
+      // DTD should be updated to new value
+      expect(localStorage.getItem(TRUSTED_DEVICE_TOKEN_KEY)).toBe(
+        'new-dtd-jwt-token',
+      );
+    });
+  });
+
+  describe('getTrustedDeviceToken', () => {
+    it('should return empty string when DTD is not set in localStorage', () => {
+      expect(getTrustedDeviceToken()).toBe('');
+    });
+
+    it('should retrieve DTD from localStorage', () => {
+      localStorage.setItem(TRUSTED_DEVICE_TOKEN_KEY, 'my-localStorage-dtd');
+      expect(getTrustedDeviceToken()).toBe('my-localStorage-dtd');
+    });
+
+    it('should retrieve DTD with storage prefix from localStorage', () => {
+      const prefix = 'test-';
+      localStorage.setItem(prefix + TRUSTED_DEVICE_TOKEN_KEY, 'my-dtd-token');
+      expect(getTrustedDeviceToken(prefix)).toBe('my-dtd-token');
+    });
+  });
+});


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/13303

In case you do not want the `Descope` prefix in the log messages, you can provide a custom logger
See more details [here](https://github.com/descope/descope-js/blob/main/packages/sdks/web-component/README.md#logger---an-object-that-defines-how-to-log-error-warning-and-info-defaults-to-consoleerror-consolewarn-and-consoleinfo-respectively)

