### PR TITLE
feat(wc): support multiple consecutive sdk script runs

### DIFF
--- a/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
+++ b/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
@@ -327,12 +327,12 @@ class DescopeWc extends BaseDescopeWc {
               newScriptElement.setAttribute('data-script-id', script.id);
               newScriptElement.moduleRes = moduleRes;
               this.shadowRoot.appendChild(newScriptElement);
-              const unsubscribe = this.nextRequestStatus.subscribe(() => {
+              const subscriptionToken = this.nextRequestStatus.subscribe(() => {
                 this.loggerWrapper.debug('Stopping script', script.id);
                 // if the script is stopped successfully, we want to remove it from the DOM
                 // to allow the script element to be re-created on the next request
                 if (moduleRes.stop?.()) {
-                  this.nextRequestStatus.unsubscribe(unsubscribe);
+                  this.nextRequestStatus.unsubscribe(subscriptionToken);
                   this.loggerWrapper.debug('Removing script', script.id);
                   this.shadowRoot.removeChild(newScriptElement);
                 }

--- a/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
+++ b/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
@@ -302,11 +302,13 @@ class DescopeWc extends BaseDescopeWc {
           moduleRes?.start?.();
           return moduleRes;
         }
-        await this.injectNpmLib(
-          '@descope/flow-scripts',
-          '1.0.14', // currently using a fixed version when loading scripts
-          `dist/${script.id}.js`,
-        );
+        if (!globalThis.descope?.[script.id]) {
+          await this.injectNpmLib(
+            '@descope/flow-scripts',
+            '1.0.16', // currently using a fixed version when loading scripts
+            `dist/${script.id}.js`,
+          );
+        }
         const module = globalThis.descope?.[script.id];
         return new Promise((resolve, reject) => {
           try {
@@ -325,9 +327,15 @@ class DescopeWc extends BaseDescopeWc {
               newScriptElement.setAttribute('data-script-id', script.id);
               newScriptElement.moduleRes = moduleRes;
               this.shadowRoot.appendChild(newScriptElement);
-              this.nextRequestStatus.subscribe(() => {
-                this.loggerWrapper.debug('Unloading script', script.id);
-                moduleRes.stop?.();
+              const unsubscribe = this.nextRequestStatus.subscribe(() => {
+                this.loggerWrapper.debug('Stopping script', script.id);
+                // if the script is stopped successfully, we want to remove it from the DOM
+                // to allow the script element to be re-created on the next request
+                if (moduleRes.stop?.()) {
+                  this.nextRequestStatus.unsubscribe(unsubscribe);
+                  this.loggerWrapper.debug('Removing script', script.id);
+                  this.shadowRoot.removeChild(newScriptElement);
+                }
               });
             }
           } catch (e) {

--- a/packages/sdks/web-component/test/descope-wc.clientScripts.test.ts
+++ b/packages/sdks/web-component/test/descope-wc.clientScripts.test.ts
@@ -357,5 +357,143 @@ describe('web-component', () => {
         }),
       );
     });
+
+    it('should skip npm lib injection when script is already available in globalThis.descope', async () => {
+      startMock.mockReturnValueOnce(generateSdkResponse());
+      const mockForterScript = jest.fn(() => ({
+        id: 'forter',
+        start: jest.fn(),
+        stop: jest.fn(),
+        refresh: jest.fn(),
+        present: jest.fn(),
+      }));
+      window.descope = { forter: mockForterScript };
+
+      fixtures.configContent = {
+        flows: {
+          'sign-in': {
+            startScreenId: 'screen-0',
+            sdkScripts: [
+              {
+                id: 'forter',
+                initArgs: { siteId: 'some-site-id' },
+                resultKey: 'some-result-key',
+              },
+            ],
+          },
+        },
+      };
+
+      fixtures.pageContent = `<descope-button type="button" id="interactionId">Click</descope-button>`;
+
+      document.body.innerHTML = `<h1>Custom element test</h1> <descope-wc flow-id="sign-in" project-id="1"></descope-wc>`;
+
+      // module is called directly from globalThis.descope without needing scriptMock.onload()
+      await waitFor(() => expect(mockForterScript).toHaveBeenCalled(), {
+        timeout: WAIT_TIMEOUT,
+      });
+
+      // no script element should have been injected into document.body
+      const appendCalls = (document.body.append as jest.Mock).mock.calls;
+      const scriptWasInjected = appendCalls.some(
+        ([el]: [HTMLElement]) => el?.localName === 'script',
+      );
+      expect(scriptWasInjected).toBe(false);
+    });
+
+    describe('sdk script stop behavior', () => {
+      let mockStopFn: jest.Mock;
+      let mockForterScript: jest.Mock;
+
+      beforeEach(() => {
+        startMock.mockReturnValueOnce(generateSdkResponse());
+        nextMock.mockReturnValue(generateSdkResponse());
+
+        mockStopFn = jest.fn();
+        mockForterScript = jest.fn(() => ({
+          id: 'forter',
+          start: jest.fn(),
+          stop: mockStopFn,
+          refresh: jest.fn(),
+          present: jest.fn(),
+        }));
+        window.descope = { forter: mockForterScript };
+
+        fixtures.configContent = {
+          flows: {
+            'sign-in': {
+              startScreenId: 'screen-0',
+              sdkScripts: [
+                {
+                  id: 'forter',
+                  initArgs: { siteId: 'some-site-id' },
+                  resultKey: 'some-result-key',
+                },
+              ],
+            },
+          },
+        };
+
+        fixtures.pageContent = `<descope-button type="button" id="submitterId">Click</descope-button>`;
+      });
+
+      it('should remove script element from DOM and unsubscribe when stop returns truthy', async () => {
+        mockStopFn.mockReturnValue(true);
+
+        document.body.innerHTML = `<h1>Custom element test</h1> <descope-wc flow-id="sign-in" project-id="1"></descope-wc>`;
+
+        await waitFor(() => screen.findByShadowText('Click'), {
+          timeout: WAIT_TIMEOUT,
+        });
+        await waitFor(() => expect(mockForterScript).toHaveBeenCalled(), {
+          timeout: WAIT_TIMEOUT,
+        });
+
+        const wc = document.querySelector('descope-wc');
+        expect(
+          wc.shadowRoot.querySelector('[data-script-id="forter"]'),
+        ).toBeTruthy();
+
+        fireEvent.click(screen.getByShadowText('Click'));
+
+        await waitFor(
+          () =>
+            expect(
+              wc.shadowRoot.querySelector('[data-script-id="forter"]'),
+            ).toBeNull(),
+          { timeout: WAIT_TIMEOUT },
+        );
+
+        expect(mockStopFn).toHaveBeenCalledTimes(1);
+      });
+
+      it('should not remove script element from DOM when stop returns falsy', async () => {
+        mockStopFn.mockReturnValue(false);
+
+        document.body.innerHTML = `<h1>Custom element test</h1> <descope-wc flow-id="sign-in" project-id="1"></descope-wc>`;
+
+        await waitFor(() => screen.findByShadowText('Click'), {
+          timeout: WAIT_TIMEOUT,
+        });
+        await waitFor(() => expect(mockForterScript).toHaveBeenCalled(), {
+          timeout: WAIT_TIMEOUT,
+        });
+
+        const wc = document.querySelector('descope-wc');
+        expect(
+          wc.shadowRoot.querySelector('[data-script-id="forter"]'),
+        ).toBeTruthy();
+
+        fireEvent.click(screen.getByShadowText('Click'));
+
+        await waitFor(() => expect(mockStopFn).toHaveBeenCalled(), {
+          timeout: WAIT_TIMEOUT,
+        });
+
+        expect(
+          wc.shadowRoot.querySelector('[data-script-id="forter"]'),
+        ).toBeTruthy();
+      });
+    });
   });
 });

--- a/packages/sdks/web-component/test/descope-wc.clientScripts.test.ts
+++ b/packages/sdks/web-component/test/descope-wc.clientScripts.test.ts
@@ -386,6 +386,9 @@ describe('web-component', () => {
 
       fixtures.pageContent = `<descope-button type="button" id="interactionId">Click</descope-button>`;
 
+      // Spy on appendChild to verify no script injection
+      const appendChildSpy = jest.spyOn(document.body, 'appendChild');
+
       document.body.innerHTML = `<h1>Custom element test</h1> <descope-wc flow-id="sign-in" project-id="1"></descope-wc>`;
 
       // module is called directly from globalThis.descope without needing scriptMock.onload()
@@ -394,11 +397,13 @@ describe('web-component', () => {
       });
 
       // no script element should have been injected into document.body
-      const appendCalls = (document.body.append as jest.Mock).mock.calls;
-      const scriptWasInjected = appendCalls.some(
+      const appendChildCalls = appendChildSpy.mock.calls;
+      const scriptWasInjected = appendChildCalls.some(
         ([el]: [HTMLElement]) => el?.localName === 'script',
       );
       expect(scriptWasInjected).toBe(false);
+
+      appendChildSpy.mockRestore();
     });
 
     describe('sdk script stop behavior', () => {


### PR DESCRIPTION
## Related Issues

Fixes: https://github.com/descope/etc/issues/15385

## Related PRs

### Upstream PRs
- https://github.com/descope/content/pull/1814

## Description

Enables consecutive `sdkScripts` runs (e.g. multiple reCAPTCHA executions with different `action`s/site keys) to work correctly without leaking stale script instances.

- `DescopeWc.ts`: Skip `injectNpmLib` when the script is already available on `globalThis.descope` (avoids re-fetching/re-attaching on subsequent runs).
- `DescopeWc.ts`: Use the return value of `moduleRes.stop?.()` to confirm the previous module was actually torn down before removing the `<script>` element from the shadow DOM and unsubscribing the listener. This pairs with the upstream `flow-scripts` change where `grecaptcha.stopTimer` now returns `true`.
- Bumps `@descope/flow-scripts` to `1.0.16`.

## Must

- [x] Tests — added coverage for the skip-injection path and both truthy/falsy `stop()` outcomes.
- [x] Documentation — N/A

Made with [Cursor](https://cursor.com)