### PR TITLE
fix: Bridge actions (native) now trigger component state reset

### DIFF
--- a/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
+++ b/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
@@ -1005,6 +1005,12 @@ class DescopeWc extends BaseDescopeWc {
       // the response will be in the form of calling the 'nativeCallbacks.complete' callback via
       // the 'nativeResume' function.
       this.#nativeNotifyBridge(nativeResponseType, nativePayload);
+      // since the native bridge takes over and will display cancelable modal UI
+      // we want to reset the loading state of button components to prevent
+      // endless loading state in case the user cancels the native UI
+      setTimeout(() => {
+        this.dispatchEvent(new Event('popupclosed'));
+      }, 500);
       return;
     }
 


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/13466

## Description

Bridge actions (native) now trigger component state reset via `popupclosed` event

## Must

- [ ] Tests
- [ ] Documentation (if applicable)
