### PR TITLE
fix(wc): add wsfedIdpStateId URL param support for WS-Fed IDP flow RELEASE

### DIFF
--- a/packages/sdks/core-js-sdk/src/sdk/types.ts
+++ b/packages/sdks/core-js-sdk/src/sdk/types.ts
@@ -348,6 +348,7 @@ export type Options = {
   oidcIdpStateId?: string;
   preview?: boolean;
   samlIdpStateId?: string;
+  wsfedIdpStateId?: string;
   samlIdpUsername?: string;
   ssoAppId?: string;
   thirdPartyAppId?: string;

--- a/packages/sdks/web-component/src/lib/constants/index.ts
+++ b/packages/sdks/web-component/src/lib/constants/index.ts
@@ -20,6 +20,7 @@ export const DESCOPE_LAST_AUTH_LOCAL_STORAGE_KEY = 'dls_last_auth';
 // SSO query params
 export const OIDC_IDP_STATE_ID_PARAM_NAME = 'state_id';
 export const SAML_IDP_STATE_ID_PARAM_NAME = 'saml_idp_state_id';
+export const WSFED_IDP_STATE_ID_PARAM_NAME = 'wsfed_idp_state_id';
 export const SAML_IDP_USERNAME_PARAM_NAME = 'saml_idp_username';
 export const DESCOPE_IDP_INITIATED_PARAM_NAME = 'descope_idp_initiated';
 export const SSO_APP_ID_PARAM_NAME = 'sso_app_id';

--- a/packages/sdks/web-component/src/lib/helpers/helpers.ts
+++ b/packages/sdks/web-component/src/lib/helpers/helpers.ts
@@ -12,6 +12,7 @@ import {
   URL_REDIRECT_AUTH_INITIATOR_PARAM_NAME,
   OIDC_IDP_STATE_ID_PARAM_NAME,
   SAML_IDP_STATE_ID_PARAM_NAME,
+  WSFED_IDP_STATE_ID_PARAM_NAME,
   SAML_IDP_USERNAME_PARAM_NAME,
   SSO_APP_ID_PARAM_NAME,
   OIDC_LOGIN_HINT_PARAM_NAME,
@@ -271,6 +272,14 @@ export function clearSAMLIDPParamFromUrl() {
   resetUrlParam(SAML_IDP_STATE_ID_PARAM_NAME);
 }
 
+export function getWSFedIDPParamFromUrl() {
+  return getUrlParam(WSFED_IDP_STATE_ID_PARAM_NAME);
+}
+
+export function clearWSFedIDPParamFromUrl() {
+  resetUrlParam(WSFED_IDP_STATE_ID_PARAM_NAME);
+}
+
 export function getSAMLIDPUsernameParamFromUrl() {
   return getUrlParam(SAML_IDP_USERNAME_PARAM_NAME);
 }
@@ -432,6 +441,11 @@ export const handleUrlParams = (
     clearSAMLIDPParamFromUrl();
   }
 
+  const wsfedIdpStateId = getWSFedIDPParamFromUrl();
+  if (wsfedIdpStateId) {
+    clearWSFedIDPParamFromUrl();
+  }
+
   const samlIdpUsername = getSAMLIDPUsernameParamFromUrl();
   if (samlIdpStateId) {
     clearSAMLIDPUsernameParamFromUrl();
@@ -498,6 +512,7 @@ export const handleUrlParams = (
     ssoQueryParams: {
       oidcIdpStateId,
       samlIdpStateId,
+      wsfedIdpStateId,
       samlIdpUsername,
       descopeIdpInitiated: idpInitiatedVal,
       ssoAppId,

--- a/packages/sdks/web-component/src/lib/helpers/helpers.ts
+++ b/packages/sdks/web-component/src/lib/helpers/helpers.ts
@@ -696,6 +696,7 @@ export const showFirstScreenOnExecutionInit = (
   {
     oidcIdpStateId,
     samlIdpStateId,
+    wsfedIdpStateId,
     samlIdpUsername,
     ssoAppId,
     oidcLoginHint,
@@ -710,6 +711,7 @@ export const showFirstScreenOnExecutionInit = (
   !!startScreenId &&
   !oidcIdpStateId &&
   !samlIdpStateId &&
+  !wsfedIdpStateId &&
   !samlIdpUsername &&
   !ssoAppId &&
   !oidcLoginHint &&

--- a/packages/sdks/web-component/src/lib/types.ts
+++ b/packages/sdks/web-component/src/lib/types.ts
@@ -71,6 +71,7 @@ export interface ScreenState {
 export type SSOQueryParams = {
   oidcIdpStateId?: string;
   samlIdpStateId?: string;
+  wsfedIdpStateId?: string;
   samlIdpUsername?: string;
   descopeIdpInitiated?: boolean;
   ssoAppId?: string;

--- a/packages/sdks/web-component/test/descope-wc.condition.test.ts
+++ b/packages/sdks/web-component/test/descope-wc.condition.test.ts
@@ -31,6 +31,7 @@ import {
   URL_REDIRECT_AUTH_INITIATOR_PARAM_NAME,
   OIDC_IDP_STATE_ID_PARAM_NAME,
   SAML_IDP_STATE_ID_PARAM_NAME,
+  WSFED_IDP_STATE_ID_PARAM_NAME,
   SAML_IDP_USERNAME_PARAM_NAME,
   DESCOPE_IDP_INITIATED_PARAM_NAME,
   SSO_APP_ID_PARAM_NAME,
@@ -676,6 +677,45 @@ describe('web-component', () => {
               ...defaultOptionsValues,
               samlIdpStateId: 'abcdefgh',
               samlIdpUsername: 'dummyUser',
+            },
+            undefined,
+            '',
+            '1.2.3',
+            {
+              'sign-in': 0,
+            },
+            {},
+          ),
+        { timeout: WAIT_TIMEOUT },
+      );
+      await waitFor(() => screen.getByShadowText('It works!'), {
+        timeout: WAIT_TIMEOUT,
+      });
+      await waitFor(() => expect(window.location.search).toBe(''));
+    });
+
+    it('should call start with wsfed idp flag and clear it from url', async () => {
+      startMock.mockReturnValueOnce(generateSdkResponse());
+
+      fixtures.pageContent = '<span>It works!</span>';
+      fixtures.configContent = {
+        ...fixtures.configContent,
+        flows: {
+          'sign-in': { version: 0 },
+        },
+      };
+      const wsfedIdpStateId = 'abcdefgh';
+      const encodedWsfedIdpStateId = encodeURIComponent(wsfedIdpStateId);
+      window.location.search = `?${WSFED_IDP_STATE_ID_PARAM_NAME}=${encodedWsfedIdpStateId}`;
+      document.body.innerHTML = `<h1>Custom element test</h1> <descope-wc flow-id="sign-in" project-id="1"></descope-wc>`;
+
+      await waitFor(
+        () =>
+          expect(startMock).toHaveBeenCalledWith(
+            'sign-in',
+            {
+              ...defaultOptionsValues,
+              wsfedIdpStateId: 'abcdefgh',
             },
             undefined,
             '',

--- a/packages/sdks/web-component/test/descope-wc.test-harness.ts
+++ b/packages/sdks/web-component/test/descope-wc.test-harness.ts
@@ -31,6 +31,7 @@ export const defaultOptionsValues = {
   oidcLoginHint: null,
   oidcPrompt: null,
   samlIdpStateId: null,
+  wsfedIdpStateId: null,
   samlIdpUsername: null,
   oidcErrorRedirectUri: null,
   oidcResource: null,

--- a/packages/sdks/web-component/test/descope-wc.test.ts
+++ b/packages/sdks/web-component/test/descope-wc.test.ts
@@ -35,6 +35,7 @@ const defaultOptionsValues = {
   oidcLoginHint: null,
   oidcPrompt: null,
   samlIdpStateId: null,
+  wsfedIdpStateId: null,
   samlIdpUsername: null,
   oidcErrorRedirectUri: null,
   oidcResource: null,

--- a/packages/sdks/web-js-sdk/src/sdk/flow.ts
+++ b/packages/sdks/web-js-sdk/src/sdk/flow.ts
@@ -9,6 +9,7 @@ type Options = Pick<
   | 'redirectAuth'
   | 'oidcIdpStateId'
   | 'samlIdpStateId'
+  | 'wsfedIdpStateId'
   | 'samlIdpUsername'
   | 'ssoAppId'
   | 'thirdPartyAppId'


### PR DESCRIPTION
## Related Issues
descope/etc#15054

## Description
Add `wsfed_idp_state_id` URL parameter handling so the flow SDK correctly routes WS-Fed IDP flows through a dedicated handler instead of the OIDC handler (which previously caused a panic).

- Add `WSFED_IDP_STATE_ID_PARAM_NAME` constant
- Add getter/clearer functions in helpers
- Add `wsfedIdpStateId` to Options type
- Add test in descope-wc.condition.test.ts

## Related PRs
- descope/descope#532 (backend fixes)

## Test Plan
- [x] Unit test: should call start with wsfed idp flag and clear it from url

🤖 Generated with [Claude Code](https://claude.com/claude-code)