### PR TITLE
feat(web-js-sdk): opt-in tryRefresh optimization using DSL cookie

### DIFF
--- a/packages/sdks/web-js-sdk/src/enhancers/withPersistTokens/constants.ts
+++ b/packages/sdks/web-js-sdk/src/enhancers/withPersistTokens/constants.ts
@@ -8,3 +8,7 @@ export const ID_TOKEN_KEY = 'DSI';
 export const TRUSTED_DEVICE_TOKEN_KEY = 'DTD';
 /* Key for persisting the server-returned refresh cookie name */
 export const REFRESH_COOKIE_NAME_KEY = 'DSRCN';
+/* Non-HttpOnly cookie set by backend on login — used to skip the tryRefresh network call when absent */
+export const LOGGED_IN_COOKIE_KEY = 'DSL';
+/* localStorage key that must be set to 'true' to enable the DSL-cookie-based tryRefresh optimization */
+export const REFRESH_OPTIMIZATION_KEY = 'DSLO';

--- a/packages/sdks/web-js-sdk/src/enhancers/withPersistTokens/helpers.ts
+++ b/packages/sdks/web-js-sdk/src/enhancers/withPersistTokens/helpers.ts
@@ -3,6 +3,7 @@ import Cookies from 'js-cookie';
 import { BeforeRequestHook, WebJWTResponse } from '../../types';
 import {
   ID_TOKEN_KEY,
+  LOGGED_IN_COOKIE_KEY,
   REFRESH_COOKIE_NAME_KEY,
   REFRESH_TOKEN_KEY,
   SESSION_TOKEN_KEY,
@@ -228,6 +229,11 @@ export function getTrustedDeviceToken(prefix: string = ''): string {
 /** Return the server-returned refresh cookie name from localStorage, if available */
 export function getStoredRefreshCookieName(prefix: string = ''): string | null {
   return getLocalStorage(`${prefix}${REFRESH_COOKIE_NAME_KEY}`);
+}
+
+/** Returns true if the backend-set DSL login cookie is present, indicating the user has an active session */
+export function hasLoggedInCookie(): boolean {
+  return !!Cookies.get(LOGGED_IN_COOKIE_KEY);
 }
 
 /** Remove auth tokens from localStorage (refresh JWT, session JWT, ID token, server-returned refresh cookie name)

--- a/packages/sdks/web-js-sdk/src/sdk/index.ts
+++ b/packages/sdks/web-js-sdk/src/sdk/index.ts
@@ -5,7 +5,10 @@ import withFlow from './flow';
 import {
   getSessionToken,
   getRefreshToken,
+  hasLoggedInCookie,
 } from '../enhancers/withPersistTokens/helpers';
+import { REFRESH_OPTIMIZATION_KEY } from '../enhancers/withPersistTokens/constants';
+import { getLocalStorage } from '../enhancers/helpers';
 import createOidc from './oidc';
 import { CoreSdk, WebSdkConfig } from '../types';
 import {
@@ -37,6 +40,18 @@ const createSdk = (config: WebSdkConfig) => {
               'Refresh is not supported in native flows via the web SDK',
           },
         });
+      }
+
+      // Skip the network call entirely when the user has never logged in (no DSL cookie).
+      // This avoids a round-trip on every page load for unauthenticated visitors.
+      // Currently opt-in: set localStorage key 'DSLO' to 'true' to enable.
+      // Will be enabled by default once all projects are ensured to have this cookie set, taking into account their refresh token expiration.
+      if (
+        tryRefresh &&
+        getLocalStorage(REFRESH_OPTIMIZATION_KEY) === 'true' &&
+        !hasLoggedInCookie()
+      ) {
+        return Promise.resolve({ ok: true });
       }
 
       if (config.oidcConfig) {

--- a/packages/sdks/web-js-sdk/test/persistTokens.test.ts
+++ b/packages/sdks/web-js-sdk/test/persistTokens.test.ts
@@ -3,6 +3,7 @@ import {
   getIdToken,
   getSessionToken,
   getRefreshToken,
+  hasLoggedInCookie,
 } from '../src/enhancers/withPersistTokens/helpers';
 import createSdk from '../src/index';
 import { authInfo, oidcAuthInfo } from './mocks';
@@ -1212,6 +1213,29 @@ describe('persistTokens', () => {
       localStorage.setItem('DSI', 'id-token-1');
 
       expect(getIdToken()).toEqual('id-token-1');
+    });
+  });
+
+  describe('hasLoggedInCookie', () => {
+    it('should return true when DSL cookie is present', () => {
+      const getMock = Cookies.get as jest.Mock;
+      getMock.mockReturnValue('1');
+      expect(hasLoggedInCookie()).toBe(true);
+      expect(getMock).toHaveBeenCalledWith('DSL');
+    });
+
+    it('should return false when DSL cookie is absent', () => {
+      const getMock = Cookies.get as jest.Mock;
+      getMock.mockReturnValue(undefined);
+      expect(hasLoggedInCookie()).toBe(false);
+      expect(getMock).toHaveBeenCalledWith('DSL');
+    });
+
+    it('should return false when DSL cookie is an empty string', () => {
+      const getMock = Cookies.get as jest.Mock;
+      getMock.mockReturnValue('');
+      expect(hasLoggedInCookie()).toBe(false);
+      expect(getMock).toHaveBeenCalledWith('DSL');
     });
   });
 

--- a/packages/sdks/web-js-sdk/test/sdk.test.ts
+++ b/packages/sdks/web-js-sdk/test/sdk.test.ts
@@ -177,4 +177,68 @@ describe('sdk', () => {
     expect(SESSION_TOKEN_KEY).toBeDefined();
     expect(REFRESH_TOKEN_KEY).toBeDefined();
   });
+
+  describe('tryRefresh + DSL cookie optimization', () => {
+    const clearDslCookie = () => {
+      document.cookie = 'DSL=; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+    };
+    const setDslCookie = () => {
+      document.cookie = 'DSL=1';
+    };
+
+    beforeEach(() => {
+      clearDslCookie();
+      localStorage.removeItem('DSLO');
+    });
+
+    it('should call fetch when DSLO opt-in key is not set, even without DSL cookie', async () => {
+      clearDslCookie();
+      // DSLO not set — optimization is off by default
+      const mockFetch = jest
+        .fn()
+        .mockReturnValue(createMockReturnValue(flowResponse));
+      global.fetch = mockFetch;
+      const sdk = createSdk({ projectId: 'pid' });
+      await sdk.refresh(undefined, true);
+      expect(mockFetch).toHaveBeenCalled();
+    });
+
+    it('should skip fetch when DSLO is enabled and DSL cookie is absent', async () => {
+      clearDslCookie();
+      localStorage.setItem('DSLO', 'true');
+      const mockFetch = jest
+        .fn()
+        .mockReturnValue(createMockReturnValue(flowResponse));
+      global.fetch = mockFetch;
+      const sdk = createSdk({ projectId: 'pid' });
+      const result = await sdk.refresh(undefined, true);
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(result).toEqual({ ok: true });
+    });
+
+    it('should call fetch when DSLO is enabled and DSL cookie is present', async () => {
+      setDslCookie();
+      localStorage.setItem('DSLO', 'true');
+      const mockFetch = jest
+        .fn()
+        .mockReturnValue(createMockReturnValue(flowResponse));
+      global.fetch = mockFetch;
+      const sdk = createSdk({ projectId: 'pid' });
+      await sdk.refresh(undefined, true);
+      expect(mockFetch).toHaveBeenCalled();
+    });
+
+    it('should call fetch when DSLO is enabled but tryRefresh is false', async () => {
+      clearDslCookie();
+      localStorage.setItem('DSLO', 'true');
+      const mockFetch = jest
+        .fn()
+        .mockReturnValue(createMockReturnValue(flowResponse));
+      global.fetch = mockFetch;
+      const sdk = createSdk({ projectId: 'pid' });
+      // regular refresh (not tryRefresh) — optimization must not apply
+      await sdk.refresh(undefined, false);
+      expect(mockFetch).toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
## Related issues
https://github.com/descope/etc/issues/15235

## Summary

- Adds a `hasLoggedInCookie()` helper that checks for the backend-set `DSL` cookie (non-HttpOnly, set on login)
- When `tryRefresh=true`, `sdk.refresh()` now skips the network call entirely if the `DSL` cookie is absent — avoiding a round-trip for unauthenticated visitors
- Gated behind a localStorage opt-in key (`DSLO=true`) until all projects are confirmed to have this cookie set, taking into account their refresh token expiration

**To enable:**
```ts
localStorage.setItem('DSLO', 'true');
```

## New constants
- `LOGGED_IN_COOKIE_KEY = 'DSL'` — the cookie name set by the backend on login
- `REFRESH_OPTIMIZATION_KEY = 'DSLO'` — the localStorage opt-in flag

## Test plan
- [ ] `hasLoggedInCookie` unit tests (present / absent / empty string) in `persistTokens.test.ts`
- [ ] Integration tests in `sdk.test.ts`: opt-in off by default, skip when DSL absent, proceed when DSL present, no skip on regular `refresh()` (non-tryRefresh)
- [ ] All 228 existing + new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)