### PR TITLE
feat(web-js-sdk): skip redundant initial refresh when no session exists

### DIFF
--- a/packages/libs/sdk-helpers/src/index.ts
+++ b/packages/libs/sdk-helpers/src/index.ts
@@ -5,3 +5,4 @@ export * from './mixins';
 export * from './state';
 export * from './jwt';
 export * from './csv';
+export * from './ksuid';

--- a/packages/libs/sdk-helpers/src/ksuid.ts
+++ b/packages/libs/sdk-helpers/src/ksuid.ts
@@ -1,0 +1,32 @@
+const KSUID_EPOCH = 1_400_000_000;
+const BASE62 = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+
+/**
+ * Decodes the creation timestamp (Unix seconds) from a Descope project ID.
+ * Project IDs use KSUID format: the last 27 base62 characters encode 20 bytes,
+ * where the first 4 bytes are seconds since the KSUID epoch (2014-05-13).
+ * Returns null for any malformed input.
+ */
+export function decodeProjectCreatedAt(projectId: string): number | null {
+  if (!projectId || projectId.length < 27) return null;
+
+  const body = projectId.slice(-27);
+  const bytes = new Uint8Array(20);
+
+  for (let ci = 0; ci < body.length; ci++) {
+    const idx = BASE62.indexOf(body[ci]);
+    if (idx < 0) return null;
+    // Multiply the running value by 62 and add the new digit (LSB → MSB carry)
+    let carry = idx;
+    for (let i = 19; i >= 0; i--) {
+      const val = bytes[i] * 62 + carry;
+      bytes[i] = val & 0xff;
+      carry = val >> 8;
+    }
+  }
+
+  // First 4 bytes are the timestamp as a big-endian uint32
+  const ts =
+    ((bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3]) >>> 0;
+  return ts + KSUID_EPOCH;
+}

--- a/packages/libs/sdk-helpers/test/dom.spec.ts
+++ b/packages/libs/sdk-helpers/test/dom.spec.ts
@@ -14,7 +14,7 @@ describe('dom helpers', () => {
       const template = createTemplate('');
 
       expect(template).toBeInstanceOf(HTMLTemplateElement);
-      expect(template).toBeEmptyDOMElement();
+      expect(template.innerHTML).toBe('');
     });
   });
 });

--- a/packages/libs/sdk-helpers/test/dom.spec.ts
+++ b/packages/libs/sdk-helpers/test/dom.spec.ts
@@ -14,7 +14,7 @@ describe('dom helpers', () => {
       const template = createTemplate('');
 
       expect(template).toBeInstanceOf(HTMLTemplateElement);
-      expect(template.innerHTML).toBe('');
+      expect(template).toBeEmptyDOMElement();
     });
   });
 });

--- a/packages/libs/sdk-helpers/test/ksuid.spec.ts
+++ b/packages/libs/sdk-helpers/test/ksuid.spec.ts
@@ -1,0 +1,49 @@
+import { decodeProjectCreatedAt } from '../src';
+
+describe('decodeProjectCreatedAt', () => {
+  it('returns null for empty string', () => {
+    expect(decodeProjectCreatedAt('')).toBeNull();
+  });
+
+  it('returns null when string is shorter than 27 chars', () => {
+    expect(decodeProjectCreatedAt('short')).toBeNull();
+    expect(decodeProjectCreatedAt('pid')).toBeNull();
+    expect(decodeProjectCreatedAt('P' + '0'.repeat(25))).toBeNull();
+  });
+
+  it('returns null when last 27 chars contain a non-base62 character', () => {
+    // '_' and '!' are not in the base62 alphabet
+    expect(decodeProjectCreatedAt('P_00000000000000000000000000')).toBeNull();
+    expect(decodeProjectCreatedAt('P00000000000000000000000000!')).toBeNull();
+  });
+
+  it('returns KSUID epoch (1_400_000_000) for all-zero KSUID body', () => {
+    // 27 zeros → 20 zero bytes → timestamp 0 → Unix ts = KSUID_EPOCH
+    expect(decodeProjectCreatedAt('P' + '0'.repeat(27))).toBe(1_400_000_000);
+    // Same result with a 5-char prefix
+    expect(decodeProjectCreatedAt('Peuc1' + '0'.repeat(27))).toBe(
+      1_400_000_000,
+    );
+  });
+
+  it('returns a valid timestamp for a 28-char project ID (1-char prefix + 27-char KSUID)', () => {
+    const ts = decodeProjectCreatedAt('P2My9KRakUMj40L8KOBjAJLVWhWC');
+    expect(ts).not.toBeNull();
+    expect(ts).toBeGreaterThan(1_400_000_000); // after KSUID epoch (2014)
+    expect(ts).toBeLessThan(2_000_000_000); // before 2033
+  });
+
+  it('returns a valid timestamp for a 32-char project ID (5-char prefix + 27-char KSUID)', () => {
+    const ts = decodeProjectCreatedAt('Peuc12xciZCJzdRCXtRxJQEK0wDpKupo');
+    expect(ts).not.toBeNull();
+    expect(ts).toBeGreaterThan(1_400_000_000);
+    expect(ts).toBeLessThan(2_000_000_000);
+  });
+
+  it('extracts timestamp from the last 27 chars regardless of prefix length', () => {
+    const suffix27 = '2My9KRakUMj40L8KOBjAJLVWhWC';
+    const ts28 = decodeProjectCreatedAt('P' + suffix27);
+    const ts32 = decodeProjectCreatedAt('Peuc1' + suffix27);
+    expect(ts28).toBe(ts32);
+  });
+});

--- a/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/services/descope-auth.service.ts
+++ b/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/services/descope-auth.service.ts
@@ -70,15 +70,17 @@ export class DescopeAuthService {
       ...beforeRefreshSession,
       isSessionLoading: true
     });
