### PR TITLE
feat(web-js-sdk): export last user helper functions

### DIFF
--- a/packages/sdks/web-js-sdk/src/index.ts
+++ b/packages/sdks/web-js-sdk/src/index.ts
@@ -33,6 +33,15 @@ export {
   clearFingerprintData,
 } from './enhancers/withFingerprint/helpers';
 
+export {
+  getLastUserLoginId,
+  getLastUserDisplayName,
+  setLastUserLoginId,
+  setLastUserDisplayName,
+  removeLastUserLoginId,
+  removeLastUserDisplayName,
+} from './enhancers/withLastLoggedInUser/helpers';
+
 export { getSessionToken } from './enhancers/withPersistTokens/helpers';
 
 export { hasOidcParamsInUrl } from './sdk/oidc/helpers';

--- a/packages/sdks/web-js-sdk/test/umd.test.ts
+++ b/packages/sdks/web-js-sdk/test/umd.test.ts
@@ -16,4 +16,13 @@ describe('umd sdk', () => {
     expect(Descope['SESSION_TOKEN_KEY']).toBeDefined();
     expect(Descope['REFRESH_TOKEN_KEY']).toBeDefined();
   });
+
+  it('should export last user helpers', () => {
+    expect(Descope['getLastUserLoginId']).toBeInstanceOf(Function);
+    expect(Descope['getLastUserDisplayName']).toBeInstanceOf(Function);
+    expect(Descope['setLastUserLoginId']).toBeInstanceOf(Function);
+    expect(Descope['setLastUserDisplayName']).toBeInstanceOf(Function);
+    expect(Descope['removeLastUserLoginId']).toBeInstanceOf(Function);
+    expect(Descope['removeLastUserDisplayName']).toBeInstanceOf(Function);
+  });
 });


### PR DESCRIPTION
## Summary

Export the last authenticated user helper functions from the public API:

- `setLastUserLoginId(loginId: string)`
- `setLastUserDisplayName(displayName: string)` 
- `removeLastUserLoginId()`
- `removeLastUserDisplayName()`

The getter functions (`getLastUserLoginId`, `getLastUserDisplayName`) are also exported for completeness, though they were already accessible on the SDK instance.

## Motivation

Fixes #1331

These functions already exist in `enhancers/withLastLoggedInUser/helpers.ts` but are not exported from the package. This makes it impossible for consumers to programmatically set or clear the last authenticated user without directly accessing the internal localStorage keys.

## Changes

- Added exports to `packages/sdks/web-js-sdk/src/index.ts`
- Added UMD export tests to `packages/sdks/web-js-sdk/test/umd.test.ts`