### PR TITLE
fix(web-js-sdk): clear tokens before OIDC logout navigation

### DIFF
--- a/packages/sdks/web-js-sdk/src/constants.ts
+++ b/packages/sdks/web-js-sdk/src/constants.ts
@@ -13,6 +13,10 @@ export const REFRESH_THRESHOLD = 20 * 1000; // 20 sec
 export const OIDC_CLIENT_TS_DESCOPE_CDN_URL = `https://descopecdn.com/npm/oidc-client-ts@${OIDC_CLIENT_TS_VERSION}/dist/browser/oidc-client-ts.min.js`;
 export const OIDC_CLIENT_TS_JSDELIVR_CDN_URL = `https://cdn.jsdelivr.net/npm/oidc-client-ts@${OIDC_CLIENT_TS_VERSION}/dist/browser/oidc-client-ts.min.js`;
 
+// Synthetic path used as an afterRequest signal when oidc.logout fires,
+// so withPersistTokens clears tokens before the browser navigates away.
+export const OIDC_LOGOUT_SIGNAL_PATH = 'oidc/logout/signal';
+
 export const OIDC_LOGOUT_ERROR_CODE = 'J161000';
 export const OIDC_REFRESH_ERROR_CODE = 'J161001';
 

--- a/packages/sdks/web-js-sdk/src/enhancers/helpers/index.ts
+++ b/packages/sdks/web-js-sdk/src/enhancers/helpers/index.ts
@@ -6,10 +6,10 @@ import {
   WebSigninResponse,
 } from '../../types';
 import { jwtDecode, JwtPayload } from 'jwt-decode';
-import { IS_BROWSER } from '../../constants';
+import { IS_BROWSER, OIDC_LOGOUT_SIGNAL_PATH } from '../../constants';
 
-// Routes where a failed response indicates an invalid/expired session
-// Other routes (like OTP verify) may fail for invalid input, not session expiration
+// Routes where a failed response indicates an invalid/expired session.
+// Other routes (like OTP verify) may fail for invalid input, not session expiration.
 const SESSION_VALIDATION_ROUTES = [
   '/v1/auth/refresh',
   '/v1/auth/try-refresh',
@@ -167,9 +167,10 @@ export const isInvalidSessionResponse = (
   req: { path?: string },
   res: Response | undefined,
 ): boolean => {
+  const path = req?.path || '';
+  if (path === OIDC_LOGOUT_SIGNAL_PATH) return true;
   const is4xx = res?.status >= 400 && res?.status < 500;
   if (!is4xx) return false;
-  const path = req?.path || '';
   return SESSION_VALIDATION_ROUTES.includes(path);
 };
 

--- a/packages/sdks/web-js-sdk/src/enhancers/withPersistTokens/index.ts
+++ b/packages/sdks/web-js-sdk/src/enhancers/withPersistTokens/index.ts
@@ -139,14 +139,14 @@ const logoutWrapper =
   ): SdkFnWrapper<{}> =>
   (fn) =>
   async (...args) => {
-    const resp = await fn(...args);
-
     clearTokens(
       prefix,
       sessionTokenViaCookie,
       refreshTokenViaCookie,
       getCookieOptions?.(),
     );
+
+    const resp = await fn(...args);
 
     return resp;
   };

--- a/packages/sdks/web-js-sdk/src/enhancers/withPersistTokens/index.ts
+++ b/packages/sdks/web-js-sdk/src/enhancers/withPersistTokens/index.ts
@@ -139,14 +139,14 @@ const logoutWrapper =
   ): SdkFnWrapper<{}> =>
   (fn) =>
   async (...args) => {
+    const resp = await fn(...args);
+
     clearTokens(
       prefix,
       sessionTokenViaCookie,
       refreshTokenViaCookie,
       getCookieOptions?.(),
     );
-
-    const resp = await fn(...args);
 
     return resp;
   };

