### PR TITLE
fix(web-js-sdk): call afterRequest hook in OIDC loginWithRedirect before navigation

### DIFF
--- a/packages/sdks/web-js-sdk/src/sdk/oidc/index.ts
+++ b/packages/sdks/web-js-sdk/src/sdk/oidc/index.ts
@@ -212,7 +212,7 @@ const createOidc = (
     if (!disableNavigation) {
       // In order to make sure all the after-hooks are running with the success response
       // we are generating a fake response with the success data and calling the http client after hook fn with it
-      await sdk.httpClient.hooks.afterRequest(
+      await sdk.httpClient.hooks?.afterRequest(
         {} as any,
         new Response(JSON.stringify(res)),
       );

--- a/packages/sdks/web-js-sdk/src/sdk/oidc/index.ts
+++ b/packages/sdks/web-js-sdk/src/sdk/oidc/index.ts
@@ -210,6 +210,12 @@ const createOidc = (
     const res = await client.createSigninRequest(arg);
     const { url } = res;
     if (!disableNavigation) {
+      // In order to make sure all the after-hooks are running with the success response
+      // we are generating a fake response with the success data and calling the http client after hook fn with it
+      await sdk.httpClient.hooks.afterRequest(
+        {} as any,
+        new Response(JSON.stringify(res)),
+      );
       window.location.href = url;
     }
     return { ok: true, data: res };

--- a/packages/sdks/web-js-sdk/test/oidc.test.ts
+++ b/packages/sdks/web-js-sdk/test/oidc.test.ts
@@ -2,6 +2,17 @@ import { OidcClient } from 'oidc-client-ts';
 import createOidc from '../src/sdk/oidc';
 import { CoreSdk } from '../src/types';
 
+Object.defineProperty(global, 'Response', {
+  value: class {
+    body: string;
+    constructor(body: string) {
+      this.body = body;
+    }
+  },
+  configurable: true,
+  writable: true,
+});
+
 jest.mock('oidc-client-ts', () => {
   return {
     OidcClient: jest.fn().mockImplementation(() => ({
@@ -20,6 +31,10 @@ describe('OIDC', () => {
     sdk = {
       httpClient: {
         buildUrl: jest.fn().mockReturnValue('http://example.com'),
+        hooks: {
+          afterRequest: jest.fn(),
+          beforeRequest: jest.fn(),
+        },
       },
       refresh: jest.fn(),
     } as unknown as CoreSdk;
@@ -80,6 +95,37 @@ describe('OIDC', () => {
       expect(mockCreateSigninRequest).toHaveBeenCalledWith({
         login_hint: 'test@example.com',
       });
+    });
+
+    it('should call afterRequest hook before navigation', async () => {
+      const mockCreateSigninRequest = jest
+        .fn()
+        .mockResolvedValue({ url: 'mockUrl' });
+      (OidcClient as jest.Mock).mockImplementation(() => ({
+        createSigninRequest: mockCreateSigninRequest,
+      }));
+
+      const oidc = createOidc(sdk, 'projectID');
+      await oidc.loginWithRedirect();
+
+      expect(sdk.httpClient.hooks.afterRequest).toHaveBeenCalledWith(
+        {},
+        expect.any(Response),
+      );
+    });
+
+    it('should not call afterRequest hook when navigation is disabled', async () => {
+      const mockCreateSigninRequest = jest
+        .fn()
+        .mockResolvedValue({ url: 'mockUrl' });
+      (OidcClient as jest.Mock).mockImplementation(() => ({
+        createSigninRequest: mockCreateSigninRequest,
+      }));
+
+      const oidc = createOidc(sdk, 'projectID');
+      await oidc.loginWithRedirect({}, true);
+
+      expect(sdk.httpClient.hooks.afterRequest).not.toHaveBeenCalled();
     });
 
     it('should handle errors during authorization', async () => {


### PR DESCRIPTION
## Related Issues
Fixes: https://github.com/descope/etc/issues/15529

## Description
In `loginWithRedirect`, the `afterRequest` hook was not being called before navigating to the OIDC provider. This meant that the persist-tokens enhancer never had a chance to store tokens from the OIDC sign-in request, causing tokens to be cleared on logout. The fix mirrors the same pattern already used in `finishLogin` and `refreshToken`.

## Must
- [x] Tests
- [ ] Documentation (if applicable)