### PR TITLE
feat(audit-widget): add export CSV button

### DIFF
--- a/packages/libs/sdk-helpers/src/csv.ts
+++ b/packages/libs/sdk-helpers/src/csv.ts
@@ -1,0 +1,40 @@
+const FORMULA_PREFIXES = ['=', '+', '-', '@', '\t', '\r'];
+
+const sanitizeFormulaInjection = (str: string): string => {
+  if (str.length > 0 && FORMULA_PREFIXES.includes(str[0])) {
+    return `'${str}`;
+  }
+  return str;
+};
+
+export const escapeCsvValue = (value: unknown): string => {
+  const raw = Array.isArray(value) ? value.join('; ') : String(value ?? '');
+  const str = sanitizeFormulaInjection(raw);
+  if (str.includes(',') || str.includes('"') || str.includes('\n')) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+};
+
+export const generateCsv = (
+  records: Record<string, unknown>[],
+  columns: { header: string; path: string }[],
+): string => {
+  const header = columns.map((col) => col.header).join(',');
+  const rows = records.map((record) =>
+    columns.map((col) => escapeCsvValue(record[col.path])).join(','),
+  );
+  return [header, ...rows].join('\n');
+};
+
+export const downloadCsv = (csv: string, filename: string) => {
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.setAttribute('download', filename);
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+};

