### PR TITLE
feat(wc): add externalAuthRedirect to nativeOptions

### DIFF
--- a/packages/sdks/core-js-sdk/src/sdk/types.ts
+++ b/packages/sdks/core-js-sdk/src/sdk/types.ts
@@ -24,6 +24,9 @@ type NativeOptions = {
 
   /** An override for web OAuth that sets the address to redirect to after authentication succeeds at the OAuth provider website */
   oauthRedirect?: string;
+
+  /** An override for external authentication that sets the address to redirect to after authentication succeeds at the external auth provider */
+  externalAuthRedirect?: string;
 };
 
 type AuthMethod =

--- a/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
+++ b/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
@@ -240,6 +240,7 @@ class DescopeWc extends BaseDescopeWc {
     oauthRedirect?: string;
     magicLinkRedirect?: string;
     ssoRedirect?: string;
+    externalAuthRedirect?: string;
     origin?: string;
   };
 
@@ -678,6 +679,7 @@ class DescopeWc extends BaseDescopeWc {
           oauthRedirect: this.nativeOptions.oauthRedirect,
           magicLinkRedirect: this.nativeOptions.magicLinkRedirect,
           ssoRedirect: this.nativeOptions.ssoRedirect,
+          externalAuthRedirect: this.nativeOptions.externalAuthRedirect,
         }
       : undefined;
     let conditionComponentsConfig: ComponentsConfig = {};


### PR DESCRIPTION
## Related Issues
https://github.com/descope/etc/issues/15077

## Description
- Add `externalAuthRedirect` to the `NativeOptions` type in `core-js-sdk` and to the web-component's `nativeOptions` shape
- Forward it through the flow-start payload alongside `oauthRedirect`, `magicLinkRedirect`, and `ssoRedirect`

## Must
- [ ] Tests
- [ ] Documentation