### PR TITLE
fix(wc): guard SAML/WS-Fed loadForm blocks with URL check RELEASE

### DIFF
--- a/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
+++ b/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
@@ -827,9 +827,10 @@ class DescopeWc extends BaseDescopeWc {
     ];
     if (
       action === RESPONSE_ACTIONS.loadForm &&
+      samlIdpResponseUrl &&
       samlProps.some((samlProp) => isChanged(samlProp))
     ) {
-      if (!samlIdpResponseUrl || !samlIdpResponseSamlResponse) {
+      if (!samlIdpResponseSamlResponse) {
         this.loggerWrapper.error('Did not get saml idp params data to load');
         return;
       }
@@ -850,9 +851,10 @@ class DescopeWc extends BaseDescopeWc {
     ];
     if (
       action === RESPONSE_ACTIONS.loadForm &&
+      wsFedIdpResponseUrl &&
       wsFedProps.some((wsFedProp) => isChanged(wsFedProp))
     ) {
-      if (!wsFedIdpResponseUrl || !wsFedIdpResponseWresult) {
+      if (!wsFedIdpResponseWresult) {
         this.loggerWrapper.error('Did not get wsfed idp params data to load');
         return;
       }


### PR DESCRIPTION
## Description
Guard SAML and WS-Fed `loadForm` blocks with a truthiness check on the response URL. Prevents the SAML block from triggering on empty response objects and returning early with "Did not get saml idp params data to load" before the WS-Fed block can execute.

Also conditionally include `samlIdpResponse`/`wsFedIdpResponse` in test utility only when URL is set.

Related: descope/etc#15054, descope/descope#543

🤖 Generated with [Claude Code](https://claude.com/claude-code)