--- a/packages/sdks/web-js-sdk/src/sdk/oidc/index.ts
+++ b/packages/sdks/web-js-sdk/src/sdk/oidc/index.ts
@@ -10,6 +10,7 @@ import type {
 import {
   OIDC_CLIENT_TS_DESCOPE_CDN_URL,
   OIDC_CLIENT_TS_JSDELIVR_CDN_URL,
+  OIDC_LOGOUT_SIGNAL_PATH,
 } from '../../constants';
 import { getIdToken } from '../../enhancers/withPersistTokens/helpers';
 import {
@@ -263,6 +264,12 @@ const createOidc = (
     const res = await client.createSignoutRequest(arg);
     const { url } = res;
     removeLocalStorage(stateUserKey);
+    // Signal withPersistTokens to clear tokens before the browser navigates away.
+    // Mirrors how finishLogin calls afterRequest to persist tokens.
+    await sdk.httpClient.hooks?.afterRequest(
+      { path: OIDC_LOGOUT_SIGNAL_PATH } as RequestConfig,
+      undefined as unknown as Response,
+    );
     if (!disableNavigation) {
       window.location.replace(url);
     }

--- a/packages/sdks/web-js-sdk/test/persistTokens.test.ts
+++ b/packages/sdks/web-js-sdk/test/persistTokens.test.ts
@@ -1105,6 +1105,7 @@ describe('persistTokens', () => {
 
     it('should clear tokens before navigation on OIDC logout', async () => {
       localStorage.setItem('DSR', authInfo.refreshJwt);
+      localStorage.setItem('DSI', 'id-token-1');
 
       let dsrPresentAtNavigation: boolean | undefined;
       const location = Object.defineProperties(
@@ -1139,6 +1140,10 @@ describe('persistTokens', () => {
 
       // DSR must already be gone when window.location.replace fires
       expect(dsrPresentAtNavigation).toBe(false);
+      // id_token_hint must be read from DSI before tokens are cleared
+      expect(mockCreateSignoutRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ id_token_hint: 'id-token-1' }),
+      );
     });
 
     it('should clear refresh token cookie on logout', async () => {

--- a/packages/sdks/web-js-sdk/test/persistTokens.test.ts
+++ b/packages/sdks/web-js-sdk/test/persistTokens.test.ts
@@ -30,6 +30,16 @@ jest.mock('js-cookie', () => ({
   remove: jest.fn(),
 }));
 
+const mockCreateSignoutRequest = jest
+  .fn()
+  .mockResolvedValue({ url: 'https://logout-url.com' });
+jest.mock('oidc-client-ts', () => ({
+  OidcClient: jest.fn().mockImplementation(() => ({
+    createSignoutRequest: mockCreateSignoutRequest,
+  })),
+  WebStorageStateStore: jest.fn(),
+}));
+
 describe('persistTokens', () => {
   afterEach(() => {
     localStorage.setItem('DSR', '');
@@ -1091,6 +1101,44 @@ describe('persistTokens', () => {
       const removeMock = Cookies.remove as jest.Mock;
       expect(removeMock).toHaveBeenCalledWith('DS', undefined);
       expect(removeMock).toHaveBeenCalledWith('DSR', undefined);
+    });
+
+    it('should clear tokens before navigation on OIDC logout', async () => {
+      localStorage.setItem('DSR', authInfo.refreshJwt);
+
+      let dsrPresentAtNavigation: boolean | undefined;
+      const location = Object.defineProperties(
+        {},
+        {
+          ...Object.getOwnPropertyDescriptors(window.location),
+          replace: {
+            enumerable: true,
+            value: jest.fn(() => {
+              dsrPresentAtNavigation = !!localStorage.getItem('DSR');
+            }),
+          },
+          href: {
+            enumerable: true,
+            value: 'http://localhost/',
+            writable: true,
+          },
+        },
+      );
+      Object.defineProperty(window, 'location', {
+        enumerable: true,
+        configurable: true,
+        get: () => location,
+      });
+
+      const sdk = createSdk({
+        projectId: 'pid',
+        oidcConfig: true,
+        persistTokens: true,
+      });
+      await sdk.logout();
+
+      // DSR must already be gone when window.location.replace fires
+      expect(dsrPresentAtNavigation).toBe(false);
     });
 
     it('should clear refresh token cookie on logout', async () => {


### PR DESCRIPTION
## Related Issues
Fixes: https://github.com/descope/etc/issues/15529

## Description
`logoutWrapper` in `withPersistTokens` called `clearTokens` after `await fn(...args)`. When OIDC logout runs, `fn()` triggers `window.location.replace()`, which begins page unload before the Promise chain can propagate back to `logoutWrapper` — so `clearTokens` never ran. Tokens (localStorage + cookies) remained after the redirect, causing the user to appear authenticated on the next page load.

Fix: move `clearTokens` to run **before** `fn()` in `logoutWrapper`. This guarantees tokens are cleared before any navigation, regardless of browser unload timing. A regression test was added to `persistTokens.test.ts` that asserts `DSR` is already gone from localStorage at the moment `window.location.replace` fires.

## Must
- [x] Tests