### PR TITLE
docs(react-sdk,nextjs-sdk): improve auto-refresh section in READMEs

### DIFF
--- a/packages/sdks/nextjs-sdk/README.md
+++ b/packages/sdks/nextjs-sdk/README.md
@@ -127,6 +127,17 @@ const App = () => {
 };
 ```
 
+#### Trigger Auto Refresh
+
+`useSession` triggers a single request to the Descope backend to attempt to refresh the session. If you **don't** `useSession` on your app, the session will not be refreshed automatically. If your app does not require `useSession`, you can trigger the refresh manually by calling `refresh` from `useDescope` hook. Example:
+
+```js
+const { refresh } = useDescope();
+useEffect(() => {
+  refresh();
+}, [refresh]);
+```
+
 #### Server Side Usage
 
 ##### Require authentication for application (Middleware)

--- a/packages/sdks/nextjs-sdk/README.md
+++ b/packages/sdks/nextjs-sdk/README.md
@@ -129,12 +129,14 @@ const App = () => {
 
 #### Trigger Auto Refresh
 
-`useSession` triggers a single request to the Descope backend to attempt to refresh the session. If you **don't** `useSession` on your app, the session will not be refreshed automatically. If your app does not require `useSession`, you can trigger the refresh manually by calling `refresh` from `useDescope` hook. Example:
+`useSession` triggers a single request to the Descope backend to attempt to refresh the session. If you **don't** `useSession` in your app, the session will not be refreshed automatically. If your app does not require `useSession`, you can trigger the refresh manually by calling `refresh` from `useDescope` hook. Example:
 
 ```js
+import { useEffect } from 'react';
+
 const { refresh } = useDescope();
 useEffect(() => {
-  refresh();
+  refresh().catch(console.error);
 }, [refresh]);
 ```
 

--- a/packages/sdks/react-sdk/README.md
+++ b/packages/sdks/react-sdk/README.md
@@ -315,7 +315,7 @@ const App = () => {
 
 ### Trigger Auto Refresh
 
-`useSession` triggers a single request to the Descope backend to attempt to refresh the session. If you **don't** `useSession` on your app, the session will not be refreshed automatically. If your app does not require `useSession`, you can trigger the refresh manually by calling `refresh` from `useDescope` hook. Example:
+`useSession` triggers a single request to the Descope backend to attempt to refresh the session. If you **don't** `useSession` in your app, the session will not be refreshed automatically. If your app does not require `useSession`, you can trigger the refresh manually by calling `refresh` from `useDescope` hook. Example:
 
 ```js
 const { refresh } = useDescope();

--- a/packages/sdks/react-sdk/README.md
+++ b/packages/sdks/react-sdk/README.md
@@ -313,7 +313,9 @@ const App = () => {
 };
 ```
 
-Note: `useSession` triggers a single request to the Descope backend to attempt to refresh the session. If you **don't** `useSession` on your app, the session will not be refreshed automatically. If your app does not require `useSession`, you can trigger the refresh manually by calling `refresh` from `useDescope` hook. Example:
+### Trigger Auto Refresh
+
+`useSession` triggers a single request to the Descope backend to attempt to refresh the session. If you **don't** `useSession` on your app, the session will not be refreshed automatically. If your app does not require `useSession`, you can trigger the refresh manually by calling `refresh` from `useDescope` hook. Example:
 
 ```js
 const { refresh } = useDescope();


### PR DESCRIPTION
## Related Issues
Fixes: https://github.com/descope/etc/issues/15284

## Description
Improves documentation for triggering auto-refresh in both the React SDK and Next.js SDK READMEs. The React SDK's existing inline note is promoted to a proper `### Trigger Auto Refresh` section with a heading. The Next.js SDK gains a new `#### Trigger Auto Refresh` section that was missing entirely.

## Must
- [ ] Tests
- [ ] Documentation (if applicable)