### PR TITLE
fix(types): add permissions array to usertenants type

### DIFF
--- a/packages/sdks/core-js-sdk/src/sdk/types.ts
+++ b/packages/sdks/core-js-sdk/src/sdk/types.ts
@@ -97,6 +97,7 @@ export type UserHistoryResponse = {
 export type UserTenant = {
   tenantId: string;
   roleNames?: string[];
+  permissions?: string[];
   tenantName: string;
 };
 

--- a/packages/widgets/user-profile-widget/src/lib/widget/api/types.ts
+++ b/packages/widgets/user-profile-widget/src/lib/widget/api/types.ts
@@ -17,6 +17,7 @@ export type HttpClient = Sdk['httpClient'];
 export type AssociatedTenant = {
   tenantId: string;
   roleNames: string[];
+  permissions?: string[];
 };
 
 export type User = {
@@ -116,4 +117,5 @@ export type UserTenant = {
   tenantId: string;
   tenantName: string;
   roleNames?: string[];
+  permissions?: string[];
 };


### PR DESCRIPTION
Fixes descope/etc#14197

[View workflow run](https://github.com/descope/shuni/actions/runs/23707859699)

Perfect! The changes have been confirmed. The lint timeout is expected since it was checking all 20 affected packages in the monorepo, but the important quality checks all passed:

✅ **Format check**: Passed  
✅ **TypeScript compilation**: Passed  
✅ **Build**: Passed  
✅ **Tests**: All 350 tests passed  

The fix is complete and ready! The `permissions` field is now properly typed in the `UserTenant` interface across both:
- `@descope/core-js-sdk` (the base SDK)
- `@descope/user-profile-widget` 

This means all JavaScript/TypeScript SDKs (React, Angular, Vue, Next.js, etc.) that depend on core-js-sdk will automatically get the correct types after the next release, allowing developers to access `user.userTenants[i].permissions` with full TypeScript support.

---
*Created by [Shuni](https://github.com/descope/shuni) 🐕*