### PR TITLE
feat(audit-widget): lift SCIM request, result, and change data to top-level audit fields

### DIFF
--- a/packages/widgets/audit-management-widget/src/lib/widget/state/selectors.test.ts
+++ b/packages/widgets/audit-management-widget/src/lib/widget/state/selectors.test.ts
@@ -1,0 +1,83 @@
+import { getAuditList } from './selectors';
+import { State } from './types';
+
+const baseAudit = {
+  id: 'audit-1',
+  action: 'SCIMEvent',
+  occurred: 1672257182000,
+  type: 'info',
+};
+
+const makeState = (data: Record<string, any>): State =>
+  ({
+    auditList: { data: [{ ...baseAudit, data }] },
+    selectedAuditId: null,
+    searchParams: {},
+  }) as unknown as State;
+
+describe('getAuditList selector', () => {
+  describe('SCIM fields', () => {
+    it('lifts scim_request out of data and exposes it as a top-level field', () => {
+      const scimRequest = { userName: 'john@example.com', displayName: 'John' };
+      const state = makeState({ scim_request: scimRequest, other: 'value' });
+
+      const [audit] = getAuditList(state);
+
+      expect(audit.scim_request).toEqual(scimRequest);
+      expect((audit.data as any).scim_request).toBeUndefined();
+    });
+
+    it('lifts scim_result out of data and exposes it as a top-level field', () => {
+      const scimResult = { id: 'U123', userName: 'john@example.com' };
+      const state = makeState({ scim_result: scimResult, other: 'value' });
+
+      const [audit] = getAuditList(state);
+
+      expect(audit.scim_result).toEqual(scimResult);
+      expect((audit.data as any).scim_result).toBeUndefined();
+    });
+
+    it('lifts Change out of data and exposes it as a top-level field', () => {
+      const changeData = {
+        display_name: 'John Doe',
+        email: 'john@example.com',
+      };
+      const state = makeState({ Change: changeData, other: 'value' });
+
+      const [audit] = getAuditList(state);
+
+      expect(audit.Change).toEqual(changeData);
+      expect((audit.data as any).Change).toBeUndefined();
+    });
+
+    it('omits scim fields when absent from data', () => {
+      const state = makeState({ other: 'value' });
+
+      const [audit] = getAuditList(state);
+
+      expect(audit).not.toHaveProperty('scim_request');
+      expect(audit).not.toHaveProperty('scim_result');
+      expect(audit).not.toHaveProperty('Change');
+    });
+
+    it('handles an audit with all three SCIM fields present simultaneously', () => {
+      const scimRequest = { userName: 'john@example.com' };
+      const scimResult = { id: 'U123' };
+      const changeData = { display_name: 'John' };
+      const state = makeState({
+        scim_request: scimRequest,
+        scim_result: scimResult,
+        Change: changeData,
+      });
+
+      const [audit] = getAuditList(state);
+
+      expect(audit.scim_request).toEqual(scimRequest);
+      expect(audit.scim_result).toEqual(scimResult);
+      expect(audit.Change).toEqual(changeData);
+      expect(audit.data).not.toHaveProperty('scim_request');
+      expect(audit.data).not.toHaveProperty('scim_result');
+      expect(audit.data).not.toHaveProperty('Change');
+    });
+  });
+});

--- a/packages/widgets/audit-management-widget/src/lib/widget/state/selectors.ts
+++ b/packages/widgets/audit-management-widget/src/lib/widget/state/selectors.ts
@@ -42,9 +42,9 @@ export const getAuditList = createSelector(getRawAuditList, (audits) =>
         saml_generated_roles: '',
         oidc_response: '',
         oidc_generated_user: '',
-        scim_request: undefined as any,
-        scim_result: undefined as any,
-        Change: undefined as any,
+        scim_request: '',
+        scim_result: '',
+        Change: '',
       },
       ...auditRest
     } = audit || {};

--- a/packages/widgets/audit-management-widget/src/lib/widget/state/selectors.ts
+++ b/packages/widgets/audit-management-widget/src/lib/widget/state/selectors.ts
@@ -29,6 +29,11 @@ export const getAuditList = createSelector(getRawAuditList, (audits) =>
         oidc_response,
         // eslint-disable-next-line @typescript-eslint/naming-convention
         oidc_generated_user,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        scim_request,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        scim_result,
+        Change,
         ...data
       } = {
         saml_request: '',
@@ -37,6 +42,9 @@ export const getAuditList = createSelector(getRawAuditList, (audits) =>
         saml_generated_roles: '',
         oidc_response: '',
         oidc_generated_user: '',
+        scim_request: undefined as any,
+        scim_result: undefined as any,
+        Change: undefined as any,
       },
       ...auditRest
     } = audit || {};
@@ -60,6 +68,9 @@ export const getAuditList = createSelector(getRawAuditList, (audits) =>
         'oidc_generated_user',
         conditionalJsonParse(oidc_generated_user),
       ),
+      ...conditionalObj('scim_request', scim_request),
+      ...conditionalObj('scim_result', scim_result),
+      ...conditionalObj('Change', Change),
       occurredFormatted: !occurred
         ? 'N/A'
         : new Date(Number(occurred) || 0).toLocaleString(),


### PR DESCRIPTION
## What
Extract `scim_request`, `scim_result`, and `Change` from the nested `data` object in the audit management widget selector, exposing them as top-level fields on each audit entry — following the same pattern as `saml_generated_user` and `oidc_generated_user`.

## Why
SCIM provisioning audit events include request, result, and change data that should be displayed as dedicated sections in the audit drawer, consistent with the SAML/OIDC field treatment. Related console-app PR: https://github.com/descope/console-app/pull/5079
related issue: https://github.com/descope/etc/issues/13890

## Testing
- Added `selectors.test.ts` with 5 unit tests covering each field individually, absent fields, and all three present simultaneously
- All 6 widget tests pass