--- a/packages/libs/sdk-helpers/src/csv.ts
+++ b/packages/libs/sdk-helpers/src/csv.ts
@@ -10,7 +10,12 @@ const sanitizeFormulaInjection = (str: string): string => {
 export const escapeCsvValue = (value: unknown): string => {
   const raw = Array.isArray(value) ? value.join('; ') : String(value ?? '');
   const str = sanitizeFormulaInjection(raw);
-  if (str.includes(',') || str.includes('"') || str.includes('\n')) {
+  if (
+    str.includes(',') ||
+    str.includes('"') ||
+    str.includes('\n') ||
+    str.includes('\r')
+  ) {
     return `"${str.replace(/"/g, '""')}"`;
   }
   return str;
@@ -20,7 +25,7 @@ export const generateCsv = (
   records: Record<string, unknown>[],
   columns: { header: string; path: string }[],
 ): string => {
-  const header = columns.map((col) => col.header).join(',');
+  const header = columns.map((col) => escapeCsvValue(col.header)).join(',');
   const rows = records.map((record) =>
     columns.map((col) => escapeCsvValue(record[col.path])).join(','),
   );
@@ -28,7 +33,7 @@ export const generateCsv = (
 };
 
 export const downloadCsv = (csv: string, filename: string) => {
-  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  const blob = new Blob(['\uFEFF' + csv], { type: 'text/csv;charset=utf-8;' });
   const url = URL.createObjectURL(blob);
   const link = document.createElement('a');
   link.href = url;

--- a/packages/libs/sdk-helpers/src/index.ts
+++ b/packages/libs/sdk-helpers/src/index.ts
@@ -4,3 +4,4 @@ export * from './generic';
 export * from './mixins';
 export * from './state';
 export * from './jwt';
+export * from './csv';

--- a/packages/libs/sdk-helpers/test/csv.spec.ts
+++ b/packages/libs/sdk-helpers/test/csv.spec.ts
@@ -66,7 +66,7 @@ describe('csv helpers', () => {
       });
 
       it('should prefix values starting with carriage return', () => {
-        expect(escapeCsvValue('\r=evil')).toBe("'\r=evil");
+        expect(escapeCsvValue('\r=evil')).toBe('"\'\r=evil"');
       });
 
       it('should not prefix normal values', () => {

--- a/packages/libs/sdk-helpers/test/csv.spec.ts
+++ b/packages/libs/sdk-helpers/test/csv.spec.ts
@@ -1,0 +1,185 @@
+import { escapeCsvValue, generateCsv, downloadCsv } from '../src';
+
+describe('csv helpers', () => {
+  describe('escapeCsvValue', () => {
+    it('should return simple strings as-is', () => {
+      expect(escapeCsvValue('hello')).toBe('hello');
+    });
+
+    it('should wrap values with commas in quotes', () => {
+      expect(escapeCsvValue('hello, world')).toBe('"hello, world"');
+    });
+
+    it('should escape double quotes by doubling them', () => {
+      expect(escapeCsvValue('say "hi"')).toBe('"say ""hi"""');
+    });
+
+    it('should wrap values with newlines in quotes', () => {
+      expect(escapeCsvValue('line1\nline2')).toBe('"line1\nline2"');
+    });
+
+    it('should join arrays with semicolons', () => {
+      expect(escapeCsvValue(['id1', 'id2'])).toBe('id1; id2');
+    });
+
+    it('should handle null and undefined', () => {
+      expect(escapeCsvValue(null)).toBe('');
+      expect(escapeCsvValue(undefined)).toBe('');
+    });
+
+    it('should handle empty string', () => {
+      expect(escapeCsvValue('')).toBe('');
+    });
+
+    it('should handle numbers', () => {
+      expect(escapeCsvValue(42)).toBe('42');
+    });
+
+    it('should handle arrays with commas in values', () => {
+      expect(escapeCsvValue(['a, b', 'c'])).toBe('"a, b; c"');
+    });
+
+    describe('formula injection prevention', () => {
+      it('should prefix values starting with = to prevent formula injection', () => {
+        expect(escapeCsvValue('=1+1')).toBe("'=1+1");
+      });
+
+      it('should prefix and quote values starting with = that contain special chars', () => {
+        // quotes trigger CSV quoting on top of the sanitization prefix
+        expect(escapeCsvValue('=CMD("hack")')).toBe('"\'=CMD(""hack"")"');
+      });
+
+      it('should prefix values starting with +', () => {
+        expect(escapeCsvValue('+1234')).toBe("'+1234");
+      });
+
+      it('should prefix values starting with -', () => {
+        expect(escapeCsvValue('-1234')).toBe("'-1234");
+      });
+
+      it('should prefix values starting with @', () => {
+        expect(escapeCsvValue('@SUM(A1:A10)')).toBe("'@SUM(A1:A10)");
+      });
+
+      it('should prefix values starting with tab character', () => {
+        expect(escapeCsvValue('\t=evil')).toBe("'\t=evil");
+      });
+
+      it('should prefix values starting with carriage return', () => {
+        expect(escapeCsvValue('\r=evil')).toBe("'\r=evil");
+      });
+
+      it('should not prefix normal values', () => {
+        expect(escapeCsvValue('normal')).toBe('normal');
+        expect(escapeCsvValue('127.0.0.1')).toBe('127.0.0.1');
+        expect(escapeCsvValue('user@example.com')).toBe('user@example.com');
+      });
+
+      it('should handle formula injection in arrays', () => {
+        expect(escapeCsvValue(['=evil', 'normal'])).toBe("'=evil; normal");
+      });
+
+      it('should sanitize =HYPERLINK attack', () => {
+        const result = escapeCsvValue('=HYPERLINK("http://evil.com","click")');
+        // prefix is added, then CSV quoting wraps and doubles internal quotes
+        expect(result).toBe('"\'=HYPERLINK(""http://evil.com"",""click"")"');
+      });
+    });
+  });
+
+  describe('generateCsv', () => {
+    const columns = [
+      { header: 'Name', path: 'name' },
+      { header: 'Email', path: 'email' },
+      { header: 'Role', path: 'role' },
+    ];
+
+    it('should generate header row only for empty data', () => {
+      const csv = generateCsv([], columns);
+      expect(csv).toBe('Name,Email,Role');
+    });
+
+    it('should generate correct CSV rows', () => {
+      const records = [
+        { name: 'Alice', email: 'alice@example.com', role: 'Admin' },
+        { name: 'Bob', email: 'bob@example.com', role: 'User' },
+      ];
+      const csv = generateCsv(records, columns);
+      const lines = csv.split('\n');
+      expect(lines).toHaveLength(3);
+      expect(lines[0]).toBe('Name,Email,Role');
+      expect(lines[1]).toBe('Alice,alice@example.com,Admin');
+      expect(lines[2]).toBe('Bob,bob@example.com,User');
+    });
+
+    it('should handle missing fields as empty strings', () => {
+      const records = [{ name: 'Alice' }];
+      const csv = generateCsv(records, columns);
+      const lines = csv.split('\n');
+      expect(lines[1]).toBe('Alice,,');
+    });
+
+    it('should escape values with special characters', () => {
+      const records = [
+        { name: 'O"Brien', email: 'a, b', role: 'line1\nline2' },
+      ];
+      const csv = generateCsv(records, columns);
+      const lines = csv.split('\n');
+      expect(lines[1]).toContain('"O""Brien"');
+      expect(lines[1]).toContain('"a, b"');
+    });
+
+    it('should handle array values', () => {
+      const records = [
+        { name: 'Alice', email: 'a@b.com', role: ['Admin', 'User'] },
+      ];
+      const csv = generateCsv(records, columns);
+      const lines = csv.split('\n');
+      expect(lines[1]).toContain('Admin; User');
+    });
+  });
+
+  describe('downloadCsv', () => {
+    const originalCreateObjectURL = URL.createObjectURL;
+    const originalRevokeObjectURL = URL.revokeObjectURL;
+
+    beforeEach(() => {
+      URL.createObjectURL = jest.fn().mockReturnValue('blob:mock-url');
+      URL.revokeObjectURL = jest.fn();
+    });
+
+    afterEach(() => {
+      URL.createObjectURL = originalCreateObjectURL;
+      URL.revokeObjectURL = originalRevokeObjectURL;
+    });
+
+    it('should create a blob URL and trigger download', () => {
+      const clickSpy = jest.fn();
+      const setAttributeSpy = jest.fn();
+      jest.spyOn(document, 'createElement').mockReturnValue({
+        href: '',
+        setAttribute: setAttributeSpy,
+        click: clickSpy,
+      } as unknown as HTMLAnchorElement);
+      const appendChildSpy = jest
+        .spyOn(document.body, 'appendChild')
+        .mockImplementation((node) => node);
+      const removeChildSpy = jest
+        .spyOn(document.body, 'removeChild')
+        .mockImplementation((node) => node);
+
+      downloadCsv('header\nrow1', 'test.csv');
+
+      expect(URL.createObjectURL).toHaveBeenCalledWith(expect.any(Blob));
+      expect(setAttributeSpy).toHaveBeenCalledWith('download', 'test.csv');
+      expect(clickSpy).toHaveBeenCalled();
+      expect(appendChildSpy).toHaveBeenCalled();
+      expect(removeChildSpy).toHaveBeenCalled();
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+
+      appendChildSpy.mockRestore();
+      removeChildSpy.mockRestore();
+      (document.createElement as jest.Mock).mockRestore();
+    });
+  });
+});

--- a/packages/widgets/audit-management-widget/e2e/audit-management-widget.spec.ts
+++ b/packages/widgets/audit-management-widget/e2e/audit-management-widget.spec.ts
@@ -197,7 +197,9 @@ test.describe('widget', () => {
     ).toBeVisible({ timeout: 10000 });
 
     // verify export button is visible
-    const exportButton = page.getByTestId('export-button');
+    const exportButton = page.locator(
+      'descope-button[data-testid="export-button"]',
+    );
     await expect(exportButton).toBeVisible();
 
     // set up download listener and click

--- a/packages/widgets/audit-management-widget/e2e/audit-management-widget.spec.ts
+++ b/packages/widgets/audit-management-widget/e2e/audit-management-widget.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { readFileSync } from 'fs';
 import { componentsPort, widgetPort } from '../playwright.config';
 import mockTheme from '../test/mocks/mockTheme';
 import { apiPaths } from '../src/lib/widget/api/apiPaths';
@@ -187,5 +188,41 @@ test.describe('widget', () => {
     await expect(
       page.locator(`text=${mockAudit.audit[2]['actorId']}`).first(),
     ).toBeVisible();
+  });
+
+  test('export button downloads CSV', async ({ page }) => {
+    // wait for audit data to load
+    await expect(
+      page.locator(`text=${mockAudit.audit[0]['actorId']}`).first(),
+    ).toBeVisible({ timeout: 10000 });
+
+    // verify export button is visible
+    const exportButton = page.getByTestId('export-button');
+    await expect(exportButton).toBeVisible();
+
+    // set up download listener and click
+    const [download] = await Promise.all([
+      page.waitForEvent('download'),
+      exportButton.click(),
+    ]);
+
+    // verify the downloaded file
+    const filename = download.suggestedFilename();
+    expect(filename).toMatch(/^audit_logs_\d{4}-\d{2}-\d{2}\.csv$/);
+
+    const downloadPath = await download.path();
+    const csvContent = readFileSync(downloadPath, 'utf-8');
+    const lines = csvContent.split('\n');
+
+    // header + 3 audit rows
+    expect(lines.length).toBe(4);
+    expect(lines[0]).toContain('Occurred');
+    expect(lines[0]).toContain('User ID');
+    expect(lines[0]).toContain('Action');
+
+    // verify audit data is in the CSV
+    expect(csvContent).toContain(mockAudit.audit[0]['actorId']);
+    expect(csvContent).toContain(mockAudit.audit[1]['actorId']);
+    expect(csvContent).toContain(mockAudit.audit[2]['actorId']);
   });
 });

--- a/packages/widgets/audit-management-widget/src/lib/widget/helpers/csv.ts
+++ b/packages/widgets/audit-management-widget/src/lib/widget/helpers/csv.ts
@@ -1,0 +1,14 @@
+export { generateCsv, downloadCsv } from '@descope/sdk-helpers';
+
+export const AUDIT_CSV_COLUMNS = [
+  { header: 'Occurred', path: 'occurredFormatted' },
+  { header: 'User ID', path: 'userId' },
+  { header: 'Actor', path: 'actorId' },
+  { header: 'Login IDs', path: 'externalIds' },
+  { header: 'Remote Address', path: 'remoteAddress' },
+  { header: 'Type', path: 'type' },
+  { header: 'Action', path: 'action' },
+  { header: 'Device', path: 'device' },
+  { header: 'Method', path: 'method' },
+  { header: 'Geo', path: 'geo' },
+];

--- a/packages/widgets/audit-management-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initExportButtonMixin.ts
+++ b/packages/widgets/audit-management-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initExportButtonMixin.ts
@@ -1,0 +1,44 @@
+import { ButtonDriver } from '@descope/sdk-component-drivers';
+import { compose, createSingletonMixin } from '@descope/sdk-helpers';
+import { loggerMixin } from '@descope/sdk-mixins';
+import { getAuditList } from '../../../state/selectors';
+import {
+  AUDIT_CSV_COLUMNS,
+  downloadCsv,
+  generateCsv,
+} from '../../../helpers/csv';
+import { stateManagementMixin } from '../../stateManagementMixin';
+import { initWidgetRootMixin } from './initWidgetRootMixin';
+
+export const initExportButtonMixin = createSingletonMixin(
+  <T extends CustomElementConstructor>(superclass: T) =>
+    class InitExportButtonMixinClass extends compose(
+      loggerMixin,
+      initWidgetRootMixin,
+      stateManagementMixin,
+    )(superclass) {
+      exportButton: ButtonDriver;
+
+      #initExportButton() {
+        this.exportButton = new ButtonDriver(
+          this.shadowRoot?.querySelector('[data-id="export-button"]'),
+          { logger: this.logger },
+        );
+        this.exportButton.onClick(() => {
+          const auditList = getAuditList(this.state);
+          if (!auditList.length) {
+            this.logger.warn('No audit data to export');
+            return;
+          }
+          const csv = generateCsv(auditList, AUDIT_CSV_COLUMNS);
+          const timestamp = new Date().toISOString().slice(0, 10);
+          downloadCsv(csv, `audit_logs_${timestamp}.csv`);
+        });
+      }
+
+      async onWidgetRootReady() {
+        await super.onWidgetRootReady?.();
+        this.#initExportButton();
+      }
+    },
+);

--- a/packages/widgets/audit-management-widget/src/lib/widget/mixins/initMixin/initMixin.ts
+++ b/packages/widgets/audit-management-widget/src/lib/widget/mixins/initMixin/initMixin.ts
@@ -2,6 +2,7 @@ import { compose, createSingletonMixin } from '@descope/sdk-helpers';
 import { debuggerMixin, themeMixin } from '@descope/sdk-mixins';
 import { initFilterAuditInputMixin } from './initComponentsMixins/initFilterAuditInputMixin';
 import { initAuditTableMixin } from './initComponentsMixins/initAuditTableMixin';
+import { initExportButtonMixin } from './initComponentsMixins/initExportButtonMixin';
 
 export const initMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) =>
@@ -11,6 +12,7 @@ export const initMixin = createSingletonMixin(
       themeMixin,
       initAuditTableMixin,
       initFilterAuditInputMixin,
+      initExportButtonMixin,
     )(superclass) {
       async init() {
         await super.init?.();

--- a/packages/widgets/audit-management-widget/test/audit-management-widget.test.ts
+++ b/packages/widgets/audit-management-widget/test/audit-management-widget.test.ts
@@ -1,8 +1,10 @@
+import { generateCsv, downloadCsv } from '@descope/sdk-helpers';
 import { waitFor } from '@testing-library/dom';
 import '@testing-library/jest-dom';
 import '../src/lib/index';
 import { apiPaths } from '../src/lib/widget/api/apiPaths';
 import { createSdk } from '../src/lib/widget/api/sdk';
+import { AUDIT_CSV_COLUMNS } from '../src/lib/widget/helpers/csv';
 import { mockAudit } from './mocks/mockAudit';
 import rootMock from './mocks/rootMock';
 
@@ -88,6 +90,79 @@ describe('audit-management-widget', () => {
     document.getElementsByTagName('body')[0].innerHTML = '';
     document.body.append = origAppend;
     mockHttpClient.reset();
+  });
+
+  describe('export', () => {
+    it('should generate CSV from audit data using AUDIT_CSV_COLUMNS', () => {
+      const audits = mockAudit.audit.map((a) => ({
+        ...a,
+        occurredFormatted: new Date(a.occurred).toLocaleString(),
+      }));
+      const csv = generateCsv(audits, AUDIT_CSV_COLUMNS);
+      const lines = csv.split('\n');
+
+      // header + 3 audit rows
+      expect(lines).toHaveLength(4);
+      expect(lines[0]).toBe(
+        'Occurred,User ID,Actor,Login IDs,Remote Address,Type,Action,Device,Method,Geo',
+      );
+      // verify each row contains the expected audit data
+      expect(lines[1]).toContain('User 1');
+      expect(lines[1]).toContain('Actor 1');
+      expect(lines[1]).toContain('Action 1');
+      expect(lines[2]).toContain('User 2');
+      expect(lines[3]).toContain('User 3');
+    });
+
+    it('should trigger a CSV file download', () => {
+      const originalCreateObjectURL = URL.createObjectURL;
+      const originalRevokeObjectURL = URL.revokeObjectURL;
+      URL.createObjectURL = jest.fn().mockReturnValue('blob:mock-url');
+      URL.revokeObjectURL = jest.fn();
+
+      const clickSpy = jest.fn();
+      const setAttributeSpy = jest.fn();
+      jest.spyOn(document, 'createElement').mockReturnValue({
+        href: '',
+        setAttribute: setAttributeSpy,
+        click: clickSpy,
+      } as unknown as HTMLAnchorElement);
+      jest
+        .spyOn(document.body, 'appendChild')
+        .mockImplementation((node) => node);
+      jest
+        .spyOn(document.body, 'removeChild')
+        .mockImplementation((node) => node);
+
+      const csv = generateCsv(
+        [{ occurredFormatted: 'time', userId: 'u1' }],
+        AUDIT_CSV_COLUMNS,
+      );
+      downloadCsv(csv, 'audit_logs_2026-04-11.csv');
+
+      expect(URL.createObjectURL).toHaveBeenCalledWith(expect.any(Blob));
+      expect(setAttributeSpy).toHaveBeenCalledWith(
+        'download',
+        'audit_logs_2026-04-11.csv',
+      );
+      expect(clickSpy).toHaveBeenCalled();
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+
+      (document.createElement as jest.Mock).mockRestore();
+      (document.body.appendChild as jest.Mock).mockRestore();
+      (document.body.removeChild as jest.Mock).mockRestore();
+      URL.createObjectURL = originalCreateObjectURL;
+      URL.revokeObjectURL = originalRevokeObjectURL;
+    });
+
+    it('should generate empty CSV when no audit data', () => {
+      const csv = generateCsv([], AUDIT_CSV_COLUMNS);
+      const lines = csv.split('\n');
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toBe(
+        'Occurred,User ID,Actor,Login IDs,Remote Address,Type,Action,Device,Method,Geo',
+      );
+    });
   });
 
   describe('sdk', () => {

--- a/packages/widgets/audit-management-widget/test/csv.test.ts
+++ b/packages/widgets/audit-management-widget/test/csv.test.ts
@@ -1,0 +1,55 @@
+import { generateCsv } from '@descope/sdk-helpers';
+import { AUDIT_CSV_COLUMNS } from '../src/lib/widget/helpers/csv';
+
+describe('audit csv', () => {
+  it('should have the expected audit columns', () => {
+    expect(AUDIT_CSV_COLUMNS).toEqual([
+      { header: 'Occurred', path: 'occurredFormatted' },
+      { header: 'User ID', path: 'userId' },
+      { header: 'Actor', path: 'actorId' },
+      { header: 'Login IDs', path: 'externalIds' },
+      { header: 'Remote Address', path: 'remoteAddress' },
+      { header: 'Type', path: 'type' },
+      { header: 'Action', path: 'action' },
+      { header: 'Device', path: 'device' },
+      { header: 'Method', path: 'method' },
+      { header: 'Geo', path: 'geo' },
+    ]);
+  });
+
+  it('should generate correct CSV for audit data with AUDIT_CSV_COLUMNS', () => {
+    const audits = [
+      {
+        occurredFormatted: '2026-01-01 00:00:00',
+        userId: 'user1',
+        actorId: 'actor1',
+        externalIds: ['login1'],
+        remoteAddress: '127.0.0.1',
+        type: 'Info',
+        action: 'LoginSucceed',
+        device: 'Chrome',
+        method: 'otp',
+        geo: 'US',
+      },
+    ];
+    const csv = generateCsv(audits, AUDIT_CSV_COLUMNS);
+    const lines = csv.split('\n');
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toBe(
+      'Occurred,User ID,Actor,Login IDs,Remote Address,Type,Action,Device,Method,Geo',
+    );
+    expect(lines[1]).toBe(
+      '2026-01-01 00:00:00,user1,actor1,login1,127.0.0.1,Info,LoginSucceed,Chrome,otp,US',
+    );
+  });
+
+  it('should handle missing audit fields gracefully', () => {
+    const audits = [{ occurredFormatted: 'time1', action: 'Login' }];
+    const csv = generateCsv(audits, AUDIT_CSV_COLUMNS);
+    const lines = csv.split('\n');
+    expect(lines).toHaveLength(2);
+    expect(lines[1]).toContain('time1');
+    expect(lines[1]).toContain('Login');
+    expect(lines[1].split(',').length).toBe(AUDIT_CSV_COLUMNS.length);
+  });
+});

--- a/packages/widgets/audit-management-widget/test/mocks/rootMock.ts
+++ b/packages/widgets/audit-management-widget/test/mocks/rootMock.ts
@@ -1,17 +1,20 @@
 export default `
 <descope-container data-editor-type="container" direction="column" id="ROOT" space-between="md" st-horizontal-padding="1rem" st-vertical-padding="1rem" st-align-items="safe center" st-justify-content="safe center" st-host-width="100%" st-gap="1rem">
-  <descope-container data-editor-type="container" direction="row" id="headerContainer" st-horizontal-padding="0rem" st-vertical-padding="0rem" st-align-items="start" st-justify-content="space-between" st-background-color="#ffffff00" st-host-width="100%" st-gap="0rem">
+  <descope-container data-editor-type="container" direction="row" id="headerContainer" st-horizontal-padding="0rem" st-vertical-padding="0rem" st-align-items="center" st-justify-content="space-between" st-background-color="#ffffff00" st-host-width="100%" st-gap="0.5rem">
     <descope-text-field bordered="true" data-id="search-input" data-testid="search-input" full-width="false" id="search" label="" max="100" name="" placeholder="Search" required="false" size="sm"></descope-text-field>
-    <descope-combo-box bordered="true" data-id="range-input" data-testid="range-input" full-width="false" id="range" item-label-path="data-name" item-value-path="data-id" name="" size="sm" allow-custom-value="false" default-value="day" max="100">
-      <span data-name="Last 15 Minutes" data-id="minuets15">Last 15 Minutes</span>
-      <span data-name="Last Hour" data-id="hour">Last Hour</span>
-      <span data-name="Last 6 Hours" data-id="hour6">Last 6 Hours</span>
-      <span data-name="Last 24 Hours" data-id="day">Last 24 Hours</span>
-      <span data-name="Last 3 Days" data-id="day3">Last 3 Days</span>
-      <span data-name="Last Week" data-id="week">Last Week</span>
-      <span data-name="Last 2 Weeks" data-id="week2">Last 2 Weeks</span>
-      <span data-name="Last Month" data-id="month">Last Month</span>
-    </descope-combo-box>
+    <descope-container data-editor-type="container" direction="row" id="headerRightContainer" st-horizontal-padding="0rem" st-vertical-padding="0rem" st-align-items="center" st-justify-content="flex-end" st-host-width="auto" st-gap="0.5rem">
+      <descope-combo-box bordered="true" data-id="range-input" data-testid="range-input" full-width="false" id="range" item-label-path="data-name" item-value-path="data-id" name="" size="sm" allow-custom-value="false" default-value="day" max="100">
+        <span data-name="Last 15 Minutes" data-id="minuets15">Last 15 Minutes</span>
+        <span data-name="Last Hour" data-id="hour">Last Hour</span>
+        <span data-name="Last 6 Hours" data-id="hour6">Last 6 Hours</span>
+        <span data-name="Last 24 Hours" data-id="day">Last 24 Hours</span>
+        <span data-name="Last 3 Days" data-id="day3">Last 3 Days</span>
+        <span data-name="Last Week" data-id="week">Last Week</span>
+        <span data-name="Last 2 Weeks" data-id="week2">Last 2 Weeks</span>
+        <span data-name="Last Month" data-id="month">Last Month</span>
+      </descope-combo-box>
+      <descope-button data-id="export-button" data-testid="export-button" size="sm" variant="outline">Export</descope-button>
+    </descope-container>
   </descope-container>
   <descope-grid bordered="true" column-reordering-allowed="true" data-id="audit-table" size="sm" st-host-height="300px" style="width:100%">
     <descope-grid-text-column header="Occurred" path="occurredFormatted" resizable="true" sortable="false"></descope-grid-text-column>


### PR DESCRIPTION
## Summary
- Add a CSV export/download button to the audit management widget
- Generic CSV helpers (`generateCsv`, `downloadCsv`) added to `@descope/sdk-helpers` with formula injection protection (sanitizes `=`, `+`, `-`, `@`, `\t`, `\r` prefixes)
- Header layout updated: search left, time range dropdown + export button grouped right, all vertically centered

## Test plan
- [x] Unit tests for CSV generation and sanitization in `sdk-helpers` (25 tests)
- [x] Unit tests for export functionality in `audit-management-widget.test.ts`
- [x] E2e test for download flow in `audit-management-widget.spec.ts`
- [x] Manual verification of layout alignment in widget

<img width="3072" height="1790" alt="image" src="https://github.com/user-attachments/assets/273ffcae-8fe1-4498-9c0c-fc53127c7115" />


Closes https://github.com/descope/etc/issues/14172

🤖 Generated with [Claude Code](https://claude.com/claude-code)