### PR TITLE
feat: add WS-Fed apps to applications portal widget

### DIFF
--- a/packages/widgets/applications-portal-widget/e2e/applications-portal-widget.spec.ts
+++ b/packages/widgets/applications-portal-widget/e2e/applications-portal-widget.spec.ts
@@ -24,8 +24,7 @@ const oidcWithUrlApps = mockSsoApps.filter(
 );
 const wsFedApps = mockSsoApps.filter(
   (app) =>
-    app.appType === SSOAppType.wsfed &&
-    app.wsfedSettings?.idpInitiatedURL,
+    app.appType === SSOAppType.wsfed && app.wsfedSettings?.idpInitiatedUrl,
 );
 
 test.describe('widget', () => {
@@ -97,7 +96,7 @@ test.describe('widget', () => {
     const newTab = await newTabPromise;
     await newTab.waitForLoadState();
 
-    await expect(newTab).toHaveURL(wsFedApps[0].wsfedSettings.idpInitiatedURL);
+    await expect(newTab).toHaveURL(wsFedApps[0].wsfedSettings.idpInitiatedUrl);
   });
   test('click app opens a new tab', async ({ page }) => {
     const newTabPromise = page.waitForEvent('popup');

--- a/packages/widgets/applications-portal-widget/e2e/applications-portal-widget.spec.ts
+++ b/packages/widgets/applications-portal-widget/e2e/applications-portal-widget.spec.ts
@@ -88,15 +88,17 @@ test.describe('widget', () => {
     }
   });
   test('click wsfed app opens a new tab', async ({ page }) => {
+    expect(wsFedApps.length).toBeGreaterThan(0);
+    const wsFedApp = wsFedApps[0];
     const newTabPromise = page.waitForEvent('popup');
 
-    const app = page.locator(`text=${wsFedApps[0].name}`).first();
+    const app = page.locator(`text=${wsFedApp.name}`).first();
     await app.click();
 
     const newTab = await newTabPromise;
     await newTab.waitForLoadState();
 
-    await expect(newTab).toHaveURL(wsFedApps[0].wsfedSettings.idpInitiatedUrl);
+    await expect(newTab).toHaveURL(wsFedApp.wsfedSettings.idpInitiatedUrl);
   });
   test('click app opens a new tab', async ({ page }) => {
     const newTabPromise = page.waitForEvent('popup');

--- a/packages/widgets/applications-portal-widget/e2e/applications-portal-widget.spec.ts
+++ b/packages/widgets/applications-portal-widget/e2e/applications-portal-widget.spec.ts
@@ -22,6 +22,11 @@ const oidcWithUrlApps = mockSsoApps.filter(
     app.appType === SSOAppType.oidc &&
     app.oidcSettings?.customIdpInitiatedLoginPageUrl,
 );
+const wsFedApps = mockSsoApps.filter(
+  (app) =>
+    app.appType === SSOAppType.wsfed &&
+    app.wsfedSettings?.idpInitiatedURL,
+);
 
 test.describe('widget', () => {
   test.beforeEach(async ({ page }) => {
@@ -77,6 +82,22 @@ test.describe('widget', () => {
     for (const app of oidcWithUrlApps) {
       await expect(page.locator(`text=${app.name}`).first()).toBeVisible();
     }
+  });
+  test('wsfed apps are in the list', async ({ page }) => {
+    for (const app of wsFedApps) {
+      await expect(page.locator(`text=${app.name}`).first()).toBeVisible();
+    }
+  });
+  test('click wsfed app opens a new tab', async ({ page }) => {
+    const newTabPromise = page.waitForEvent('popup');
+
+    const app = page.locator(`text=${wsFedApps[0].name}`).first();
+    await app.click();
+
+    const newTab = await newTabPromise;
+    await newTab.waitForLoadState();
+
+    await expect(newTab).toHaveURL(wsFedApps[0].wsfedSettings.idpInitiatedURL);
   });
   test('click app opens a new tab', async ({ page }) => {
     const newTabPromise = page.waitForEvent('popup');

--- a/packages/widgets/applications-portal-widget/src/lib/widget/api/sdk/mocks.ts
+++ b/packages/widgets/applications-portal-widget/src/lib/widget/api/sdk/mocks.ts
@@ -42,7 +42,7 @@ const load: () => Promise<{ apps: SSOApplication[] }> = async () =>
           appType: SSOAppType.wsfed,
           logo: 'logo4',
           wsfedSettings: {
-            idpInitiatedUrl: '',
+            idpInitiatedUrl: 'http://localhost/wsfed/idp-initiated',
             realm: 'urn:mock:realm',
             replyUrl: 'http://localhost/reply',
             loginPageUrl: 'http://localhost/login',

--- a/packages/widgets/applications-portal-widget/src/lib/widget/api/sdk/mocks.ts
+++ b/packages/widgets/applications-portal-widget/src/lib/widget/api/sdk/mocks.ts
@@ -34,6 +34,20 @@ const load: () => Promise<{ apps: SSOApplication[] }> = async () =>
             idpInitiatedUrl: '',
           },
         },
+        {
+          id: 'ssoapp4',
+          name: 'App 4',
+          description: 'This is a WS-Fed app',
+          enabled: true,
+          appType: SSOAppType.wsfed,
+          logo: 'logo4',
+          wsfedSettings: {
+            idpInitiatedUrl: '',
+            realm: 'urn:mock:realm',
+            replyUrl: 'http://localhost/reply',
+            loginPageUrl: 'http://localhost/login',
+          },
+        },
       ],
     });
   });

--- a/packages/widgets/applications-portal-widget/src/lib/widget/api/types.ts
+++ b/packages/widgets/applications-portal-widget/src/lib/widget/api/types.ts
@@ -36,10 +36,10 @@ export interface OidcApplication extends App {
 export interface WsFedApplication extends App {
   appType: SSOAppType.wsfed;
   wsfedSettings?: {
-    idpInitiatedURL: string;
-    realm: string;
-    replyURL: string;
-    loginPageURL: string;
+    idpInitiatedUrl?: string;
+    realm?: string;
+    replyUrl?: string;
+    loginPageUrl?: string;
   };
 }
 

--- a/packages/widgets/applications-portal-widget/src/lib/widget/api/types.ts
+++ b/packages/widgets/applications-portal-widget/src/lib/widget/api/types.ts
@@ -7,6 +7,7 @@ export type HttpClient = Sdk['httpClient'];
 export enum SSOAppType {
   oidc = 'oidc',
   saml = 'saml',
+  wsfed = 'wsfed',
   custom = 'custom',
 }
 
@@ -32,6 +33,16 @@ export interface OidcApplication extends App {
   };
 }
 
+export interface WsFedApplication extends App {
+  appType: SSOAppType.wsfed;
+  wsfedSettings?: {
+    idpInitiatedURL: string;
+    realm: string;
+    replyURL: string;
+    loginPageURL: string;
+  };
+}
+
 export interface CustomApplication extends App {
   appType: SSOAppType.custom;
   customSettings?: {
@@ -42,4 +53,5 @@ export interface CustomApplication extends App {
 export type SSOApplication =
   | SamlApplication
   | OidcApplication
+  | WsFedApplication
   | CustomApplication;

--- a/packages/widgets/applications-portal-widget/src/lib/widget/state/selectors.ts
+++ b/packages/widgets/applications-portal-widget/src/lib/widget/state/selectors.ts
@@ -24,8 +24,7 @@ export const getWsFedApps = createSelector(
   (ssoAppsList) =>
     ssoAppsList?.filter?.(
       (app) =>
-        app.appType === SSOAppType.wsfed &&
-        app.wsfedSettings?.idpInitiatedURL,
+        app.appType === SSOAppType.wsfed && app.wsfedSettings?.idpInitiatedUrl,
     ),
 );
 

--- a/packages/widgets/applications-portal-widget/src/lib/widget/state/selectors.ts
+++ b/packages/widgets/applications-portal-widget/src/lib/widget/state/selectors.ts
@@ -19,6 +19,16 @@ export const getOidcWithCustomIdpInitiatedLoginPageUrlApps = createSelector(
     ),
 );
 
+export const getWsFedApps = createSelector(
+  getSSOAppsList,
+  (ssoAppsList) =>
+    ssoAppsList?.filter?.(
+      (app) =>
+        app.appType === SSOAppType.wsfed &&
+        app.wsfedSettings?.idpInitiatedURL,
+    ),
+);
+
 export const getCustomApps = createSelector(
   getSSOAppsList,
   (ssoAppsList) =>
@@ -31,6 +41,8 @@ const getAppUrl = (app: SSOApplication) => {
       return app.samlSettings?.idpInitiatedUrl;
     case SSOAppType.oidc:
       return app.oidcSettings?.customIdpInitiatedLoginPageUrl;
+    case SSOAppType.wsfed:
+      return app.wsfedSettings?.idpInitiatedURL;
     case SSOAppType.custom:
       return app.customSettings?.loginPageUrl;
     default:
@@ -41,9 +53,10 @@ const getAppUrl = (app: SSOApplication) => {
 export const getAppsList = createSelector(
   getSamlApps,
   getOidcWithCustomIdpInitiatedLoginPageUrlApps,
+  getWsFedApps,
   getCustomApps,
-  (samlApps, oidcApps, customApps) =>
-    [...samlApps, ...oidcApps, ...customApps].map((app) => ({
+  (samlApps, oidcApps, wsFedApps, customApps) =>
+    [...samlApps, ...oidcApps, ...wsFedApps, ...customApps].map((app) => ({
       name: app.name,
       icon: app.logo,
       url: getAppUrl(app),

--- a/packages/widgets/applications-portal-widget/src/lib/widget/state/selectors.ts
+++ b/packages/widgets/applications-portal-widget/src/lib/widget/state/selectors.ts
@@ -41,7 +41,7 @@ const getAppUrl = (app: SSOApplication) => {
     case SSOAppType.oidc:
       return app.oidcSettings?.customIdpInitiatedLoginPageUrl;
     case SSOAppType.wsfed:
-      return app.wsfedSettings?.idpInitiatedURL;
+      return app.wsfedSettings?.idpInitiatedUrl;
     case SSOAppType.custom:
       return app.customSettings?.loginPageUrl;
     default:

--- a/packages/widgets/applications-portal-widget/test/mocks/mockSsoApps.ts
+++ b/packages/widgets/applications-portal-widget/test/mocks/mockSsoApps.ts
@@ -54,4 +54,15 @@ export const mockSsoApps = [
       loginPageUrl: 'http://www.testingmcafeesites.com/testcat_ac.html',
     },
   },
+  {
+    id: 'ssoapp6',
+    name: 'WsFed App 1',
+    description: 'This is the first WS-Fed app',
+    enabled: true,
+    appType: SSOAppType.wsfed,
+    logo: 'logo4',
+    wsfedSettings: {
+      idpInitiatedURL: 'http://www.testingmcafeesites.com/testcat_ac.html',
+    },
+  },
 ];

--- a/packages/widgets/applications-portal-widget/test/mocks/mockSsoApps.ts
+++ b/packages/widgets/applications-portal-widget/test/mocks/mockSsoApps.ts
@@ -62,7 +62,10 @@ export const mockSsoApps = [
     appType: SSOAppType.wsfed,
     logo: 'logo4',
     wsfedSettings: {
-      idpInitiatedURL: 'http://www.testingmcafeesites.com/testcat_ac.html',
+      idpInitiatedUrl: 'http://www.testingmcafeesites.com/testcat_ac.html',
+      realm: 'urn:wsfed:testing:app1',
+      replyUrl: 'http://www.testingmcafeesites.com/reply',
+      loginPageUrl: 'http://www.testingmcafeesites.com/login',
     },
   },
 ];


### PR DESCRIPTION
## Related Issues
Required for:
https://github.com/descope/etc/issues/15054

## Description
Add WS-Federation app type support to the applications portal widget including type definitions, selectors, mock data, and e2e tests.

## Must
- [ ] Tests