-    return this.descopeSdk.refresh(undefined, tryRefresh).pipe(
-      finalize(() => {
-        const afterRefreshSession = this.sessionSubject.value;
-        this.sessionSubject.next({
-          ...afterRefreshSession,
-          isSessionLoading: false
-        });
-      })
-    );
+    return this.descopeSdk
+      .refresh(undefined, tryRefresh, { skipIfNoSession: true })
+      .pipe(
+        finalize(() => {
+          const afterRefreshSession = this.sessionSubject.value;
+          this.sessionSubject.next({
+            ...afterRefreshSession,
+            isSessionLoading: false
+          });
+        })
+      );
   }
 
   refreshUser() {

--- a/packages/sdks/react-sdk/src/components/AuthProvider/AuthProvider.tsx
+++ b/packages/sdks/react-sdk/src/components/AuthProvider/AuthProvider.tsx
@@ -149,7 +149,9 @@ const AuthProvider: FC<IAuthProviderProps> = ({
     isSessionFetched.current = true;
 
     setIsSessionLoading(true);
-    withValidation(sdk?.refresh)(undefined, true).then(() => {
+    withValidation(sdk?.refresh)(undefined, true, {
+      skipIfNoSession: true,
+    }).then(() => {
       setIsSessionLoading(false);
     });
   }, [sdk]);

--- a/packages/sdks/react-sdk/test/components/App.test.tsx
+++ b/packages/sdks/react-sdk/test/components/App.test.tsx
@@ -186,7 +186,7 @@ describe('App', () => {
 
     // ensure refresh called only once
     expect(refresh).toHaveBeenCalledTimes(1);
-    expect(refresh).toHaveBeenCalledWith(undefined, true); // the second argument (tryRefresh) should be true
+    expect(refresh).toHaveBeenCalledWith(undefined, true, { skipIfNoSession: true });
 
     const loginButton = await screen.findByText('Login');
     fireEvent.click(loginButton);

--- a/packages/sdks/react-sdk/test/components/App.test.tsx
+++ b/packages/sdks/react-sdk/test/components/App.test.tsx
@@ -186,7 +186,9 @@ describe('App', () => {
 
     // ensure refresh called only once
     expect(refresh).toHaveBeenCalledTimes(1);
-    expect(refresh).toHaveBeenCalledWith(undefined, true, { skipIfNoSession: true });
+    expect(refresh).toHaveBeenCalledWith(undefined, true, {
+      skipIfNoSession: true,
+    });
 
     const loginButton = await screen.findByText('Login');
     fireEvent.click(loginButton);

--- a/packages/sdks/vue-sdk/src/plugin.ts
+++ b/packages/sdks/vue-sdk/src/plugin.ts
@@ -56,7 +56,7 @@ export default {
     const fetchSession = async (tryRefresh?: boolean) => {
       if (isDescopeBridge()) return;
       isSessionLoading.value = true;
-      await sdk.refresh(undefined, tryRefresh);
+      await sdk.refresh(undefined, tryRefresh, { skipIfNoSession: true });
       isSessionLoading.value = false;
     };
 

--- a/packages/sdks/web-js-sdk/package.json
+++ b/packages/sdks/web-js-sdk/package.json
@@ -87,6 +87,7 @@
     "typescript": "^5.0.2"
   },
   "dependencies": {
+    "@descope/sdk-helpers": "workspace:*",
     "@descope/core-js-sdk": "workspace:*",
     "@fingerprintjs/fingerprintjs-pro": "3.11.6",
     "js-cookie": "3.0.5",

--- a/packages/sdks/web-js-sdk/src/constants.ts
+++ b/packages/sdks/web-js-sdk/src/constants.ts
@@ -17,3 +17,8 @@ export const OIDC_LOGOUT_ERROR_CODE = 'J161000';
 export const OIDC_REFRESH_ERROR_CODE = 'J161001';
 
 export const REFRESH_DISABLED = 'J171000';
+
+// Projects created after this Unix timestamp (2026-05-05 UTC) will skip the
+// initial refresh entirely when no session state is present. Set to approx.
+// the feature release date + 7-day buffer. Update before shipping.
+export const SKIP_INITIAL_REFRESH_FOR_PROJECTS_AFTER = 1777939200;

--- a/packages/sdks/web-js-sdk/src/enhancers/withPersistTokens/constants.ts
+++ b/packages/sdks/web-js-sdk/src/enhancers/withPersistTokens/constants.ts
@@ -8,3 +8,6 @@ export const ID_TOKEN_KEY = 'DSI';
 export const TRUSTED_DEVICE_TOKEN_KEY = 'DTD';
 /* Key for persisting the server-returned refresh cookie name */
 export const REFRESH_COOKIE_NAME_KEY = 'DSRCN';
+/* Key for tracking last known auth status per project */
+export const LAST_AUTH_KEY = 'DSP_LAST_AUTH';
+export const LAST_AUTH_STATE = { auth: 'auth', unauth: 'unauth' } as const;

--- a/packages/sdks/web-js-sdk/src/enhancers/withPersistTokens/helpers.ts
+++ b/packages/sdks/web-js-sdk/src/enhancers/withPersistTokens/helpers.ts
@@ -3,6 +3,8 @@ import Cookies from 'js-cookie';
 import { BeforeRequestHook, WebJWTResponse } from '../../types';
 import {
   ID_TOKEN_KEY,
+  LAST_AUTH_KEY,
+  LAST_AUTH_STATE,
   REFRESH_COOKIE_NAME_KEY,
   REFRESH_TOKEN_KEY,
   SESSION_TOKEN_KEY,
@@ -13,7 +15,12 @@ import {
   removeLocalStorage,
   setLocalStorage,
 } from '../helpers';
-import { CookieConfig, LastCookieOptions, SameSite } from './types';
+import {
+  CookieConfig,
+  LastCookieOptions,
+  LastAuthStateValue,
+  SameSite,
+} from './types';
 import logger from '../helpers/logger';
 
 /**
@@ -85,6 +92,7 @@ export const persistTokens = (
   sessionTokenViaCookie: boolean | CookieConfig = false,
   storagePrefix = '',
   refreshTokenViaCookie: boolean | CookieConfig = false,
+  projectId = '',
 ): LastCookieOptions | undefined => {
   // persist refresh token
   const { sessionJwt, refreshJwt, trustedDeviceJwt } = authInfo;
@@ -131,6 +139,8 @@ export const persistTokens = (
       // persist in local storage
       setLocalStorage(`${storagePrefix}${REFRESH_TOKEN_KEY}`, refreshJwt);
     }
+
+    setLastAuthStatus(projectId, LAST_AUTH_STATE.auth);
   }
 
   // persist session token
@@ -239,6 +249,7 @@ export function clearTokens(
   sessionTokenViaCookie?: CookieConfig,
   refreshTokenViaCookie?: CookieConfig,
   cookieOptions?: LastCookieOptions,
+  projectId = '',
 ) {
   removeLocalStorage(`${prefix}${REFRESH_TOKEN_KEY}`);
   removeLocalStorage(`${prefix}${SESSION_TOKEN_KEY}`);
@@ -249,6 +260,28 @@ export function clearTokens(
 
   const refreshCookieName = getRefreshCookieName(refreshTokenViaCookie);
   Cookies.remove(refreshCookieName, cookieOptions?.refresh);
+
+  setLastAuthStatus(projectId, LAST_AUTH_STATE.unauth);
+}
+
+export function setLastAuthStatus(
+  projectId: string,
+  status: LastAuthStateValue,
+) {
+  if (projectId) {
+    setLocalStorage(`${LAST_AUTH_KEY}_${projectId}`, status);
+  }
+}
+
+/** Returns the last known auth status for a project, or null if unknown (never set). */
+export function getLastAuthStatus(
+  projectId: string,
+): LastAuthStateValue | null {
+  const value = getLocalStorage(`${LAST_AUTH_KEY}_${projectId}`);
+  if (value === LAST_AUTH_STATE.auth || value === LAST_AUTH_STATE.unauth) {
+    return value;
+  }
+  return null;
 }
 
 export const beforeRequest =

--- a/packages/sdks/web-js-sdk/src/enhancers/withPersistTokens/helpers.ts
+++ b/packages/sdks/web-js-sdk/src/enhancers/withPersistTokens/helpers.ts
@@ -139,8 +139,6 @@ export const persistTokens = (
       // persist in local storage
       setLocalStorage(`${storagePrefix}${REFRESH_TOKEN_KEY}`, refreshJwt);
     }
-
-    setLastAuthStatus(projectId, LAST_AUTH_STATE.auth);
   }
 
   // persist session token
@@ -179,6 +177,12 @@ export const persistTokens = (
     } else {
       setLocalStorage(`${storagePrefix}${SESSION_TOKEN_KEY}`, sessionJwt);
     }
+  }
+
+  // sessionJwt and refreshJwt may be delivered as HttpOnly cookies (invisible to JS),
+  // but sessionExpiration is always present in the response body on successful auth.
+  if (sessionJwt || authInfo.sessionExpiration) {
+    setLastAuthStatus(projectId, LAST_AUTH_STATE.auth);
   }
 
   if (authInfo.idToken) {

--- a/packages/sdks/web-js-sdk/src/enhancers/withPersistTokens/index.ts
+++ b/packages/sdks/web-js-sdk/src/enhancers/withPersistTokens/index.ts
@@ -85,7 +85,7 @@ export const withPersistTokens =
           sessionTokenViaCookie,
           storagePrefix,
           refreshTokenViaCookie,
-          (config as any).projectId,
+          config.projectId,
         );
         // Only update lastCookieOptions if we actually set a cookie
         if (newCookieOptions) {
@@ -116,7 +116,7 @@ export const withPersistTokens =
         sessionTokenViaCookie,
         refreshTokenViaCookie,
         () => lastCookieOptions,
-        (config as any).projectId,
+        config.projectId,
       ),
     );
 

--- a/packages/sdks/web-js-sdk/src/enhancers/withPersistTokens/index.ts
+++ b/packages/sdks/web-js-sdk/src/enhancers/withPersistTokens/index.ts
@@ -61,6 +61,7 @@ export const withPersistTokens =
           sessionTokenViaCookie,
           refreshTokenViaCookie,
           lastCookieOptions,
+          config.projectId,
         );
       } else {
         const authInfo = await getAuthInfoFromResponse(res);
@@ -84,6 +85,7 @@ export const withPersistTokens =
           sessionTokenViaCookie,
           storagePrefix,
           refreshTokenViaCookie,
+          (config as any).projectId,
         );
         // Only update lastCookieOptions if we actually set a cookie
         if (newCookieOptions) {
@@ -114,6 +116,7 @@ export const withPersistTokens =
         sessionTokenViaCookie,
         refreshTokenViaCookie,
         () => lastCookieOptions,
+        (config as any).projectId,
       ),
     );
 
@@ -136,6 +139,7 @@ const logoutWrapper =
     sessionTokenViaCookie?: CookieConfig,
     refreshTokenViaCookie?: CookieConfig,
     getCookieOptions?: () => LastCookieOptions | undefined,
+    projectId?: string,
   ): SdkFnWrapper<{}> =>
   (fn) =>
   async (...args) => {
@@ -146,6 +150,7 @@ const logoutWrapper =
       sessionTokenViaCookie,
       refreshTokenViaCookie,
       getCookieOptions?.(),
+      projectId,
     );
 
     return resp;

--- a/packages/sdks/web-js-sdk/src/enhancers/withPersistTokens/types.ts
+++ b/packages/sdks/web-js-sdk/src/enhancers/withPersistTokens/types.ts
@@ -1,4 +1,5 @@
 export type SameSite = 'Strict' | 'Lax' | 'None';
+export type LastAuthStateValue = 'auth' | 'unauth';
 export type CookieConfig =
   | boolean
   | {

--- a/packages/sdks/web-js-sdk/src/sdk/index.ts
+++ b/packages/sdks/web-js-sdk/src/sdk/index.ts
@@ -5,13 +5,17 @@ import withFlow from './flow';
 import {
   getSessionToken,
   getRefreshToken,
+  getLastAuthStatus,
 } from '../enhancers/withPersistTokens/helpers';
+import { LAST_AUTH_STATE } from '../enhancers/withPersistTokens/constants';
+import { decodeProjectCreatedAt } from '@descope/sdk-helpers';
 import createOidc from './oidc';
 import { CoreSdk, WebSdkConfig } from '../types';
 import {
   OIDC_LOGOUT_ERROR_CODE,
   OIDC_REFRESH_ERROR_CODE,
   REFRESH_DISABLED,
+  SKIP_INITIAL_REFRESH_FOR_PROJECTS_AFTER,
 } from '../constants';
 import logger from '../enhancers/helpers/logger';
 import { isDescopeBridge } from '../enhancers/helpers';
@@ -26,6 +30,7 @@ const createSdk = (config: WebSdkConfig) => {
     refresh: async (
       token?: string,
       tryRefresh?: boolean,
+      options?: { skipIfNoSession?: boolean },
     ): ReturnType<CoreSdk['refresh']> => {
       if (isDescopeBridge()) {
         logger.debug(`Refresh called in native flow: ${new Error().stack}`);
@@ -53,10 +58,33 @@ const createSdk = (config: WebSdkConfig) => {
           });
         }
       }
-      // Descope use this query param to monitor if refresh is made
-      // When the user is already logged in in the past or not (We want to optimize that in the future)
       const currentSessionToken = getSessionToken();
       const currentRefreshToken = getRefreshToken();
+
+      // Skip the refresh call when we can prove there is no session to restore.
+      // Callers opt-in via options.skipIfNoSession (e.g. AuthProvider on mount).
+      if (
+        options?.skipIfNoSession &&
+        !currentSessionToken &&
+        !currentRefreshToken &&
+        !config.getExternalToken
+      ) {
+        const status = getLastAuthStatus(config.projectId);
+        if (status === LAST_AUTH_STATE.unauth) {
+          return { ok: true };
+        }
+        if (status !== LAST_AUTH_STATE.auth) {
+          // Flag absent: skip immediately for projects newer than the cutoff
+          const createdAt = decodeProjectCreatedAt(config.projectId);
+          if (
+            createdAt !== null &&
+            createdAt >= SKIP_INITIAL_REFRESH_FOR_PROJECTS_AFTER
+          ) {
+            return { ok: true };
+          }
+          // Legacy project: fall through to make the bootstrap call
+        }
+      }
 
       let externalToken = '';
       if (config.getExternalToken) {

--- a/packages/sdks/web-js-sdk/test/persistTokens.test.ts
+++ b/packages/sdks/web-js-sdk/test/persistTokens.test.ts
@@ -1215,6 +1215,82 @@ describe('persistTokens', () => {
     });
   });
 
+  describe('lastAuthStatus flag (DSP_LAST_AUTH)', () => {
+    beforeEach(() => {
+      localStorage.clear();
+      jest.clearAllMocks();
+    });
+
+    it('should set DSP_LAST_AUTH_pid to "auth" after a successful auth response', async () => {
+      const mockFetch = jest
+        .fn()
+        .mockReturnValue(createMockReturnValue(authInfo));
+      global.fetch = mockFetch;
+
+      const sdk = createSdk({ projectId: 'pid', persistTokens: true });
+      await sdk.httpClient.get('1/2/3');
+      await new Promise(process.nextTick);
+
+      expect(localStorage.getItem('DSP_LAST_AUTH_pid')).toEqual('auth');
+    });
+
+    it('should set DSP_LAST_AUTH_pid to "unauth" after logout', async () => {
+      localStorage.setItem('DSP_LAST_AUTH_pid', 'auth');
+      const mockFetch = jest.fn().mockReturnValue(createMockReturnValue({}));
+      global.fetch = mockFetch;
+
+      const sdk = createSdk({ projectId: 'pid', persistTokens: true });
+      await sdk.logout();
+
+      expect(localStorage.getItem('DSP_LAST_AUTH_pid')).toEqual('unauth');
+    });
+
+    it('should set DSP_LAST_AUTH_pid to "unauth" when session is invalidated by a 4xx on /refresh', async () => {
+      const failedMock = {
+        clone: () => failedMock,
+        ok: false,
+        status: 401,
+        text: () => Promise.resolve(JSON.stringify({})),
+        url: new URL('http://example.com'),
+        headers: new Headers(),
+      };
+      const mockFetch = jest
+        .fn()
+        .mockReturnValueOnce(createMockReturnValue(authInfo))
+        .mockReturnValueOnce(failedMock);
+      global.fetch = mockFetch;
+
+      const sdk = createSdk({ projectId: 'pid', persistTokens: true });
+
+      await sdk.httpClient.get('1/2/3');
+      await new Promise(process.nextTick);
+      expect(localStorage.getItem('DSP_LAST_AUTH_pid')).toEqual('auth');
+
+      await sdk.httpClient.get('/v1/auth/refresh');
+      await new Promise(process.nextTick);
+      expect(localStorage.getItem('DSP_LAST_AUTH_pid')).toEqual('unauth');
+    });
+
+    it('should not apply storagePrefix to the auth status flag', async () => {
+      const mockFetch = jest
+        .fn()
+        .mockReturnValue(createMockReturnValue(authInfo));
+      global.fetch = mockFetch;
+
+      const sdk = createSdk({
+        projectId: 'pid',
+        persistTokens: true,
+        storagePrefix: 'myapp.',
+      });
+      await sdk.httpClient.get('1/2/3');
+      await new Promise(process.nextTick);
+
+      // Flag key is DSP_LAST_AUTH_<projectId>, not affected by storagePrefix
+      expect(localStorage.getItem('DSP_LAST_AUTH_pid')).toEqual('auth');
+      expect(localStorage.getItem('myapp.DSP_LAST_AUTH_pid')).toBeNull();
+    });
+  });
+
   describe('server-returned refresh cookie name (DSRCN)', () => {
     beforeEach(() => {
       localStorage.clear();

--- a/packages/sdks/web-js-sdk/test/persistTokens.test.ts
+++ b/packages/sdks/web-js-sdk/test/persistTokens.test.ts
@@ -1221,10 +1221,48 @@ describe('persistTokens', () => {
       jest.clearAllMocks();
     });
 
-    it('should set DSP_LAST_AUTH_pid to "auth" after a successful auth response', async () => {
+    it('should set DSP_LAST_AUTH_pid to "auth" after a successful auth response (both tokens)', async () => {
       const mockFetch = jest
         .fn()
         .mockReturnValue(createMockReturnValue(authInfo));
+      global.fetch = mockFetch;
+
+      const sdk = createSdk({ projectId: 'pid', persistTokens: true });
+      await sdk.httpClient.get('1/2/3');
+      await new Promise(process.nextTick);
+
+      expect(localStorage.getItem('DSP_LAST_AUTH_pid')).toEqual('auth');
+    });
+
+    it('should set DSP_LAST_AUTH_pid to "auth" when sessionJwt is returned', async () => {
+      const sessionOnlyInfo = {
+        sessionJwt: authInfo.sessionJwt,
+        sessionExpiration: authInfo.sessionExpiration,
+        cookieDomain: authInfo.cookieDomain,
+        cookiePath: authInfo.cookiePath,
+        cookieExpiration: authInfo.cookieExpiration,
+      };
+      const mockFetch = jest
+        .fn()
+        .mockReturnValue(createMockReturnValue(sessionOnlyInfo));
+      global.fetch = mockFetch;
+
+      const sdk = createSdk({ projectId: 'pid', persistTokens: true });
+      await sdk.httpClient.get('1/2/3');
+      await new Promise(process.nextTick);
+
+      expect(localStorage.getItem('DSP_LAST_AUTH_pid')).toEqual('auth');
+    });
+
+    it('should set DSP_LAST_AUTH_pid to "auth" when tokens are HttpOnly cookies (only sessionExpiration in body)', async () => {
+      // sessionJwt and refreshJwt are delivered as HttpOnly cookies — invisible to JS.
+      // sessionExpiration is always present in the response body and is the reliable signal.
+      const expirationOnlyInfo = {
+        sessionExpiration: authInfo.sessionExpiration,
+      };
+      const mockFetch = jest
+        .fn()
+        .mockReturnValue(createMockReturnValue(expirationOnlyInfo));
       global.fetch = mockFetch;
 
       const sdk = createSdk({ projectId: 'pid', persistTokens: true });

--- a/packages/sdks/web-js-sdk/test/skipRefresh.test.ts
+++ b/packages/sdks/web-js-sdk/test/skipRefresh.test.ts
@@ -1,0 +1,110 @@
+import { decodeProjectCreatedAt } from '@descope/sdk-helpers';
+import createSdk from '../src/index';
+import { SKIP_INITIAL_REFRESH_FOR_PROJECTS_AFTER } from '../src/constants';
+import { createMockReturnValue } from './testUtils';
+import { flowResponse } from './mocks';
+
+jest.mock('@descope/sdk-helpers', () => ({
+  ...jest.requireActual('@descope/sdk-helpers'),
+  decodeProjectCreatedAt: jest.fn(),
+}));
+
+const mockDecodeProjectCreatedAt = decodeProjectCreatedAt as jest.Mock;
+
+globalThis.Headers = class Headers {
+  constructor(obj: object) {
+    return Object.assign({}, obj);
+  }
+} as any;
+
+jest.mock('js-cookie', () => ({
+  set: jest.fn(),
+  get: jest.fn(),
+  remove: jest.fn(),
+}));
+
+const OLD_PROJECT_TS = SKIP_INITIAL_REFRESH_FOR_PROJECTS_AFTER - 1;
+const NEW_PROJECT_TS = SKIP_INITIAL_REFRESH_FOR_PROJECTS_AFTER + 1;
+
+describe('sdk.refresh skipIfNoSession', () => {
+  let mockFetch: jest.Mock;
+
+  beforeEach(() => {
+    localStorage.clear();
+    mockDecodeProjectCreatedAt.mockReset();
+    mockFetch = jest.fn().mockReturnValue(createMockReturnValue(flowResponse));
+    global.fetch = mockFetch;
+  });
+
+  it('calls fetch when skipIfNoSession is not passed (back-compat)', async () => {
+    const sdk = createSdk({ projectId: 'pid', persistTokens: true });
+    await sdk.refresh(undefined, true);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls fetch when session token is present in localStorage', async () => {
+    localStorage.setItem('DS', 'session-token');
+    const sdk = createSdk({ projectId: 'pid', persistTokens: true });
+    await sdk.refresh(undefined, true, { skipIfNoSession: true });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls fetch when refresh token is present in localStorage', async () => {
+    localStorage.setItem('DSR', 'refresh-token');
+    const sdk = createSdk({ projectId: 'pid', persistTokens: true });
+    await sdk.refresh(undefined, true, { skipIfNoSession: true });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls fetch when getExternalToken is configured', async () => {
+    const sdk = createSdk({
+      projectId: 'pid',
+      persistTokens: true,
+      getExternalToken: jest.fn().mockResolvedValue('ext-token'),
+    });
+    await sdk.refresh(undefined, true, { skipIfNoSession: true });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls fetch when last auth status is "auth"', async () => {
+    localStorage.setItem('DSP_LAST_AUTH_pid', 'auth');
+    const sdk = createSdk({ projectId: 'pid', persistTokens: true });
+    await sdk.refresh(undefined, true, { skipIfNoSession: true });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips fetch and returns {ok:true} when last auth status is "unauth"', async () => {
+    localStorage.setItem('DSP_LAST_AUTH_pid', 'unauth');
+    const sdk = createSdk({ projectId: 'pid', persistTokens: true });
+    const result = await sdk.refresh(undefined, true, {
+      skipIfNoSession: true,
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result.ok).toBe(true);
+  });
+
+  it('calls fetch (bootstrap) when flag absent and project is old', async () => {
+    mockDecodeProjectCreatedAt.mockReturnValue(OLD_PROJECT_TS);
+    const sdk = createSdk({ projectId: 'pid', persistTokens: true });
+    await sdk.refresh(undefined, true, { skipIfNoSession: true });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips fetch and returns {ok:true} when flag absent and project is new', async () => {
+    mockDecodeProjectCreatedAt.mockReturnValue(NEW_PROJECT_TS);
+    const sdk = createSdk({ projectId: 'pid', persistTokens: true });
+    const result = await sdk.refresh(undefined, true, {
+      skipIfNoSession: true,
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result.ok).toBe(true);
+  });
+
+  it('calls fetch when flag absent and projectId is too short to decode (safe default)', async () => {
+    // 'pid' is only 3 chars — decodeProjectCreatedAt returns null
+    mockDecodeProjectCreatedAt.mockReturnValue(null);
+    const sdk = createSdk({ projectId: 'pid', persistTokens: true });
+    await sdk.refresh(undefined, true, { skipIfNoSession: true });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,8 +88,6 @@ importers:
         specifier: 10.9.2
         version: 10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3)
 
-  packages/libs/csp/dist/cjs: {}
-
   packages/libs/e2e-helpers:
     dependencies:
       '@playwright/test':
@@ -1411,7 +1409,7 @@ importers:
         specifier: ^5.0.2
         version: 5.4.5
 
-  packages/sdks/solid-sdk/dist/cjs: {}
+  packages/sdks/react-sdk/dist/cjs: {}
 
   packages/sdks/vue-sdk:
     dependencies:
@@ -1587,7 +1585,7 @@ importers:
     devDependencies:
       '@descope/web-components-ui':
         specifier: latest
-        version: 2.2.58
+        version: 3.3.2
       '@open-wc/rollup-plugin-html':
         specifier: 1.2.5
         version: 1.2.5
@@ -1729,6 +1727,9 @@ importers:
       '@descope/core-js-sdk':
         specifier: workspace:*
         version: link:../core-js-sdk
+      '@descope/sdk-helpers':
+        specifier: workspace:*
+        version: link:../../libs/sdk-helpers
       '@fingerprintjs/fingerprintjs-pro':
         specifier: 3.11.6
         version: 3.11.6
@@ -1912,7 +1913,7 @@ importers:
         version: link:../../libs/e2e-helpers
       '@descope/web-components-ui':
         specifier: latest
-        version: 2.2.58
+        version: 3.3.2
       '@open-wc/rollup-plugin-html':
         specifier: 1.2.5
         version: 1.2.5
@@ -2093,7 +2094,7 @@ importers:
         version: link:../../libs/e2e-helpers
       '@descope/web-components-ui':
         specifier: latest
-        version: 2.2.58
+        version: 3.3.2
       '@open-wc/rollup-plugin-html':
         specifier: 1.2.5
         version: 1.2.5
@@ -2274,7 +2275,7 @@ importers:
         version: link:../../libs/e2e-helpers
       '@descope/web-components-ui':
         specifier: latest
-        version: 2.2.58
+        version: 3.3.2
       '@open-wc/rollup-plugin-html':
         specifier: 1.2.5
         version: 1.2.5
@@ -2458,7 +2459,7 @@ importers:
         version: link:../../libs/e2e-helpers
       '@descope/web-components-ui':
         specifier: latest
-        version: 2.2.58
+        version: 3.3.2
       '@open-wc/rollup-plugin-html':
         specifier: 1.2.5
         version: 1.2.5
@@ -2639,7 +2640,7 @@ importers:
         version: link:../../libs/e2e-helpers
       '@descope/web-components-ui':
         specifier: latest
-        version: 2.2.58
+        version: 3.3.2
       '@open-wc/rollup-plugin-html':
         specifier: 1.2.5
         version: 1.2.5
@@ -2823,7 +2824,7 @@ importers:
         version: link:../../libs/e2e-helpers
       '@descope/web-components-ui':
         specifier: latest
-        version: 2.2.58
+        version: 3.3.2
       '@open-wc/rollup-plugin-html':
         specifier: 1.2.5
         version: 1.2.5
@@ -3014,7 +3015,7 @@ importers:
         version: link:../../libs/e2e-helpers
       '@descope/web-components-ui':
         specifier: latest
-        version: 2.2.58
+        version: 3.3.2
       '@open-wc/rollup-plugin-html':
         specifier: 1.2.5
         version: 1.2.5
@@ -3198,7 +3199,7 @@ importers:
         version: link:../../libs/e2e-helpers
       '@descope/web-components-ui':
         specifier: latest
-        version: 2.2.58
+        version: 3.3.2
       '@open-wc/rollup-plugin-html':
         specifier: 1.2.5
         version: 1.2.5
@@ -3816,8 +3817,8 @@ packages:
     resolution: {integrity: sha512-8NHiL98vsi0mbPQmYAGWwfcFaOy4j2HY49fXJCfuDcdE7fMIsH9a7GdaeXpIBsbT7307WU8KCMp5pUVDNL4f9A==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helpers@7.28.6':
-    resolution: {integrity: sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==}
+  '@babel/helpers@7.29.2':
+    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/highlight@7.23.4':
@@ -3843,8 +3844,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/parser@7.29.0':
-    resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -4522,86 +4523,92 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
-  '@descope-ui/common@2.2.58':
-    resolution: {integrity: sha512-i8qG/sI3dbDMUjcU+oae2BMscLMPzuHi6OY+mozD2SS/K4cR4m1lc92K6xEj77uD1rjc9m9DXLYyROZ1Y3+k/g==}
+  '@descope-ui/common@3.3.2':
+    resolution: {integrity: sha512-J/QNAoOv5+gtvadL2OV+B2o25q7GZuHw5W0RLBUL6+SbjP9d4yFJzjQCbJRUGh+p/yvgqAh/abNceWftQxFz+A==}
 
-  '@descope-ui/descope-address-field@2.2.58':
-    resolution: {integrity: sha512-7uM+kGJVtcgRjfLrIRMkdwh9zSDvvtI7MWqbEgaaECHqOUwReDxzfb6G+tnAoROCPtH/JuOmuMBa5p8V1tmM6w==}
+  '@descope-ui/descope-address-field@3.3.2':
+    resolution: {integrity: sha512-GzNUoxQrcNzfAMJCwG/YSzGM2c9csQxYxjuXVihYSn7kwiKpmLwinvomSvjSfcqXVA/uY4ZubIhdoz4H+QoqOQ==}
 
-  '@descope-ui/descope-apps-list@2.2.58':
-    resolution: {integrity: sha512-XRhALTDBul3BTtY/SuvDH7bwPpNPxpVOKXNntlrPNWGgQJZC1Wy9l/+k882MSbjXqbPk0h6fKyVDjNRjTD6e6w==}
+  '@descope-ui/descope-apps-list@3.3.2':
+    resolution: {integrity: sha512-AKawfGjQb1BNa81NlLmMPJUmHAv9kemgbQHSz4wKNBZji5hbfldHy4pTuQ/gPY5nu6KpwyGpntxqUhrwNd2Y8w==}
 
-  '@descope-ui/descope-autocomplete-field@2.2.58':
-    resolution: {integrity: sha512-NJ6FiI0xlGFM3ziU97WyoC+yfgojjXX9PrmReDfEB+i2kRWToDgqbKSY2an0ibAUQs4RNUG5VwZDZGE0Yg37zQ==}
+  '@descope-ui/descope-attachment@3.3.2':
+    resolution: {integrity: sha512-CqhcnWdUK/b0PP0Slc15ZiOPT1nxW1NdDD9wHX3smY8dK1mfS1QwDAIPlkYvQ4seNIr+4iPOr8WEdxe4U6RW8Q==}
 
-  '@descope-ui/descope-avatar@2.2.58':
-    resolution: {integrity: sha512-tXEAuvLyVnN4gCv1hYFzKhZ9/fgUlUhJm1j3J7Edl2FyCrbFV1bQcWTweUNAQN72w9ROcFQPslnhvAR4bobo3A==}
+  '@descope-ui/descope-autocomplete-field@3.3.2':
+    resolution: {integrity: sha512-Ddzdd2basvN2+cSo9QH7D3aPV7GQ2F4AeI2obYdU1hvCLS+UZ3zp20BDxw+KR92fMunqg/ElICm8GQnlQImLPA==}
 
-  '@descope-ui/descope-badge@2.2.58':
-    resolution: {integrity: sha512-Y5adsAh84oLm68CMjMjm49diYp+5gBlGB0Dnyr+zZ02C4/qUpe6JCekn88Qkxid3mFIQ3VKLqIiaaKbHHt8oOA==}
+  '@descope-ui/descope-avatar@3.3.2':
+    resolution: {integrity: sha512-oxqa+0ZMYdNsGCKXx08le534sBhrskPoZuuVBQIYWdSUbEvlQOtI/BnfZZPt1+eNRrusqogbCX1R7edSMtzrCA==}
 
-  '@descope-ui/descope-button@2.2.58':
-    resolution: {integrity: sha512-JydhxPcw8EfmYJKAw6CaN2UYaE8lljGSZ6vv8cWi4dDu2+nnP9s5WXeebyLha2mEDhNcoBTQvq1+CHRkFN3z1A==}
+  '@descope-ui/descope-badge@3.3.2':
+    resolution: {integrity: sha512-sJmqPwmsb5ocCFZYEpQm189EXHmA1wOkFT99ycFhJa+gRxiZ3lrW9d/VDsw6ayP3fl87nVeO3G5om18IbcdeNg==}
 
-  '@descope-ui/descope-collapsible-container@2.2.58':
-    resolution: {integrity: sha512-n1FMUQBEeLYcfAyyrmerwNq/LkEzNIptl0yVqH29keDG+1qEMN9CRWGOYM3UMBhW1UbwmZ1cTXh9reb4onjQJQ==}
+  '@descope-ui/descope-button@3.3.2':
+    resolution: {integrity: sha512-Ib29bSVj7xhSHJ9J41ndzc3jk0Xcfwem+QOOEtydmHtxWxE6iGhfhPKpdw2sKBmtMvRhUJ4r3NdDuvgICB2GUA==}
 
-  '@descope-ui/descope-combo-box@2.2.58':
-    resolution: {integrity: sha512-+odu/YjiXEAZhSv9IYfNx3xDDZOIeEvvcfji9x670YXAlInv8ojT68KtexPe9jWQZInIsetF/Knm1+9fjv3CnQ==}
+  '@descope-ui/descope-collapsible-container@3.3.2':
+    resolution: {integrity: sha512-WU5oM/8xMnP0i5aUw09weEHBBO2o8+fThHLZrBy/0HHY5aYf70AbT7cSsRCLwaakOq93Yh4I16/ejDC6Gp+R2Q==}
 
-  '@descope-ui/descope-enriched-text@2.2.58':
-    resolution: {integrity: sha512-K787DpApshoPLftOAV0Q1DGsWz2vozUAFgNBe9KFk3cRBJDulv/23BfXSuBCYSrGS3QtIN48JhG6xW5eF9H9YA==}
+  '@descope-ui/descope-combo-box@3.3.2':
+    resolution: {integrity: sha512-PIvSehnfl2p7rgS00puq4BRN7wBuy9r4aoee75pLYwR/dqIWasGgQWog5DDpQ+BGT0nO0jM6yE8AbacRL8MBmg==}
 
-  '@descope-ui/descope-icon@2.2.58':
-    resolution: {integrity: sha512-e5lIbe4j/up3LOxrwvZQsizKEkfDlXVS/I9xOWqajIolhFb1+Fvkqh80pRJlf0cHUmk5i01orkg969uCOrpNQg==}
+  '@descope-ui/descope-country-subdivision-city-field@3.3.2':
+    resolution: {integrity: sha512-prPYW2zy+U/WfTVU6WscAS523HuuQ3mZZUMyqFkcfEpyhRt8Od2Q85RxWUJUI4n+i894BBBwO6CB70fV5emqUQ==}
 
-  '@descope-ui/descope-image@2.2.58':
-    resolution: {integrity: sha512-J6ZXwCj2H9gTjtKaEvNQ0cAoBqijbER5BlKhOkkEn3zL1ejl9ehaL50LaywHCTBV6QsDy8hq1EvBnNIAwPFc3w==}
+  '@descope-ui/descope-enriched-text@3.3.2':
+    resolution: {integrity: sha512-PSRdwJKYeDAD002yw3nr+DAveUtzEL8XJ0ZRq5rhwgJveZes1h960IIFmPmny/Zi+FAx4h73YTCt0elC+90z8A==}
 
-  '@descope-ui/descope-link@2.2.58':
-    resolution: {integrity: sha512-w8vydTcB2713Qg2a/WbLkeYnl7sfSjm/q/NyiKnbFLTl4hJHE2qLGadTgdDArrkMl19n0kiOe8SUgWCcIL9fmA==}
+  '@descope-ui/descope-icon@3.3.2':
+    resolution: {integrity: sha512-1Sj1+w2Q0Yy3TbpKtz7b+5AbrNXWIFiUUp7G8SMjib+PX+llwxv2QdLRutugWVPO1f/aHcclaw1ltSiGnGwzjA==}
 
-  '@descope-ui/descope-list-item@2.2.58':
-    resolution: {integrity: sha512-ZGajF6+uDycuVgoiKicASqRxMuEDiGTOP5NSPkIfYqIS7wWVNyqRZ8i0ir5TYy37bFkRGY7iXBSaDsuCBTHHLQ==}
+  '@descope-ui/descope-image@3.3.2':
+    resolution: {integrity: sha512-NTENT+voEws0p8Dwl+i0kEYwj3NzO/MgCBRYDPB7fNxxrODo9dTk8+ExLDq/FqqAzu/0ef1sPw6sQmhpMinG3w==}
 
-  '@descope-ui/descope-list@2.2.58':
-    resolution: {integrity: sha512-6dOeIngbWwIE3vOUA+oVPnwwi3N0I7uxzVgN6GAP1P4KB77awK40+AavHvseIos00f2DSU/SACXujOJB8nkGrA==}
+  '@descope-ui/descope-link@3.3.2':
+    resolution: {integrity: sha512-XGJi/3YKi3XfRDK03RgNAX0JOKjxu4sI+s5VOjjtr3H2nZIm72i3P3oy8UzTHBK13Fzrj2Zh6pvF97LcTK0i8A==}
 
-  '@descope-ui/descope-outbound-app-button@2.2.58':
-    resolution: {integrity: sha512-GRsKOE4ZF82UCp/J/Y149Ob/MmrRjv6lg2DbrgyhuldBHIxnpVKD32gLtFr3Boa+XD1JvEjSxLTwFwuJTvvHKQ==}
+  '@descope-ui/descope-list-item@3.3.2':
+    resolution: {integrity: sha512-jzUvxerImPXuzNJEEOZI87BEF8nl8TyVZ9+r2I1BliyOIvrNrmCSJLkjknaCa7o1/pJhChztApL8VUMBmR9mpw==}
 
-  '@descope-ui/descope-outbound-apps@2.2.58':
-    resolution: {integrity: sha512-v6vKlxHvQqt9Etwar/CbmhqNukzTka1Hd5TSjF0hHai1YwO6gK1AVLQBSKGuPp3hkAMCfu4JKW2imlKvO9Gdpw==}
+  '@descope-ui/descope-list@3.3.2':
+    resolution: {integrity: sha512-1FVp6m5bzjS6e7/qd7bOm39z2t42xbuLQ5gVGhAX+YwuT6vLIlVBdIeaWp6jXGmZ3OhnJASipSelf7E5JQs90A==}
 
-  '@descope-ui/descope-password-strength@2.2.58':
-    resolution: {integrity: sha512-U4ic41vJ+AQpFHivpK/K+VYyoWN/Eux1OkYV7Zz3KAHNxBFmsym+r05nkopaZdpTy+xYiynDY4BIFGH6/Ay5ig==}
+  '@descope-ui/descope-outbound-app-button@3.3.2':
+    resolution: {integrity: sha512-JgfUMrqdw6b569/wckWucgJM6tlppjzBM+/kFSmjh2g3hMeNE/glEmCIE2p01HcMqBJjt0IIkvGgYMfDmhK4Qw==}
 
-  '@descope-ui/descope-ponyhot@2.2.58':
-    resolution: {integrity: sha512-5FDCVun3YrRLmfKj6Yz9ybzf83VVYbW2dzTJ3YAFkzXsdC/k3xgFNA+pnmxG2PLMYe0rUHO9q1xmO/2FC09vpQ==}
+  '@descope-ui/descope-outbound-apps@3.3.2':
+    resolution: {integrity: sha512-/DS47or5D2Nqk2xY8XUvDGXAMbTTlBpArcWSF89/jLLhqVRk7s82jWt/pcIoaNzR8gbFT2Z1PSyym39INePevA==}
 
-  '@descope-ui/descope-recovery-codes@2.2.58':
-    resolution: {integrity: sha512-hNySfvpFhxTIKkZbhiLzwyeH5teuIZOtT7++qPULGqicp3sl4zRKr2CjduCC6hkx9cPWJ3a6twnILE9Sunn8AA==}
+  '@descope-ui/descope-password-strength@3.3.2':
+    resolution: {integrity: sha512-oomDSpcuo3Y8j9IsFh7/dz0ePt73EwzO2/2P3zPMJHohcM6fDLKWc5KHBuyg/PPBSH0E6tvFj9Qaf2G+KqKnOQ==}
 
-  '@descope-ui/descope-text@2.2.58':
-    resolution: {integrity: sha512-zFL2ZkwiD3kaCSDpvAbKflL7JyAUa9cGUinR/qLhWsHh411PWj9tIExH108MBGV/bIKDzlM11ll8nkrO+OBe4A==}
+  '@descope-ui/descope-ponyhot@3.3.2':
+    resolution: {integrity: sha512-JHj7ZtJ0rqiYScHeskFumLKbo2VlNhdzGg3T0MQ76DR2bxsNi8ACnlMPnAs7T1CBoMzSPvXuFB5RFMVonkoqGQ==}
 
-  '@descope-ui/descope-timer-button@2.2.58':
-    resolution: {integrity: sha512-7+e6IR6viMXJwq5dQiukQ+NoaAJ3G8u8sh2hQYY7HATioCt/w9zrhLYB0MVKhgreozGTU6DCNqCuUzz5hcnJqA==}
+  '@descope-ui/descope-recovery-codes@3.3.2':
+    resolution: {integrity: sha512-VkL8scGr06jHe/bAS43MhOB5AJohgaoxmmlWjhxXhONIJ/wzvGHCksh9hKsexMqgTK5tABDEOiUqx4JWH9mrvQ==}
 
-  '@descope-ui/descope-timer@2.2.58':
-    resolution: {integrity: sha512-knZ2dd/hoaeasGEzAgPdtlVKqilWeslXOQgYFAkJ+y0NN6us9sfM2Zj6QImBu04hROXB4xji6ClXY23D3ImGyg==}
+  '@descope-ui/descope-text@3.3.2':
+    resolution: {integrity: sha512-6rUDES8us+GmhUZ/ZnumUPGGbbjza+VLTMb2ViWyxQ5GpWhG+QL/D4/Bl/6KDRK9K1Pa1mep95FbV+BQtCk4Gw==}
 
-  '@descope-ui/descope-tooltip@2.2.58':
-    resolution: {integrity: sha512-Rln/D+AucMzPD/MXji/7nt7tjUAjjlvvR9A1JKa/v+phDoZj+LO0cCy3C8eVGs1pSxlMBIMck77HT/GHXPaHNg==}
+  '@descope-ui/descope-timer-button@3.3.2':
+    resolution: {integrity: sha512-+OaZt+T2AsNoU6O9uv4eayA4HoQIrtP1YljxuoQYbKS1lGGuK8C0tnUrRHpoVCYofqAR0SJRZSB17DH6s4MKbQ==}
 
-  '@descope-ui/descope-trusted-devices@2.2.58':
-    resolution: {integrity: sha512-OQ6cRyo6puDOAIBSi2A3Y40w1YAgRLhzlploe/aQrZBXKGUaC2c4dZ7lk93/BWq4xVBrML1psbHUePTAh2IT5g==}
+  '@descope-ui/descope-timer@3.3.2':
+    resolution: {integrity: sha512-U4xL4Q4q7oQSYqISlEXyGYyR86CwtgQYGk2lmlccgKU2QuaZiGJf6cWtpnttyVKGSxDozt4ric1I6MDy0QGcKQ==}
 
-  '@descope-ui/theme-globals@2.2.58':
-    resolution: {integrity: sha512-SMZ3lYHJ6/MsBr9Ch51Zy9P+6LKzsmu+vGMKm0f76lbVTvukUlwrXwVdmDwTXfY/tHwbg3dnQRbOxtT66NcpmQ==}
+  '@descope-ui/descope-tooltip@3.3.2':
+    resolution: {integrity: sha512-qz/7bsvC9dV/NC+0vYaem+rwRnXEZqnIYpWHzWQs0sDu3FlKeMJnNOm4jU4tnM7obTACIhQjMKGaXD7ZN0HQxg==}
 
-  '@descope-ui/theme-input-wrapper@2.2.58':
-    resolution: {integrity: sha512-NWA+putxh3HkzVQxXJfmwydj/IX+n2VK55zX6S0Cd8ys4qSip/fBzki4Tb50fXbS8yPYE8vu8oCZ8UWKGvEfFg==}
+  '@descope-ui/descope-trusted-devices@3.3.2':
+    resolution: {integrity: sha512-OWU4wV5uehHTyddNP+rZvusPaWP3NQ5xfIsSoKiYBvdT5YdIYgqBP5q/YbS0XqfCB2xb6otTIokTX8XP+9pxiw==}
+
+  '@descope-ui/theme-globals@3.3.2':
+    resolution: {integrity: sha512-r2zTbDg7mVViX9KIy+ZiHvK9TRZLUxaV6DBlJN5KOh/w6Lj4OHaPEapM7QknDbWSnLjEzZmipBOjL03NhNBn8A==}
+
+  '@descope-ui/theme-input-wrapper@3.3.2':
+    resolution: {integrity: sha512-MDyO4Y6eyhO5a90sJ+UCyKOd0BmrdlzxoL81A6Sj0JdVaBioZl8RWnR4vA1WLEwfAUFHrZUxMANZsy4+uK/w8A==}
 
   '@descope/core-js-sdk@2.40.0':
     resolution: {integrity: sha512-hFr/SzQO0QbyDaI1LlN//HKi3hXNJAnU0lFUpsqwo92YmCvYzhSZ7r6aBvT0DU2jaXmvt/0Y9TyNQuEKsGpT/A==}
@@ -4613,8 +4620,8 @@ packages:
     resolution: {integrity: sha512-v4kII4vcCdQO/ootlGpB97ovjTwE3Z2S0MmIF5j7kgXQIPTUM01fOsbAaPPUn5lXX7muD2VcsDs6Ic1k2yQjrA==}
     engines: {node: '>= 16.0.0'}
 
-  '@descope/web-components-ui@2.2.58':
-    resolution: {integrity: sha512-egGzzLTLw9VLWIumXhgWc5aGDSzBfujCmdb55ulYjgDJ+rHCGT5esXFbVedgN01o7tGgf9lTVKZrizn9RH/HIw==}
+  '@descope/web-components-ui@3.3.2':
+    resolution: {integrity: sha512-BcbMMnzmSoGjR9MldCJOBUtN8fyUrcAv8SWoUJgD0KHzaBozSZvcS9aLnniU+DHh8BnWKhEG5WAwNGecWLXpiA==}
 
   '@descope/web-js-sdk@1.29.1':
     resolution: {integrity: sha512-YUMJQ9TrEhp8SDtOcERF4tr7IguBt5//0sm8k8/tFc/9qb1uZ9Hz1z2+1NX8cnni+tMpOUH7tRFEoprpKayPEw==}
@@ -8903,8 +8910,8 @@ packages:
     resolution: {integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==}
     engines: {node: ^4.5.0 || >= 5.9}
 
-  baseline-browser-mapping@2.10.0:
-    resolution: {integrity: sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==}
+  baseline-browser-mapping@2.10.23:
+    resolution: {integrity: sha512-xwVXGqevyKPsiuQdLj+dZMVjidjJV508TBqexND5HrF89cGdCYCJFB3qhcxRHSeMctdCfbR1jrxBajhDy7o29g==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -9081,8 +9088,8 @@ packages:
   caniuse-lite@1.0.30001696:
     resolution: {integrity: sha512-pDCPkvzfa39ehJtJ+OwGT/2yvT2SbjfHhiIW2LWOAcMQ7BzwxT/XuyUp4OTOd0XFWA6BKw0JalnBHgSi5DGJBQ==}
 
-  caniuse-lite@1.0.30001774:
-    resolution: {integrity: sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==}
+  caniuse-lite@1.0.30001791:
+    resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
 
   case-sensitive-paths-webpack-plugin@2.4.0:
     resolution: {integrity: sha512-roIFONhcxog0JSSWbvVAh3OocukmSgpqOH6YpMkCvav/ySIV3JKg4Dc8vYtQjYi/UxpNE36r/9v+VqTQqgkYmw==}
@@ -10130,8 +10137,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.3.1:
-    resolution: {integrity: sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==}
+  dompurify@3.4.1:
+    resolution: {integrity: sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==}
 
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
@@ -10208,8 +10215,8 @@ packages:
   electron-to-chromium@1.4.825:
     resolution: {integrity: sha512-OCcF+LwdgFGcsYPYC5keEEFC2XT0gBhrYbeGzHCx7i9qRFbzO/AqTmc/C/1xNhJj+JA7rzlN7mpBuStshh96Cg==}
 
-  electron-to-chromium@1.5.302:
-    resolution: {integrity: sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==}
+  electron-to-chromium@1.5.344:
+    resolution: {integrity: sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==}
 
   electron-to-chromium@1.5.90:
     resolution: {integrity: sha512-C3PN4aydfW91Natdyd449Kw+BzhLmof6tzy5W1pFC5SpQxVXT+oyiyOG9AgYYSN9OdA/ik3YkCrpwqI8ug5Tug==}
@@ -11191,7 +11198,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    deprecated: Glob versions prior to v9 are no longer supported
 
   global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
@@ -13114,8 +13121,8 @@ packages:
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
 
-  node-releases@2.0.27:
-    resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
+  node-releases@2.0.38:
+    resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
 
   nopt@7.2.1:
     resolution: {integrity: sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==}
@@ -13840,6 +13847,10 @@ packages:
 
   postcss@8.5.1:
     resolution: {integrity: sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.12:
+    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.3:
@@ -16567,8 +16578,8 @@ snapshots:
       '@babel/generator': 7.29.1
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.26.10)
-      '@babel/helpers': 7.28.6
-      '@babel/parser': 7.29.0
+      '@babel/helpers': 7.29.2
+      '@babel/parser': 7.29.2
       '@babel/template': 7.28.6
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
@@ -16607,7 +16618,7 @@ snapshots:
 
   '@babel/generator@7.29.1':
     dependencies:
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
@@ -16690,7 +16701,7 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-compilation-targets': 7.26.5
       '@babel/helper-plugin-utils': 7.26.5
-      debug: 4.4.1
+      debug: 4.4.3
       lodash.debounce: 4.0.8
       resolve: 1.22.10
     transitivePeerDependencies:
@@ -16865,7 +16876,7 @@ snapshots:
       '@babel/template': 7.25.9
       '@babel/types': 7.27.0
 
-  '@babel/helpers@7.28.6':
+  '@babel/helpers@7.29.2':
     dependencies:
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
@@ -16896,7 +16907,7 @@ snapshots:
     dependencies:
       '@babel/types': 7.27.0
 
-  '@babel/parser@7.29.0':
+  '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
 
@@ -17662,7 +17673,7 @@ snapshots:
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.2
       '@babel/types': 7.29.0
     optional: true
 
@@ -17676,7 +17687,7 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.24.7
       '@babel/parser': 7.27.0
       '@babel/types': 7.27.0
-      debug: 4.4.1
+      debug: 4.4.3
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -17688,7 +17699,7 @@ snapshots:
       '@babel/parser': 7.27.0
       '@babel/template': 7.25.9
       '@babel/types': 7.27.0
-      debug: 4.4.0
+      debug: 4.4.3
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -17698,7 +17709,7 @@ snapshots:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.2
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
       debug: 4.4.3
@@ -17857,193 +17868,205 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@descope-ui/common@2.2.58':
+  '@descope-ui/common@3.3.2':
     dependencies:
       color: 4.2.3
       element-internals-polyfill: 1.3.11
       lodash.debounce: 4.0.8
       lodash.merge: 4.6.2
 
-  '@descope-ui/descope-address-field@2.2.58':
+  '@descope-ui/descope-address-field@3.3.2':
     dependencies:
-      '@descope-ui/common': 2.2.58
-      '@descope-ui/descope-autocomplete-field': 2.2.58
-      '@descope-ui/theme-input-wrapper': 2.2.58
+      '@descope-ui/common': 3.3.2
+      '@descope-ui/descope-autocomplete-field': 3.3.2
+      '@descope-ui/theme-input-wrapper': 3.3.2
       '@vaadin/custom-field': 24.3.4
 
-  '@descope-ui/descope-apps-list@2.2.58':
+  '@descope-ui/descope-apps-list@3.3.2':
     dependencies:
-      '@descope-ui/common': 2.2.58
-      '@descope-ui/descope-avatar': 2.2.58
-      '@descope-ui/descope-list': 2.2.58
-      '@descope-ui/descope-list-item': 2.2.58
-      '@descope-ui/descope-text': 2.2.58
-      '@descope-ui/theme-globals': 2.2.58
+      '@descope-ui/common': 3.3.2
+      '@descope-ui/descope-avatar': 3.3.2
+      '@descope-ui/descope-list': 3.3.2
+      '@descope-ui/descope-list-item': 3.3.2
+      '@descope-ui/descope-text': 3.3.2
+      '@descope-ui/theme-globals': 3.3.2
 
-  '@descope-ui/descope-autocomplete-field@2.2.58':
+  '@descope-ui/descope-attachment@3.3.2':
     dependencies:
-      '@descope-ui/common': 2.2.58
-      '@descope-ui/descope-combo-box': 2.2.58
-      '@descope-ui/theme-globals': 2.2.58
-      '@descope-ui/theme-input-wrapper': 2.2.58
+      '@descope-ui/common': 3.3.2
+      '@descope-ui/theme-globals': 3.3.2
+
+  '@descope-ui/descope-autocomplete-field@3.3.2':
+    dependencies:
+      '@descope-ui/common': 3.3.2
+      '@descope-ui/descope-combo-box': 3.3.2
+      '@descope-ui/theme-globals': 3.3.2
+      '@descope-ui/theme-input-wrapper': 3.3.2
       '@vaadin/custom-field': 24.3.4
 
-  '@descope-ui/descope-avatar@2.2.58':
+  '@descope-ui/descope-avatar@3.3.2':
     dependencies:
-      '@descope-ui/common': 2.2.58
-      '@descope-ui/theme-globals': 2.2.58
+      '@descope-ui/common': 3.3.2
+      '@descope-ui/theme-globals': 3.3.2
       '@vaadin/avatar': 24.3.4
       '@vaadin/icon': 24.3.4
       '@vaadin/icons': 24.3.4
 
-  '@descope-ui/descope-badge@2.2.58':
+  '@descope-ui/descope-badge@3.3.2':
     dependencies:
-      '@descope-ui/common': 2.2.58
-      '@descope-ui/theme-globals': 2.2.58
+      '@descope-ui/common': 3.3.2
+      '@descope-ui/theme-globals': 3.3.2
 
-  '@descope-ui/descope-button@2.2.58':
+  '@descope-ui/descope-button@3.3.2':
     dependencies:
-      '@descope-ui/common': 2.2.58
-      '@descope-ui/descope-icon': 2.2.58
-      '@descope-ui/theme-globals': 2.2.58
+      '@descope-ui/common': 3.3.2
+      '@descope-ui/descope-icon': 3.3.2
+      '@descope-ui/theme-globals': 3.3.2
       '@vaadin/button': 24.3.4
 
-  '@descope-ui/descope-collapsible-container@2.2.58':
+  '@descope-ui/descope-collapsible-container@3.3.2':
     dependencies:
-      '@descope-ui/common': 2.2.58
-      '@descope-ui/descope-icon': 2.2.58
-      '@descope-ui/descope-text': 2.2.58
-      '@descope-ui/theme-globals': 2.2.58
+      '@descope-ui/common': 3.3.2
+      '@descope-ui/descope-icon': 3.3.2
+      '@descope-ui/descope-text': 3.3.2
+      '@descope-ui/theme-globals': 3.3.2
 
-  '@descope-ui/descope-combo-box@2.2.58':
+  '@descope-ui/descope-combo-box@3.3.2':
     dependencies:
-      '@descope-ui/common': 2.2.58
-      '@descope-ui/theme-globals': 2.2.58
-      '@descope-ui/theme-input-wrapper': 2.2.58
+      '@descope-ui/common': 3.3.2
+      '@descope-ui/theme-globals': 3.3.2
+      '@descope-ui/theme-input-wrapper': 3.3.2
       '@vaadin/combo-box': 24.3.4
 
-  '@descope-ui/descope-enriched-text@2.2.58':
+  '@descope-ui/descope-country-subdivision-city-field@3.3.2':
     dependencies:
-      '@descope-ui/common': 2.2.58
-      '@descope-ui/descope-link': 2.2.58
-      '@descope-ui/descope-text': 2.2.58
-      '@descope-ui/theme-globals': 2.2.58
+      '@descope-ui/common': 3.3.2
+      '@descope-ui/descope-combo-box': 3.3.2
+      '@descope-ui/theme-input-wrapper': 3.3.2
+      '@vaadin/custom-field': 24.3.4
+
+  '@descope-ui/descope-enriched-text@3.3.2':
+    dependencies:
+      '@descope-ui/common': 3.3.2
+      '@descope-ui/descope-link': 3.3.2
+      '@descope-ui/descope-text': 3.3.2
+      '@descope-ui/theme-globals': 3.3.2
       markdown-it: 14.1.1
 
-  '@descope-ui/descope-icon@2.2.58':
+  '@descope-ui/descope-icon@3.3.2':
     dependencies:
-      '@descope-ui/common': 2.2.58
-      '@descope-ui/descope-image': 2.2.58
-      '@descope-ui/theme-globals': 2.2.58
+      '@descope-ui/common': 3.3.2
+      '@descope-ui/descope-image': 3.3.2
+      '@descope-ui/theme-globals': 3.3.2
       '@vaadin/icon': 24.3.4
-      dompurify: 3.3.1
+      dompurify: 3.4.1
 
-  '@descope-ui/descope-image@2.2.58':
+  '@descope-ui/descope-image@3.3.2':
     dependencies:
-      '@descope-ui/common': 2.2.58
-      '@descope-ui/theme-globals': 2.2.58
-      dompurify: 3.3.1
+      '@descope-ui/common': 3.3.2
+      '@descope-ui/theme-globals': 3.3.2
+      dompurify: 3.4.1
 
-  '@descope-ui/descope-link@2.2.58':
+  '@descope-ui/descope-link@3.3.2':
     dependencies:
-      '@descope-ui/common': 2.2.58
-      '@descope-ui/theme-globals': 2.2.58
+      '@descope-ui/common': 3.3.2
+      '@descope-ui/theme-globals': 3.3.2
 
-  '@descope-ui/descope-list-item@2.2.58':
+  '@descope-ui/descope-list-item@3.3.2':
     dependencies:
-      '@descope-ui/common': 2.2.58
-      '@descope-ui/theme-globals': 2.2.58
+      '@descope-ui/common': 3.3.2
+      '@descope-ui/theme-globals': 3.3.2
 
-  '@descope-ui/descope-list@2.2.58':
+  '@descope-ui/descope-list@3.3.2':
     dependencies:
-      '@descope-ui/common': 2.2.58
-      '@descope-ui/descope-list-item': 2.2.58
-      '@descope-ui/theme-globals': 2.2.58
+      '@descope-ui/common': 3.3.2
+      '@descope-ui/descope-list-item': 3.3.2
+      '@descope-ui/theme-globals': 3.3.2
 
-  '@descope-ui/descope-outbound-app-button@2.2.58':
+  '@descope-ui/descope-outbound-app-button@3.3.2':
     dependencies:
-      '@descope-ui/common': 2.2.58
-      '@descope-ui/descope-button': 2.2.58
-      '@descope-ui/descope-icon': 2.2.58
-      '@descope-ui/theme-globals': 2.2.58
+      '@descope-ui/common': 3.3.2
+      '@descope-ui/descope-button': 3.3.2
+      '@descope-ui/descope-icon': 3.3.2
+      '@descope-ui/theme-globals': 3.3.2
 
-  '@descope-ui/descope-outbound-apps@2.2.58':
+  '@descope-ui/descope-outbound-apps@3.3.2':
     dependencies:
-      '@descope-ui/common': 2.2.58
-      '@descope-ui/descope-avatar': 2.2.58
-      '@descope-ui/descope-button': 2.2.58
-      '@descope-ui/descope-icon': 2.2.58
-      '@descope-ui/descope-list': 2.2.58
-      '@descope-ui/descope-list-item': 2.2.58
-      '@descope-ui/descope-text': 2.2.58
-      '@descope-ui/theme-globals': 2.2.58
+      '@descope-ui/common': 3.3.2
+      '@descope-ui/descope-avatar': 3.3.2
+      '@descope-ui/descope-button': 3.3.2
+      '@descope-ui/descope-icon': 3.3.2
+      '@descope-ui/descope-list': 3.3.2
+      '@descope-ui/descope-list-item': 3.3.2
+      '@descope-ui/descope-text': 3.3.2
+      '@descope-ui/theme-globals': 3.3.2
 
-  '@descope-ui/descope-password-strength@2.2.58':
+  '@descope-ui/descope-password-strength@3.3.2':
     dependencies:
-      '@descope-ui/common': 2.2.58
-      '@descope-ui/theme-globals': 2.2.58
-      '@descope-ui/theme-input-wrapper': 2.2.58
+      '@descope-ui/common': 3.3.2
+      '@descope-ui/theme-globals': 3.3.2
+      '@descope-ui/theme-input-wrapper': 3.3.2
       '@zxcvbn-ts/core': 3.0.4
       '@zxcvbn-ts/language-common': 3.0.4
       '@zxcvbn-ts/language-en': 3.0.2
 
-  '@descope-ui/descope-ponyhot@2.2.58':
+  '@descope-ui/descope-ponyhot@3.3.2':
     dependencies:
-      '@descope-ui/common': 2.2.58
-      '@descope-ui/theme-globals': 2.2.58
+      '@descope-ui/common': 3.3.2
+      '@descope-ui/theme-globals': 3.3.2
 
-  '@descope-ui/descope-recovery-codes@2.2.58':
+  '@descope-ui/descope-recovery-codes@3.3.2':
     dependencies:
-      '@descope-ui/common': 2.2.58
-      '@descope-ui/descope-text': 2.2.58
-      '@descope-ui/theme-globals': 2.2.58
+      '@descope-ui/common': 3.3.2
+      '@descope-ui/descope-text': 3.3.2
+      '@descope-ui/theme-globals': 3.3.2
       '@vaadin/icon': 24.3.4
       '@vaadin/icons': 24.3.4
 
-  '@descope-ui/descope-text@2.2.58':
+  '@descope-ui/descope-text@3.3.2':
     dependencies:
-      '@descope-ui/common': 2.2.58
-      '@descope-ui/theme-globals': 2.2.58
+      '@descope-ui/common': 3.3.2
+      '@descope-ui/theme-globals': 3.3.2
 
-  '@descope-ui/descope-timer-button@2.2.58':
+  '@descope-ui/descope-timer-button@3.3.2':
     dependencies:
-      '@descope-ui/common': 2.2.58
-      '@descope-ui/descope-button': 2.2.58
-      '@descope-ui/descope-timer': 2.2.58
-      '@descope-ui/theme-globals': 2.2.58
+      '@descope-ui/common': 3.3.2
+      '@descope-ui/descope-button': 3.3.2
+      '@descope-ui/descope-timer': 3.3.2
+      '@descope-ui/theme-globals': 3.3.2
 
-  '@descope-ui/descope-timer@2.2.58':
+  '@descope-ui/descope-timer@3.3.2':
     dependencies:
-      '@descope-ui/common': 2.2.58
-      '@descope-ui/descope-icon': 2.2.58
-      '@descope-ui/theme-globals': 2.2.58
+      '@descope-ui/common': 3.3.2
+      '@descope-ui/descope-icon': 3.3.2
+      '@descope-ui/theme-globals': 3.3.2
 
-  '@descope-ui/descope-tooltip@2.2.58':
+  '@descope-ui/descope-tooltip@3.3.2':
     dependencies:
-      '@descope-ui/common': 2.2.58
-      '@descope-ui/descope-enriched-text': 2.2.58
-      '@descope-ui/theme-globals': 2.2.58
+      '@descope-ui/common': 3.3.2
+      '@descope-ui/descope-enriched-text': 3.3.2
+      '@descope-ui/theme-globals': 3.3.2
       '@vaadin/tooltip': 24.3.4
 
-  '@descope-ui/descope-trusted-devices@2.2.58':
+  '@descope-ui/descope-trusted-devices@3.3.2':
     dependencies:
-      '@descope-ui/common': 2.2.58
-      '@descope-ui/descope-badge': 2.2.58
-      '@descope-ui/descope-icon': 2.2.58
-      '@descope-ui/descope-link': 2.2.58
-      '@descope-ui/descope-list': 2.2.58
-      '@descope-ui/descope-list-item': 2.2.58
-      '@descope-ui/descope-text': 2.2.58
-      '@descope-ui/theme-globals': 2.2.58
+      '@descope-ui/common': 3.3.2
+      '@descope-ui/descope-badge': 3.3.2
+      '@descope-ui/descope-icon': 3.3.2
+      '@descope-ui/descope-link': 3.3.2
+      '@descope-ui/descope-list': 3.3.2
+      '@descope-ui/descope-list-item': 3.3.2
+      '@descope-ui/descope-text': 3.3.2
+      '@descope-ui/theme-globals': 3.3.2
 
-  '@descope-ui/theme-globals@2.2.58':
+  '@descope-ui/theme-globals@3.3.2':
     dependencies:
-      '@descope-ui/common': 2.2.58
+      '@descope-ui/common': 3.3.2
 
-  '@descope-ui/theme-input-wrapper@2.2.58':
+  '@descope-ui/theme-input-wrapper@3.3.2':
     dependencies:
-      '@descope-ui/common': 2.2.58
-      '@descope-ui/theme-globals': 2.2.58
+      '@descope-ui/common': 3.3.2
+      '@descope-ui/theme-globals': 3.3.2
 
   '@descope/core-js-sdk@2.40.0':
     dependencies:
@@ -18063,33 +18086,35 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@descope/web-components-ui@2.2.58':
+  '@descope/web-components-ui@3.3.2':
     dependencies:
-      '@descope-ui/common': 2.2.58
-      '@descope-ui/descope-address-field': 2.2.58
-      '@descope-ui/descope-apps-list': 2.2.58
-      '@descope-ui/descope-autocomplete-field': 2.2.58
-      '@descope-ui/descope-avatar': 2.2.58
-      '@descope-ui/descope-badge': 2.2.58
-      '@descope-ui/descope-button': 2.2.58
-      '@descope-ui/descope-collapsible-container': 2.2.58
-      '@descope-ui/descope-combo-box': 2.2.58
-      '@descope-ui/descope-enriched-text': 2.2.58
-      '@descope-ui/descope-icon': 2.2.58
-      '@descope-ui/descope-image': 2.2.58
-      '@descope-ui/descope-link': 2.2.58
-      '@descope-ui/descope-list': 2.2.58
-      '@descope-ui/descope-list-item': 2.2.58
-      '@descope-ui/descope-outbound-app-button': 2.2.58
-      '@descope-ui/descope-outbound-apps': 2.2.58
-      '@descope-ui/descope-password-strength': 2.2.58
-      '@descope-ui/descope-ponyhot': 2.2.58
-      '@descope-ui/descope-recovery-codes': 2.2.58
-      '@descope-ui/descope-text': 2.2.58
-      '@descope-ui/descope-timer': 2.2.58
-      '@descope-ui/descope-timer-button': 2.2.58
-      '@descope-ui/descope-tooltip': 2.2.58
-      '@descope-ui/descope-trusted-devices': 2.2.58
+      '@descope-ui/common': 3.3.2
+      '@descope-ui/descope-address-field': 3.3.2
+      '@descope-ui/descope-apps-list': 3.3.2
+      '@descope-ui/descope-attachment': 3.3.2
+      '@descope-ui/descope-autocomplete-field': 3.3.2
+      '@descope-ui/descope-avatar': 3.3.2
+      '@descope-ui/descope-badge': 3.3.2
+      '@descope-ui/descope-button': 3.3.2
+      '@descope-ui/descope-collapsible-container': 3.3.2
+      '@descope-ui/descope-combo-box': 3.3.2
+      '@descope-ui/descope-country-subdivision-city-field': 3.3.2
+      '@descope-ui/descope-enriched-text': 3.3.2
+      '@descope-ui/descope-icon': 3.3.2
+      '@descope-ui/descope-image': 3.3.2
+      '@descope-ui/descope-link': 3.3.2
+      '@descope-ui/descope-list': 3.3.2
+      '@descope-ui/descope-list-item': 3.3.2
+      '@descope-ui/descope-outbound-app-button': 3.3.2
+      '@descope-ui/descope-outbound-apps': 3.3.2
+      '@descope-ui/descope-password-strength': 3.3.2
+      '@descope-ui/descope-ponyhot': 3.3.2
+      '@descope-ui/descope-recovery-codes': 3.3.2
+      '@descope-ui/descope-text': 3.3.2
+      '@descope-ui/descope-timer': 3.3.2
+      '@descope-ui/descope-timer-button': 3.3.2
+      '@descope-ui/descope-tooltip': 3.3.2
+      '@descope-ui/descope-trusted-devices': 3.3.2
       '@vaadin/checkbox': 24.3.4
       '@vaadin/custom-field': 24.3.4
       '@vaadin/dialog': 24.3.4
@@ -18574,7 +18599,7 @@ snapshots:
   '@eslint/eslintrc@0.4.3':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.1
+      debug: 4.4.3
       espree: 7.3.1
       globals: 13.24.0
       ignore: 4.0.6
@@ -18664,7 +18689,7 @@ snapshots:
   '@humanwhocodes/config-array@0.5.0':
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.4.1
+      debug: 4.4.3
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -19392,21 +19417,21 @@ snapshots:
       inquirer: 8.2.6
       rxjs: 7.8.1
 
-  '@jsonjoy.com/base64@1.1.2(tslib@2.6.3)':
+  '@jsonjoy.com/base64@1.1.2(tslib@2.8.1)':
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
 
-  '@jsonjoy.com/json-pack@1.1.1(tslib@2.6.3)':
+  '@jsonjoy.com/json-pack@1.1.1(tslib@2.8.1)':
     dependencies:
-      '@jsonjoy.com/base64': 1.1.2(tslib@2.6.3)
-      '@jsonjoy.com/util': 1.5.0(tslib@2.6.3)
+      '@jsonjoy.com/base64': 1.1.2(tslib@2.8.1)
+      '@jsonjoy.com/util': 1.5.0(tslib@2.8.1)
       hyperdyperid: 1.2.0
-      thingies: 1.21.0(tslib@2.6.3)
-      tslib: 2.6.3
+      thingies: 1.21.0(tslib@2.8.1)
+      tslib: 2.8.1
 
-  '@jsonjoy.com/util@1.5.0(tslib@2.6.3)':
+  '@jsonjoy.com/util@1.5.0(tslib@2.8.1)':
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   '@leichtgewicht/ip-codec@2.0.5': {}
 
@@ -19824,21 +19849,6 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nrwl/js@19.8.4(@babel/traverse@7.29.0)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.4.5)':
-    dependencies:
-      '@nx/js': 19.8.4(@babel/traverse@7.29.0)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.4.5)
-    transitivePeerDependencies:
-      - '@babel/traverse'
-      - '@swc-node/register'
-      - '@swc/core'
-      - '@swc/wasm'
-      - '@types/node'
-      - debug
-      - nx
-      - supports-color
-      - typescript
-      - verdaccio
-
   '@nrwl/js@19.8.4(@babel/traverse@7.29.0)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)':
     dependencies:
       '@nx/js': 19.8.4(@babel/traverse@7.29.0)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)
@@ -20029,7 +20039,7 @@ snapshots:
       '@babel/preset-env': 7.26.0(@babel/core@7.26.0)
       '@babel/preset-typescript': 7.26.0(@babel/core@7.26.0)
       '@babel/runtime': 7.25.6
-      '@nrwl/js': 19.8.4(@babel/traverse@7.29.0)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.4.5)
+      '@nrwl/js': 19.8.4(@babel/traverse@7.29.0)(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))(typescript@5.7.3)
       '@nx/devkit': 19.8.4(nx@19.8.14(@swc/core@1.7.1(@swc/helpers@0.5.15)))
       '@nx/workspace': 19.8.4(@swc/core@1.7.1(@swc/helpers@0.5.15))
       babel-plugin-const-enum: 1.2.0(@babel/core@7.26.0)
@@ -21321,7 +21331,7 @@ snapshots:
       '@typescript-eslint/type-utils': 6.21.0(eslint@8.57.0)(typescript@5.7.3)
       '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.1
+      debug: 4.4.3
       eslint: 8.57.0
       graphemer: 1.4.0
       ignore: 5.3.2
@@ -21459,7 +21469,7 @@ snapshots:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.7.3)
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.1
+      debug: 4.4.3
       eslint: 8.57.0
     optionalDependencies:
       typescript: 5.7.3
@@ -21578,7 +21588,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.4.5)
       '@typescript-eslint/utils': 5.62.0(eslint@7.32.0)(typescript@5.4.5)
-      debug: 4.4.1
+      debug: 4.4.3
       eslint: 7.32.0
       tsutils: 3.21.0(typescript@5.4.5)
     optionalDependencies:
@@ -21590,7 +21600,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.7.3)
       '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.7.3)
-      debug: 4.4.1
+      debug: 4.4.3
       eslint: 8.57.0
       ts-api-utils: 1.3.0(typescript@5.7.3)
     optionalDependencies:
@@ -21662,7 +21672,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 8.23.0(typescript@5.7.3)
       '@typescript-eslint/utils': 8.23.0(eslint@9.18.0(jiti@1.21.0))(typescript@5.7.3)
-      debug: 4.4.1
+      debug: 4.4.3
       eslint: 9.18.0(jiti@1.21.0)
       ts-api-utils: 2.1.0(typescript@5.7.3)
       typescript: 5.7.3
@@ -21685,7 +21695,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.4.1
+      debug: 4.4.3
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.7.1
@@ -21699,7 +21709,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.1
+      debug: 4.4.3
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
@@ -21804,7 +21814,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.23.0
       '@typescript-eslint/visitor-keys': 8.23.0
-      debug: 4.4.1
+      debug: 4.4.3
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -21818,7 +21828,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.29.0
       '@typescript-eslint/visitor-keys': 8.29.0
-      debug: 4.4.1
+      debug: 4.4.3
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -21832,7 +21842,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.29.0
       '@typescript-eslint/visitor-keys': 8.29.0
-      debug: 4.4.1
+      debug: 4.4.3
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -21846,7 +21856,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.29.0
       '@typescript-eslint/visitor-keys': 8.29.0
-      debug: 4.4.1
+      debug: 4.4.3
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -21860,7 +21870,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.29.0
       '@typescript-eslint/visitor-keys': 8.29.0
-      debug: 4.4.1
+      debug: 4.4.3
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -22817,7 +22827,7 @@ snapshots:
 
   '@vue/compiler-core@3.5.13':
     dependencies:
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.2
       '@vue/shared': 3.5.13
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -22847,14 +22857,14 @@ snapshots:
 
   '@vue/compiler-sfc@3.5.13':
     dependencies:
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.2
       '@vue/compiler-core': 3.5.13
       '@vue/compiler-dom': 3.5.13
       '@vue/compiler-ssr': 3.5.13
       '@vue/shared': 3.5.13
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.6
+      postcss: 8.5.12
       source-map-js: 1.2.1
 
   '@vue/compiler-ssr@3.4.31':
@@ -23234,7 +23244,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -23704,7 +23714,7 @@ snapshots:
 
   base64id@2.0.0: {}
 
-  baseline-browser-mapping@2.10.0:
+  baseline-browser-mapping@2.10.23:
     optional: true
 
   basic-auth@2.0.1:
@@ -23863,10 +23873,10 @@ snapshots:
 
   browserslist@4.28.1:
     dependencies:
-      baseline-browser-mapping: 2.10.0
-      caniuse-lite: 1.0.30001774
-      electron-to-chromium: 1.5.302
-      node-releases: 2.0.27
+      baseline-browser-mapping: 2.10.23
+      caniuse-lite: 1.0.30001791
+      electron-to-chromium: 1.5.344
+      node-releases: 2.0.38
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
     optional: true
 
@@ -23988,7 +23998,7 @@ snapshots:
 
   caniuse-lite@1.0.30001696: {}
 
-  caniuse-lite@1.0.30001774:
+  caniuse-lite@1.0.30001791:
     optional: true
 
   case-sensitive-paths-webpack-plugin@2.4.0: {}
@@ -24855,7 +24865,6 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
-    optional: true
 
   decimal.js@10.4.3: {}
 
@@ -24961,7 +24970,7 @@ snapshots:
   detect-port@1.5.1:
     dependencies:
       address: 1.2.2
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -25023,7 +25032,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.3.1:
+  dompurify@3.4.1:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -25099,7 +25108,7 @@ snapshots:
 
   electron-to-chromium@1.4.825: {}
 
-  electron-to-chromium@1.5.302:
+  electron-to-chromium@1.5.344:
     optional: true
 
   electron-to-chromium@1.5.90: {}
@@ -27297,14 +27306,14 @@ snapshots:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -27389,14 +27398,14 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -27486,7 +27495,7 @@ snapshots:
 
   injection-js@2.4.0:
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   inquirer@8.2.6:
     dependencies:
@@ -27842,7 +27851,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
       istanbul-lib-coverage: 3.2.0
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -29010,7 +29019,7 @@ snapshots:
     dependencies:
       copy-anything: 2.0.6
       parse-node-version: 1.0.1
-      tslib: 2.6.3
+      tslib: 2.8.1
     optionalDependencies:
       errno: 0.1.8
       graceful-fs: 4.2.11
@@ -29024,7 +29033,7 @@ snapshots:
     dependencies:
       copy-anything: 2.0.6
       parse-node-version: 1.0.1
-      tslib: 2.6.3
+      tslib: 2.8.1
     optionalDependencies:
       errno: 0.1.8
       graceful-fs: 4.2.11
@@ -29427,10 +29436,10 @@ snapshots:
 
   memfs@4.17.0:
     dependencies:
-      '@jsonjoy.com/json-pack': 1.1.1(tslib@2.6.3)
-      '@jsonjoy.com/util': 1.5.0(tslib@2.6.3)
-      tree-dump: 1.0.2(tslib@2.6.3)
-      tslib: 2.6.3
+      '@jsonjoy.com/json-pack': 1.1.1(tslib@2.8.1)
+      '@jsonjoy.com/util': 1.5.0(tslib@2.8.1)
+      tree-dump: 1.0.2(tslib@2.8.1)
+      tslib: 2.8.1
 
   meow@12.1.1: {}
 
@@ -29863,7 +29872,7 @@ snapshots:
 
   node-releases@2.0.19: {}
 
-  node-releases@2.0.27:
+  node-releases@2.0.38:
     optional: true
 
   nopt@7.2.1:
@@ -30848,6 +30857,12 @@ snapshots:
   postcss@8.5.1:
     dependencies:
       nanoid: 3.3.8
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.12:
+    dependencies:
+      nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -32138,7 +32153,7 @@ snapshots:
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.1
+      debug: 4.4.3
       socks: 2.8.3
     transitivePeerDependencies:
       - supports-color
@@ -32197,7 +32212,7 @@ snapshots:
 
   spdy-transport@3.0.0:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -32208,7 +32223,7 @@ snapshots:
 
   spdy@4.0.2:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
@@ -32573,9 +32588,9 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
-  thingies@1.21.0(tslib@2.6.3):
+  thingies@1.21.0(tslib@2.8.1):
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   thread-loader@3.0.4(webpack@5.93.0(@swc/core@1.7.1(@swc/helpers@0.5.15))):
     dependencies:
@@ -32632,9 +32647,9 @@ snapshots:
     dependencies:
       punycode: 2.3.0
 
-  tree-dump@1.0.2(tslib@2.6.3):
+  tree-dump@1.0.2(tslib@2.8.1):
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   tree-kill@1.2.2: {}
 
@@ -33060,7 +33075,7 @@ snapshots:
   tuf-js@3.0.1:
     dependencies:
       '@tufjs/models': 3.0.1
-      debug: 4.4.1
+      debug: 4.4.3
       make-fetch-happen: 14.0.3
     transitivePeerDependencies:
       - supports-color
@@ -33329,7 +33344,7 @@ snapshots:
 
   vue-eslint-parser@8.3.0(eslint@7.32.0):
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
       eslint: 7.32.0
       eslint-scope: 7.2.2
       eslint-visitor-keys: 3.4.3


### PR DESCRIPTION
## Summary

- Adds a three-state localStorage flag (`DSP_LAST_AUTH_<projectId>`) written by `withPersistTokens` hooks: `'auth'` on every successful login/refresh response, `'unauth'` on logout or server-confirmed session invalidation
- Adds `options?: { skipIfNoSession?: boolean }` to `sdk.refresh()` in `web-js-sdk`; when opted in, the flag drives a skip-or-call-through decision before any network call
- New `decodeProjectCreatedAt()` helper in `sdk-helpers` decodes the KSUID timestamp from a project ID (last-27-chars rule, byte-array arithmetic, no BigInt) so brand-new projects can skip the bootstrap call entirely
- React, Vue, and Angular SDKs pass `{ skipIfNoSession: true }` at their refresh call sites; NextJS inherits the fix via the React SDK

**Decision tree on mount (when `skipIfNoSession: true`):**
| State | Action |
|---|---|
| Session or refresh token present | Call through (may be HttpOnly cookie) |
| `getExternalToken` configured | Call through |
| Flag = `'auth'` | Call through |
| Flag = `'unauth'` | Skip — return `{ ok: true }` |
| Flag absent + new project (KSUID > cutoff) | Skip — no legacy users possible |
| Flag absent + old/unknown project | Bootstrap call (upgrade safety) |

Related: https://github.com/descope/etc/issues/13959

## Test plan

- [ ] `packages/libs/sdk-helpers/test/ksuid.spec.ts` — 7 new tests for `decodeProjectCreatedAt` (null cases, epoch, real project IDs, prefix-length independence)
- [ ] `packages/sdks/web-js-sdk/test/skipRefresh.test.ts` — 9 new tests covering all skip/call-through branches
- [ ] `packages/sdks/web-js-sdk/test/persistTokens.test.ts` — 4 new tests verifying `DSP_LAST_AUTH` flag writes on auth, logout, and session invalidation; confirms `storagePrefix` is not applied to the flag
- [ ] `packages/sdks/react-sdk/test/components/App.test.tsx` — assertion updated to verify `refresh` receives `{ skipIfNoSession: true }` as third argument
- [ ] Manual: fresh browser profile, network tab open — load page → 0 `/refresh` calls; log in → reload → 1 call; log out → reload → 0 calls
- [ ] Update `SKIP_INITIAL_REFRESH_FOR_PROJECTS_AFTER` to actual release date + buffer before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)