### PR TITLE
feature: Add color theme override

### DIFF
--- a/packages/libs/sdk-mixins/src/mixins/themeMixin/helpers.ts
+++ b/packages/libs/sdk-mixins/src/mixins/themeMixin/helpers.ts
@@ -1,5 +1,39 @@
 import { UI_COMPONENTS_URL_KEY } from '../descopeUiMixin/constants';
 
+export const isSafeCssVarSegment = (segment: string): boolean =>
+  /^[a-zA-Z0-9-]+$/.test(segment);
+
+export const serializeOverrideCssValue = (value: unknown): string | null => {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? String(value) : null;
+  }
+  if (typeof value !== 'string') return null;
+  if (/[;{}]/.test(value)) return null;
+  return value.trim();
+};
+
+export const flattenToVars = (
+  obj: Record<string, any>,
+  onError: (msg: string) => void,
+  prefix = '',
+): string =>
+  Object.entries(obj).reduce((css, [key, value]) => {
+    if (!isSafeCssVarSegment(key)) {
+      onError('Ignoring invalid override-css token path segment');
+      return css;
+    }
+    const path = prefix ? `${prefix}-${key}` : key;
+    if (typeof value === 'object' && value !== null) {
+      return css + flattenToVars(value, onError, path);
+    }
+    const serializedValue = serializeOverrideCssValue(value);
+    if (serializedValue === null) {
+      onError('Ignoring invalid override-css token value');
+      return css;
+    }
+    return `${css}--descope-${path}:${serializedValue};`;
+  }, '');
+
 export const loadFont = (url: string) => {
   const font = document.createElement('link');
   font.href = url;

--- a/packages/libs/sdk-mixins/src/mixins/themeMixin/themeMixin.ts
+++ b/packages/libs/sdk-mixins/src/mixins/themeMixin/themeMixin.ts
@@ -7,7 +7,7 @@ import { initElementMixin } from '../initElementMixin';
 import { initLifecycleMixin } from '../initLifecycleMixin';
 import { staticResourcesMixin } from '../staticResourcesMixin';
 import { DEFAULT_STYLE_ID } from './constants';
-import { loadDevTheme, loadFont } from './helpers';
+import { flattenToVars, loadDevTheme, loadFont } from './helpers';
 import { observeAttributesMixin } from '../observeAttributesMixin';
 import { UI_COMPONENTS_URL_KEY } from '../descopeUiMixin/constants';
 import { InjectedStyle, injectStyleMixin } from '../injectStyleMixin';
@@ -69,50 +69,6 @@ export const themeMixin = createSingletonMixin(
         }
       }
 
-      #isSafeCssVarSegment(segment: string): boolean {
-        return /^[a-zA-Z0-9-]+$/.test(segment);
-      }
-
-      #serializeOverrideCssValue(value: unknown): string | null {
-        if (typeof value === 'number') {
-          return Number.isFinite(value) ? String(value) : null;
-        }
-
-        if (typeof value !== 'string') {
-          return null;
-        }
-
-        if (/[;{}]/.test(value)) {
-          return null;
-        }
-
-        return value.trim();
-      }
-
-      #flattenToVars(obj: Record<string, any>, prefix = ''): string {
-        return Object.entries(obj).reduce((css, [key, value]) => {
-          if (!this.#isSafeCssVarSegment(key)) {
-            this.logger.error(
-              'Ignoring invalid override-css token path segment',
-            );
-            return css;
-          }
-
-          const path = prefix ? `${prefix}-${key}` : key;
-
-          if (typeof value === 'object' && value !== null) {
-            return css + this.#flattenToVars(value, path);
-          }
-
-          const serializedValue = this.#serializeOverrideCssValue(value);
-          if (serializedValue === null) {
-            this.logger.error('Ignoring invalid override-css token value');
-            return css;
-          }
-          return `${css}--descope-${path}:${serializedValue};`;
-        }, '');
-      }
-
       #getThemeOverrideString(): string {
         const override = this.themeOverride;
         if (!override) return '';
@@ -122,9 +78,10 @@ export const themeMixin = createSingletonMixin(
             const primary = override[theme]?.globals?.colors?.primary;
             if (!primary) return '';
 
-            return `[data-theme="${theme}"]{${this.#flattenToVars({
-              colors: { primary },
-            })}}`;
+            return `[data-theme="${theme}"]{${flattenToVars(
+              { colors: { primary } },
+              (msg) => this.logger.error(msg),
+            )}}`;
           })
           .join('');
       }
@@ -204,9 +161,8 @@ export const themeMixin = createSingletonMixin(
           this.#globalStyle = this.injectStyle('');
         }
 
-        const t = theme as Record<string, any> | undefined;
         this.#globalStyle.replaceSync(
-          (t?.light?.globals || '') + (t?.dark?.globals || ''),
+          (theme?.light?.globals || '') + (theme?.dark?.globals || ''),
         );
       }
 

--- a/packages/libs/sdk-mixins/src/mixins/themeMixin/themeMixin.ts
+++ b/packages/libs/sdk-mixins/src/mixins/themeMixin/themeMixin.ts
@@ -300,7 +300,7 @@ export const themeMixin = createSingletonMixin(
 
         this.observeAttributes(['theme'], this.#onThemeChange);
 
-        this.observeAttributes(['customization'], this.#loadCustomStyle);
+        this.observeAttributes(['customization'], () => this.#loadCustomStyle());
 
         this.observeAttributes(['style-id'], () => {
           this.#_themeResource = null;

--- a/packages/libs/sdk-mixins/src/mixins/themeMixin/themeMixin.ts
+++ b/packages/libs/sdk-mixins/src/mixins/themeMixin/themeMixin.ts
@@ -54,13 +54,16 @@ export const themeMixin = createSingletonMixin(
         return this.getAttribute('style-id') || DEFAULT_STYLE_ID;
       }
 
-      get overrideCss(): Record<string, any> | null {
-        const raw = this.getAttribute('override-css');
+      get customization(): Record<string, any> | null {
+        const raw = this.getAttribute('customization');
         if (!raw) return null;
         try {
           return JSON.parse(raw);
-        } catch {
-          this.logger.error('Failed to parse override-css attribute');
+        } catch (e) {
+          this.logger.error(
+            'Failed to parse customization attribute. error: ',
+            e,
+          );
           return null;
         }
       }
@@ -88,7 +91,9 @@ export const themeMixin = createSingletonMixin(
       #flattenToVars(obj: Record<string, any>, prefix = ''): string {
         return Object.entries(obj).reduce((css, [key, value]) => {
           if (!this.#isSafeCssVarSegment(key)) {
-            this.logger.error('Ignoring invalid override-css token path segment');
+            this.logger.error(
+              'Ignoring invalid override-css token path segment',
+            );
             return css;
           }
 
@@ -103,20 +108,22 @@ export const themeMixin = createSingletonMixin(
             this.logger.error('Ignoring invalid override-css token value');
             return css;
           }
-
           return `${css}--descope-${path}:${serializedValue};`;
         }, '');
       }
 
-      #getOverrideCssString(): string {
-        const override = this.overrideCss;
+      #getCustomizationString(): string {
+        const override = this.customization;
         if (!override) return '';
 
         return (['light', 'dark'] as const)
           .map((theme) => {
-            const globals = override[theme]?.globals;
-            if (!globals) return '';
-            return `[data-theme="${theme}"]{${this.#flattenToVars(globals)}}`;
+            const primary = override[theme]?.globals?.colors?.primary;
+            if (!primary) return '';
+
+            return `[data-theme="${theme}"]{${this.#flattenToVars({
+              colors: { primary },
+            })}}`;
           })
           .join('');
       }
@@ -189,8 +196,10 @@ export const themeMixin = createSingletonMixin(
 
       async #loadGlobalStyle() {
         const theme = await this.#themeResource;
-        if (!theme && !this.overrideCss) return;
-
+        if (!theme && !this.customization) {
+          this.#globalStyle?.replaceSync('');
+          return;
+        }
         if (!this.#globalStyle) {
           this.#globalStyle = this.injectStyle('');
         }
@@ -199,7 +208,7 @@ export const themeMixin = createSingletonMixin(
         this.#globalStyle.replaceSync(
           (t?.light?.globals || '') +
             (t?.dark?.globals || '') +
-            this.#getOverrideCssString(),
+            this.#getCustomizationString(),
         );
       }
 
@@ -281,7 +290,9 @@ export const themeMixin = createSingletonMixin(
 
         this.observeAttributes(['theme'], this.#onThemeChange);
 
-        this.observeAttributes(['override-css'], () => this.#loadGlobalStyle());
+        this.observeAttributes(['customization'], () =>
+          this.#loadGlobalStyle(),
+        );
 
         this.observeAttributes(['style-id'], () => {
           this.#_themeResource = null;

--- a/packages/libs/sdk-mixins/src/mixins/themeMixin/themeMixin.ts
+++ b/packages/libs/sdk-mixins/src/mixins/themeMixin/themeMixin.ts
@@ -76,10 +76,11 @@ export const themeMixin = createSingletonMixin(
         return (['light', 'dark'] as const)
           .map((theme) => {
             const primary = override[theme]?.globals?.colors?.primary;
-            if (!primary) return '';
+            const secondary = override[theme]?.globals?.colors?.secondary;
+            if (!primary && !secondary) return '';
 
             return `[data-theme="${theme}"]{${flattenToVars(
-              { colors: { primary } },
+              { colors: { primary, secondary } },
               (msg) => this.logger.error(msg),
             )}}`;
           })

--- a/packages/libs/sdk-mixins/src/mixins/themeMixin/themeMixin.ts
+++ b/packages/libs/sdk-mixins/src/mixins/themeMixin/themeMixin.ts
@@ -35,6 +35,7 @@ export const themeMixin = createSingletonMixin(
 
     return class ThemeMixinClass extends BaseClass {
       #globalStyle: InjectedStyle;
+      #customStyle: InjectedStyle;
 
       get theme(): ThemeOptions {
         const theme = this.getAttribute('theme') as ThemeOptions | null;
@@ -196,8 +197,7 @@ export const themeMixin = createSingletonMixin(
 
       async #loadGlobalStyle() {
         const theme = await this.#themeResource;
-        if (!theme && !this.customization) {
-          this.#globalStyle?.replaceSync('');
+        if (!theme) {
           return;
         }
         if (!this.#globalStyle) {
@@ -206,10 +206,19 @@ export const themeMixin = createSingletonMixin(
 
         const t = theme as Record<string, any> | undefined;
         this.#globalStyle.replaceSync(
-          (t?.light?.globals || '') +
-            (t?.dark?.globals || '') +
-            this.#getCustomizationString(),
+          (t?.light?.globals || '') + (t?.dark?.globals || ''),
         );
+      }
+
+      async #loadCustomStyle() {
+        if (!this.customization) {
+          this.#customStyle?.replaceSync('');
+          return;
+        }
+        if (!this.#customStyle) {
+          this.#customStyle = this.injectStyle('');
+        }
+        this.#customStyle.replaceSync(this.#getCustomizationString());
       }
 
       async #loadComponentsStyle() {
@@ -287,12 +296,11 @@ export const themeMixin = createSingletonMixin(
           this.#loadGlobalStyle(),
           this.#loadComponentsStyle(),
         ]);
+        await this.#loadCustomStyle();
 
         this.observeAttributes(['theme'], this.#onThemeChange);
 
-        this.observeAttributes(['customization'], () =>
-          this.#loadGlobalStyle(),
-        );
+        this.observeAttributes(['customization'], this.#loadCustomStyle);
 
         this.observeAttributes(['style-id'], () => {
           this.#_themeResource = null;

--- a/packages/libs/sdk-mixins/src/mixins/themeMixin/themeMixin.ts
+++ b/packages/libs/sdk-mixins/src/mixins/themeMixin/themeMixin.ts
@@ -54,6 +54,40 @@ export const themeMixin = createSingletonMixin(
         return this.getAttribute('style-id') || DEFAULT_STYLE_ID;
       }
 
+      get overrideCss(): Record<string, any> | null {
+        const raw = this.getAttribute('override-css');
+        if (!raw) return null;
+        try {
+          return JSON.parse(raw);
+        } catch {
+          this.logger.error('Failed to parse override-css attribute');
+          return null;
+        }
+      }
+
+      #flattenToVars(obj: Record<string, any>, prefix = ''): string {
+        return Object.entries(obj).reduce((css, [key, value]) => {
+          const path = prefix ? `${prefix}-${key}` : key;
+          if (typeof value === 'object' && value !== null) {
+            return css + this.#flattenToVars(value, path);
+          }
+          return `${css}--descope-${path}:${value};`;
+        }, '');
+      }
+
+      #getOverrideCssString(): string {
+        const override = this.overrideCss;
+        if (!override) return '';
+
+        return (['light', 'dark'] as const)
+          .map((theme) => {
+            const globals = override[theme]?.globals;
+            if (!globals) return '';
+            return `[data-theme="${theme}"]{${this.#flattenToVars(globals)}}`;
+          })
+          .join('');
+      }
+
       #_themeResource: Promise<void | Record<string, any>>;
 
       async #fetchTheme() {
@@ -122,14 +156,17 @@ export const themeMixin = createSingletonMixin(
 
       async #loadGlobalStyle() {
         const theme = await this.#themeResource;
-        if (!theme) return;
+        if (!theme && !this.overrideCss) return;
 
         if (!this.#globalStyle) {
           this.#globalStyle = this.injectStyle('');
         }
 
+        const t = theme as Record<string, any> | undefined;
         this.#globalStyle.replaceSync(
-          (theme?.light?.globals || '') + (theme?.dark?.globals || ''),
+          (t?.light?.globals || '') +
+            (t?.dark?.globals || '') +
+            this.#getOverrideCssString(),
         );
       }
 
@@ -210,6 +247,8 @@ export const themeMixin = createSingletonMixin(
         ]);
 
         this.observeAttributes(['theme'], this.#onThemeChange);
+
+        this.observeAttributes(['override-css'], () => this.#loadGlobalStyle());
 
         this.observeAttributes(['style-id'], () => {
           this.#_themeResource = null;

--- a/packages/libs/sdk-mixins/src/mixins/themeMixin/themeMixin.ts
+++ b/packages/libs/sdk-mixins/src/mixins/themeMixin/themeMixin.ts
@@ -65,13 +65,46 @@ export const themeMixin = createSingletonMixin(
         }
       }
 
+      #isSafeCssVarSegment(segment: string): boolean {
+        return /^[a-zA-Z0-9-]+$/.test(segment);
+      }
+
+      #serializeOverrideCssValue(value: unknown): string | null {
+        if (typeof value === 'number') {
+          return Number.isFinite(value) ? String(value) : null;
+        }
+
+        if (typeof value !== 'string') {
+          return null;
+        }
+
+        if (/[;{}]/.test(value)) {
+          return null;
+        }
+
+        return value.trim();
+      }
+
       #flattenToVars(obj: Record<string, any>, prefix = ''): string {
         return Object.entries(obj).reduce((css, [key, value]) => {
+          if (!this.#isSafeCssVarSegment(key)) {
+            this.logger.error('Ignoring invalid override-css token path segment');
+            return css;
+          }
+
           const path = prefix ? `${prefix}-${key}` : key;
+
           if (typeof value === 'object' && value !== null) {
             return css + this.#flattenToVars(value, path);
           }
-          return `${css}--descope-${path}:${value};`;
+
+          const serializedValue = this.#serializeOverrideCssValue(value);
+          if (serializedValue === null) {
+            this.logger.error('Ignoring invalid override-css token value');
+            return css;
+          }
+
+          return `${css}--descope-${path}:${serializedValue};`;
         }, '');
       }
 

--- a/packages/libs/sdk-mixins/src/mixins/themeMixin/themeMixin.ts
+++ b/packages/libs/sdk-mixins/src/mixins/themeMixin/themeMixin.ts
@@ -55,14 +55,14 @@ export const themeMixin = createSingletonMixin(
         return this.getAttribute('style-id') || DEFAULT_STYLE_ID;
       }
 
-      get customization(): Record<string, any> | null {
-        const raw = this.getAttribute('customization');
+      get themeOverride(): Record<string, any> | null {
+        const raw = this.getAttribute('theme-override');
         if (!raw) return null;
         try {
           return JSON.parse(raw);
         } catch (e) {
           this.logger.error(
-            'Failed to parse customization attribute. error: ',
+            'Failed to parse theme-override attribute. error: ',
             e,
           );
           return null;
@@ -113,8 +113,8 @@ export const themeMixin = createSingletonMixin(
         }, '');
       }
 
-      #getCustomizationString(): string {
-        const override = this.customization;
+      #getThemeOverrideString(): string {
+        const override = this.themeOverride;
         if (!override) return '';
 
         return (['light', 'dark'] as const)
@@ -211,14 +211,14 @@ export const themeMixin = createSingletonMixin(
       }
 
       async #loadCustomStyle() {
-        if (!this.customization) {
+        if (!this.themeOverride) {
           this.#customStyle?.replaceSync('');
           return;
         }
         if (!this.#customStyle) {
           this.#customStyle = this.injectStyle('');
         }
-        this.#customStyle.replaceSync(this.#getCustomizationString());
+        this.#customStyle.replaceSync(this.#getThemeOverrideString());
       }
 
       async #loadComponentsStyle() {
@@ -300,7 +300,7 @@ export const themeMixin = createSingletonMixin(
 
         this.observeAttributes(['theme'], this.#onThemeChange);
 
-        this.observeAttributes(['customization'], () => this.#loadCustomStyle());
+        this.observeAttributes(['theme-override'], () => this.#loadCustomStyle());
 
         this.observeAttributes(['style-id'], () => {
           this.#_themeResource = null;

--- a/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/descope/descope.component.ts
+++ b/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/descope/descope.component.ts
@@ -46,6 +46,7 @@ import type { CustomStorage } from '@descope/web-component';
       [attr.restart-on-error]="restartOnError"
       [attr.debug]="debug"
       [attr.style-id]="styleId"
+      [attr.theme-override]="themeOverride"
       [attr.client]="clientString"
       [attr.nonce]="nonceString"
       [attr.dismiss-screen-error-on-input]="dismissScreenErrorOnInput"
@@ -118,6 +119,7 @@ export class DescopeComponent implements OnInit, OnChanges, AfterViewInit {
   @Input() form: Record<string, any>;
   @Input() logger: ILogger;
   @Input() styleId: string;
+  @Input() themeOverride: Record<string, any>;
   @Input() popupOrigin: string;
 
   @Output() success: EventEmitter<CustomEvent> =

--- a/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/descope/descope.component.ts
+++ b/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/descope/descope.component.ts
@@ -22,6 +22,7 @@ import { DescopeAuthConfig, ILogger } from '../../types/types';
 // This is safe for SSR because it's completely erased at compile time and generates no runtime import.
 import type DescopeWebComponent from '@descope/web-component';
 import type { CustomStorage } from '@descope/web-component';
+import OverrideThemes from '@descope/web-component';
 
 @Component({
   selector: 'descope[flowId]',
@@ -119,7 +120,7 @@ export class DescopeComponent implements OnInit, OnChanges, AfterViewInit {
   @Input() form: Record<string, any>;
   @Input() logger: ILogger;
   @Input() styleId: string;
-  @Input() themeOverride: Record<string, any>;
+  @Input() themeOverride: OverrideThemes;
   @Input() popupOrigin: string;
 
   @Output() success: EventEmitter<CustomEvent> =

--- a/packages/sdks/react-sdk/src/components/Descope.tsx
+++ b/packages/sdks/react-sdk/src/components/Descope.tsx
@@ -94,7 +94,7 @@ const Descope = React.forwardRef<HTMLElement, DescopeProps>(
       popupOrigin,
       children,
       externalRequestId,
-      customization,
+      themeOverride,
     },
     ref,
   ) => {
@@ -200,7 +200,7 @@ const Descope = React.forwardRef<HTMLElement, DescopeProps>(
             tenant={tenant}
             externalRequestId={externalRequestId}
             customStorage={customStorage}
-            customization={customization}
+            themeOverride={themeOverride}
             {...{
               // attributes
               'theme.attr': theme,

--- a/packages/sdks/react-sdk/src/components/Descope.tsx
+++ b/packages/sdks/react-sdk/src/components/Descope.tsx
@@ -94,6 +94,7 @@ const Descope = React.forwardRef<HTMLElement, DescopeProps>(
       popupOrigin,
       children,
       externalRequestId,
+      customization,
     },
     ref,
   ) => {
@@ -178,9 +179,9 @@ const Descope = React.forwardRef<HTMLElement, DescopeProps>(
        * it can be removed once this issue will be solved
        * https://bugs.chromium.org/p/chromium/issues/detail?id=1404106#c2
        */
-	<form>
-		<Suspense fallback={null}>
-			<DescopeWC
+      <form>
+        <Suspense fallback={null}>
+          <DescopeWC
             projectId={projectId}
             flowId={flowId}
             baseUrl={baseUrl}
@@ -199,6 +200,7 @@ const Descope = React.forwardRef<HTMLElement, DescopeProps>(
             tenant={tenant}
             externalRequestId={externalRequestId}
             customStorage={customStorage}
+            customization={customization}
             {...{
               // attributes
               'theme.attr': theme,
@@ -220,10 +222,10 @@ const Descope = React.forwardRef<HTMLElement, DescopeProps>(
               'customStorage.prop': customStorage,
             }}
           >
-				{children}
-			</DescopeWC>
-		</Suspense>
-	</form>
+            {children}
+          </DescopeWC>
+        </Suspense>
+      </form>
     );
   },
 );

--- a/packages/sdks/react-sdk/src/types.ts
+++ b/packages/sdks/react-sdk/src/types.ts
@@ -13,6 +13,7 @@ import type {
   ILogger,
   ThemeOptions,
 } from '@descope/web-component';
+import type OverrideThemes from '@descope/web-component';
 import DescopeWc from '@descope/web-component';
 import type { UserResponse } from '@descope/web-js-sdk';
 import React, { DOMAttributes } from 'react';
@@ -165,7 +166,7 @@ export type DescopeProps = {
   ) => boolean | Promise<boolean>;
   children?: React.ReactNode;
   externalRequestId?: string;
-  themeOverride?: Record<string, any>;
+  themeOverride?: OverrideThemes;
 };
 
 export type UserManagementProps = WidgetProps;

--- a/packages/sdks/react-sdk/src/types.ts
+++ b/packages/sdks/react-sdk/src/types.ts
@@ -165,7 +165,7 @@ export type DescopeProps = {
   ) => boolean | Promise<boolean>;
   children?: React.ReactNode;
   externalRequestId?: string;
-  customization?: Record<string, any>;
+  themeOverride?: Record<string, any>;
 };
 
 export type UserManagementProps = WidgetProps;

--- a/packages/sdks/react-sdk/src/types.ts
+++ b/packages/sdks/react-sdk/src/types.ts
@@ -165,6 +165,7 @@ export type DescopeProps = {
   ) => boolean | Promise<boolean>;
   children?: React.ReactNode;
   externalRequestId?: string;
+  customization?: Record<string, any>;
 };
 
 export type UserManagementProps = WidgetProps;

--- a/packages/sdks/vue-sdk/src/Descope.vue
+++ b/packages/sdks/vue-sdk/src/Descope.vue
@@ -15,6 +15,7 @@
       :redirect-url="redirectUrl"
       :auto-focus="autoFocus"
       :style-id="styleId"
+      :therme-override="themeOverride"
       :validate-on-blur="validateOnBlur"
       :restart-on-error="restartOnError"
       :store-last-authenticated-user="storeLastAuthenticatedUser"
@@ -115,6 +116,9 @@ const props = defineProps({
   styleId: {
     type: String,
   },
+  themeOverride: {
+    type: Object,
+  },
   nonce: {
     type: String,
   },
@@ -143,12 +147,12 @@ const sdk = useDescope();
 
 const formStr = computed(() => (props.form ? JSON.stringify(props.form) : ''));
 const clientStr = computed(() =>
-  props.client ? JSON.stringify(props.client) : '',
+  props.client ? JSON.stringify(props.client) : ''
 );
 const onSuccess = async (e: CustomEvent<FlowJWTResponse>) => {
   await sdk.httpClient.hooks?.afterRequest?.(
     {} as RequestConfig,
-    new Response(JSON.stringify(e.detail)),
+    new Response(JSON.stringify(e.detail))
   );
   emit('success', e);
 };

--- a/packages/sdks/web-component/src/app/index.html
+++ b/packages/sdks/web-component/src/app/index.html
@@ -5,14 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <!-- Uncomment next section if you want to test CSP -->
 
-    <meta
+    <!-- <meta
       http-equiv="Content-Security-Policy"
       content="connect-src 'self' static.descope.com api.descope.com descopecdn.com;
     style-src fonts.googleapis.com 'nonce-rAnd0m';
     img-src static.descope.com content.app.descope.com imgs.descope.com data:;
     font-src fonts.gstatic.com;
     script-src 'self' static.descope.com descopecdn.com 'nonce-rAnd0m' 'sha256-ZfFIHrd9MzirQdadZrM3hznhYlx+PRQo8+OCWjaPDaY=';"
-    />
+    /> -->
   </head>
   <body>
     <script
@@ -33,6 +33,9 @@
         keep-last-authenticated-user-after-logout="true"
         nonce="rAnd0m"
         dismiss-screen-error-on-input="true"
+        theme="dark"
+        theme-override='{"dark":{"globals": {"colors": { "primary": {"main": "black", "dark": "#6410BC", "light": "#636C74", "highlight": "#005700", "contrast": "#A24309"}}}},  "light": {"globals": {"colors": { "primary": {"main": "#FFFFFF", "dark": "#710A86", "light": "#DA5DF3", "highlight": "#EEB6FA", "contrast": "#FFFFFF"}}}}}'
+        style-id="ofek"
       ></descope-wc>
       <div class="loading">Loading ...</div>
     </div>

--- a/packages/sdks/web-component/src/app/index.html
+++ b/packages/sdks/web-component/src/app/index.html
@@ -5,14 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <!-- Uncomment next section if you want to test CSP -->
 
-    <!-- <meta
+    <meta
       http-equiv="Content-Security-Policy"
       content="connect-src 'self' static.descope.com api.descope.com descopecdn.com;
     style-src fonts.googleapis.com 'nonce-rAnd0m';
     img-src static.descope.com content.app.descope.com imgs.descope.com data:;
     font-src fonts.gstatic.com;
     script-src 'self' static.descope.com descopecdn.com 'nonce-rAnd0m' 'sha256-ZfFIHrd9MzirQdadZrM3hznhYlx+PRQo8+OCWjaPDaY=';"
-    /> -->
+    />
   </head>
   <body>
     <script
@@ -33,9 +33,6 @@
         keep-last-authenticated-user-after-logout="true"
         nonce="rAnd0m"
         dismiss-screen-error-on-input="true"
-        theme="dark"
-        theme-override='{"dark":{"globals": {"colors": { "secondary": {"main": "black", "dark": "#6410BC", "light": "#636C74", "highlight": "#005700", "contrast": "#A24309"}}}},  "light": {"globals": {"colors": { "secondary": {"main": "#FFFFFF", "dark": "#710A86", "light": "#DA5DF3", "highlight": "#EEB6FA", "contrast": "#FFFFFF"}}}}}'
-        style-id="ofek"
       ></descope-wc>
       <div class="loading">Loading ...</div>
     </div>

--- a/packages/sdks/web-component/src/app/index.html
+++ b/packages/sdks/web-component/src/app/index.html
@@ -5,14 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <!-- Uncomment next section if you want to test CSP -->
 
-    <meta
+    <!-- <meta
       http-equiv="Content-Security-Policy"
       content="connect-src 'self' static.descope.com api.descope.com descopecdn.com;
     style-src fonts.googleapis.com 'nonce-rAnd0m';
     img-src static.descope.com content.app.descope.com imgs.descope.com data:;
     font-src fonts.gstatic.com;
     script-src 'self' static.descope.com descopecdn.com 'nonce-rAnd0m' 'sha256-ZfFIHrd9MzirQdadZrM3hznhYlx+PRQo8+OCWjaPDaY=';"
-    />
+    /> -->
   </head>
   <body>
     <script
@@ -33,6 +33,9 @@
         keep-last-authenticated-user-after-logout="true"
         nonce="rAnd0m"
         dismiss-screen-error-on-input="true"
+        theme="dark"
+        theme-override='{"dark":{"globals": {"colors": { "secondary": {"main": "black", "dark": "#6410BC", "light": "#636C74", "highlight": "#005700", "contrast": "#A24309"}}}},  "light": {"globals": {"colors": { "secondary": {"main": "#FFFFFF", "dark": "#710A86", "light": "#DA5DF3", "highlight": "#EEB6FA", "contrast": "#FFFFFF"}}}}}'
+        style-id="ofek"
       ></descope-wc>
       <div class="loading">Loading ...</div>
     </div>

--- a/packages/sdks/web-component/src/app/index.html
+++ b/packages/sdks/web-component/src/app/index.html
@@ -5,14 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <!-- Uncomment next section if you want to test CSP -->
 
-    <!-- <meta
+    <meta
       http-equiv="Content-Security-Policy"
       content="connect-src 'self' static.descope.com api.descope.com descopecdn.com;
     style-src fonts.googleapis.com 'nonce-rAnd0m';
     img-src static.descope.com content.app.descope.com imgs.descope.com data:;
     font-src fonts.gstatic.com;
     script-src 'self' static.descope.com descopecdn.com 'nonce-rAnd0m' 'sha256-ZfFIHrd9MzirQdadZrM3hznhYlx+PRQo8+OCWjaPDaY=';"
-    /> -->
+    />
   </head>
   <body>
     <script
@@ -33,9 +33,6 @@
         keep-last-authenticated-user-after-logout="true"
         nonce="rAnd0m"
         dismiss-screen-error-on-input="true"
-        theme="dark"
-        theme-override='{"dark":{"globals": {"colors": { "primary": {"main": "black", "dark": "#6410BC", "light": "#636C74", "highlight": "#005700", "contrast": "#A24309"}}}},  "light": {"globals": {"colors": { "primary": {"main": "#FFFFFF", "dark": "#710A86", "light": "#DA5DF3", "highlight": "#EEB6FA", "contrast": "#FFFFFF"}}}}}'
-        style-id="ofek"
       ></descope-wc>
       <div class="loading">Loading ...</div>
     </div>

--- a/packages/sdks/web-component/src/lib/descope-wc/BaseDescopeWc.ts
+++ b/packages/sdks/web-component/src/lib/descope-wc/BaseDescopeWc.ts
@@ -315,7 +315,7 @@ class BaseDescopeWc extends BaseClass {
       'style-id',
       'outbound-app-id',
       'outbound-app-scopes',
-      'customization',
+      'theme-override',
     ];
 
     BaseDescopeWc.observedAttributes.forEach((attr: string) => {

--- a/packages/sdks/web-component/src/lib/descope-wc/BaseDescopeWc.ts
+++ b/packages/sdks/web-component/src/lib/descope-wc/BaseDescopeWc.ts
@@ -315,6 +315,7 @@ class BaseDescopeWc extends BaseClass {
       'style-id',
       'outbound-app-id',
       'outbound-app-scopes',
+      'customization',
     ];
 
     BaseDescopeWc.observedAttributes.forEach((attr: string) => {

--- a/packages/sdks/web-component/src/lib/types.ts
+++ b/packages/sdks/web-component/src/lib/types.ts
@@ -297,6 +297,28 @@ type ThemeTemplate = {
   };
 };
 
+type ThemeColor = {
+  main: string;
+  dark: string;
+  light: string;
+  highlight: string;
+  contrast: string;
+};
+
+export type OverrideTheme = {
+  globals?: {
+    colors?: {
+      primary?: ThemeColor;
+      secondary?: ThemeColor;
+    };
+  };
+};
+
+export type OverrideThemes = {
+  dark?: OverrideTheme;
+  light?: OverrideTheme;
+};
+
 export type FlowConfig = {
   startScreenId?: string;
   startScreenName?: string;

--- a/packages/sdks/web-component/test/descope-wc.theme.test.ts
+++ b/packages/sdks/web-component/test/descope-wc.theme.test.ts
@@ -178,7 +178,6 @@ describe('web-component theme', () => {
       timeout: WAIT_TIMEOUT,
     });
 
-    const replaceSync = global.CSSStyleSheet.prototype.replaceSync as jest.Mock;
     const expectedOverrideSnippet = '--descope-colors-primary-base:red';
 
     // Verify themeOverride sheet is last in adoptedStyleSheets
@@ -288,8 +287,6 @@ describe('web-component theme', () => {
     await waitFor(() => screen.getByShadowText('It works!'), {
       timeout: WAIT_TIMEOUT,
     });
-    const expectedOverrideSnippet = '--descope-colors-primary-base:red';
-
     const wc = document.querySelector('descope-wc');
     wc.removeAttribute('theme-override');
 

--- a/packages/sdks/web-component/test/descope-wc.theme.test.ts
+++ b/packages/sdks/web-component/test/descope-wc.theme.test.ts
@@ -267,7 +267,7 @@ describe('web-component theme', () => {
     );
   });
 
-  it('should reload global style without customization when customization attribute is removed', async () => {
+  it('should clear custom style when customization attribute is removed', async () => {
     startMock.mockReturnValue(generateSdkResponse());
 
     fixtures.pageContent = '<span>It works!</span>';
@@ -294,10 +294,14 @@ describe('web-component theme', () => {
         const calls = (global.CSSStyleSheet.prototype.replaceSync as jest.Mock)
           .mock.calls;
         const lastCall = calls[calls.length - 1]?.[0] as string;
-        expect(lastCall).not.toContain('--descope-colors-primary-base');
-        expect(lastCall).toContain('body{}');
+        expect(lastCall).toBe('');
       },
       { timeout: WAIT_TIMEOUT },
+    );
+
+    // Global style with theme globals remains unchanged
+    expect(global.CSSStyleSheet.prototype.replaceSync).toHaveBeenCalledWith(
+      'body{}',
     );
   });
 });

--- a/packages/sdks/web-component/test/descope-wc.theme.test.ts
+++ b/packages/sdks/web-component/test/descope-wc.theme.test.ts
@@ -161,12 +161,10 @@ describe('web-component theme', () => {
   it('should inject themeOverride last in DOM', async () => {
     startMock.mockReturnValue(generateSdkResponse());
 
-    const lightGlobals = '[data-theme="light"]{--descope-color-bg:white;}';
-    const darkGlobals = '[data-theme="dark"]{--descope-color-bg:black;}';
     fixtures.pageContent = '<span>It works!</span>';
     fixtures.themeContent = {
-      light: { globals: lightGlobals },
-      dark: { globals: darkGlobals },
+      light: { globals: '[data-theme="light"]{--descope-color-bg:white;}' },
+      dark: { globals: '[data-theme="dark"]{--descope-color-bg:black;}' },
     };
 
     const themeOverride = JSON.stringify({
@@ -181,15 +179,17 @@ describe('web-component theme', () => {
     });
 
     const replaceSync = global.CSSStyleSheet.prototype.replaceSync as jest.Mock;
-    const expectedStyleIdCss = lightGlobals + darkGlobals;
     const expectedOverrideSnippet = '--descope-colors-primary-base:red';
 
     await waitFor(
       () => {
-        const contents = replaceSync.mock.calls.map(([css]: [string]) => css);
-        const themeIdx = contents.findIndex((css: string) =>
-          css.includes(':host[data-theme="light"]'),
+        const allCalls = replaceSync.mock.calls.map(
+          ([css]: [string]) => css ?? '',
         );
+        const themeCallIdx = allCalls.findIndex((css: string) =>
+          css.includes('[data-theme="light"]{--descope-color-bg:white;}'),
+        );
+        expect(themeCallIdx).toBeGreaterThanOrEqual(0);
       },
       { timeout: WAIT_TIMEOUT },
     );
@@ -204,9 +204,6 @@ describe('web-component theme', () => {
     );
 
     const allCalls = replaceSync.mock.calls.map(([css]: [string]) => css ?? '');
-    const overrideCallIdx = allCalls.findIndex((css: string) =>
-      css.includes(expectedOverrideSnippet),
-    );
     // themeOverride must be the last replaceSync call overall
     expect(allCalls[allCalls.length - 1]).toContain(expectedOverrideSnippet);
 
@@ -217,11 +214,10 @@ describe('web-component theme', () => {
       const sheets = shadowRoot.adoptedStyleSheets;
       expect(sheets.length).toBeGreaterThanOrEqual(4);
       const overrideSheet = sheets.find(
-        (sheet) => (sheet as any)._cssText?.includes(expectedOverrideSnippet),
+        (sheet) => (sheet as any).cssText?.includes(expectedOverrideSnippet),
       );
       expect(overrideSheet).toBeDefined();
-      // @ts-ignore - _index is a private property used in our tests to track sheet order
-      expect(overrideSheet._index).toBe(sheets.length - 1);
+      expect(overrideSheet.index).toBe(sheets.length - 1);
     }
   });
 
@@ -258,13 +254,12 @@ describe('web-component theme', () => {
       const sheets = shadowRoot.adoptedStyleSheets;
       const themeSheet = sheets.find(
         (sheet) =>
-          (sheet as any)._cssText?.includes(
+          (sheet as any).cssText?.includes(
             '[data-theme="light"]{--descope-color-bg:white;}',
           ),
       );
       expect(themeSheet).toBeDefined();
-      // @ts-ignore - _index is a private property used in our tests to track sheet order
-      expect(themeSheet._index).toBe(sheets.length - 1);
+      expect(themeSheet.index).toBe(sheets.length - 1);
     }
   });
 
@@ -345,6 +340,6 @@ describe('web-component theme', () => {
       const overrideSheet = sheets[sheets.length - 1];
       expect(overrideSheet).toBeDefined();
       expect(overrideSheet).toEqual('');
-    };
+    }
   });
 });

--- a/packages/sdks/web-component/test/descope-wc.theme.test.ts
+++ b/packages/sdks/web-component/test/descope-wc.theme.test.ts
@@ -158,13 +158,15 @@ describe('web-component theme', () => {
     );
   });
 
-  it('should inject CSS variables when a valid themeOverride attribute is set', async () => {
+  it('should inject themeOverride last in DOM', async () => {
     startMock.mockReturnValue(generateSdkResponse());
 
+    const lightGlobals = '[data-theme="light"]{--descope-color-bg:white;}';
+    const darkGlobals = '[data-theme="dark"]{--descope-color-bg:black;}';
     fixtures.pageContent = '<span>It works!</span>';
     fixtures.themeContent = {
-      light: { globals: '' },
-      dark: { globals: '' },
+      light: { globals: lightGlobals },
+      dark: { globals: darkGlobals },
     };
 
     const themeOverride = JSON.stringify({
@@ -178,25 +180,49 @@ describe('web-component theme', () => {
       timeout: WAIT_TIMEOUT,
     });
 
+    const replaceSync = global.CSSStyleSheet.prototype.replaceSync as jest.Mock;
+    const expectedStyleIdCss = lightGlobals + darkGlobals;
+    const expectedOverrideSnippet = '--descope-colors-primary-base:red';
+
     await waitFor(
-      () =>
-        expect(global.CSSStyleSheet.prototype.replaceSync).toHaveBeenCalledWith(
-          expect.stringContaining(
-            '[data-theme="light"]{--descope-colors-primary-base:red;}',
-          ),
-        ),
+      () => {
+        const contents = replaceSync.mock.calls.map(([css]: [string]) => css);
+        const themeIdx = contents.findIndex((css: string) =>
+          css.includes(':host[data-theme="light"]'),
+        );
+      },
       { timeout: WAIT_TIMEOUT },
     );
 
     await waitFor(
-      () =>
-        expect(global.CSSStyleSheet.prototype.replaceSync).toHaveBeenCalledWith(
-          expect.stringContaining(
-            '[data-theme="dark"]{--descope-colors-primary-base:blue;}',
-          ),
-        ),
+      () => {
+        expect(replaceSync).toHaveBeenCalledWith(
+          expect.stringContaining(expectedOverrideSnippet),
+        );
+      },
       { timeout: WAIT_TIMEOUT },
     );
+
+    const allCalls = replaceSync.mock.calls.map(([css]: [string]) => css ?? '');
+    const overrideCallIdx = allCalls.findIndex((css: string) =>
+      css.includes(expectedOverrideSnippet),
+    );
+    // themeOverride must be the last replaceSync call overall
+    expect(allCalls[allCalls.length - 1]).toContain(expectedOverrideSnippet);
+
+    // Verify themeOverride sheet is last in adoptedStyleSheets
+    const wc = document.querySelector('descope-wc') as Element;
+    const shadowRoot = wc.shadowRoot as ShadowRoot;
+    if ('adoptedStyleSheets' in shadowRoot) {
+      const sheets = shadowRoot.adoptedStyleSheets;
+      expect(sheets.length).toBeGreaterThanOrEqual(4);
+      const overrideSheet = sheets.find(
+        (sheet) => (sheet as any)._cssText?.includes(expectedOverrideSnippet),
+      );
+      expect(overrideSheet).toBeDefined();
+      // @ts-ignore - _index is a private property used in our tests to track sheet order
+      expect(overrideSheet._index).toBe(sheets.length - 1);
+    }
   });
 
   it('should log an error and not crash when themeOverride attribute contains invalid JSON', async () => {
@@ -205,7 +231,7 @@ describe('web-component theme', () => {
 
     fixtures.pageContent = '<span>It works!</span>';
     fixtures.themeContent = {
-      light: { globals: 'body{}' },
+      light: { globals: '[data-theme="light"]{--descope-color-bg:white;}' },
       dark: { globals: '' },
     };
 
@@ -226,13 +252,20 @@ describe('web-component theme', () => {
     );
 
     // The theme globals should still be injected despite the parse failure
-    await waitFor(
-      () =>
-        expect(global.CSSStyleSheet.prototype.replaceSync).toHaveBeenCalledWith(
-          expect.stringContaining('body{}'),
-        ),
-      { timeout: WAIT_TIMEOUT },
-    );
+    const wc = document.querySelector('descope-wc') as Element;
+    const shadowRoot = wc.shadowRoot as ShadowRoot;
+    if ('adoptedStyleSheets' in shadowRoot) {
+      const sheets = shadowRoot.adoptedStyleSheets;
+      const themeSheet = sheets.find(
+        (sheet) =>
+          (sheet as any)._cssText?.includes(
+            '[data-theme="light"]{--descope-color-bg:white;}',
+          ),
+      );
+      expect(themeSheet).toBeDefined();
+      // @ts-ignore - _index is a private property used in our tests to track sheet order
+      expect(themeSheet._index).toBe(sheets.length - 1);
+    }
   });
 
   it('should reload global style when themeOverride attribute is updated', async () => {
@@ -256,15 +289,20 @@ describe('web-component theme', () => {
     });
     wc.setAttribute('theme-override', themeOverride);
 
+    const replaceSync = global.CSSStyleSheet.prototype.replaceSync as jest.Mock;
+    const expectedOverrideSnippet = '--descope-colors-primary-base:green';
+
     await waitFor(
       () =>
-        expect(global.CSSStyleSheet.prototype.replaceSync).toHaveBeenCalledWith(
-          expect.stringContaining(
-            '[data-theme="light"]{--descope-colors-primary-base:green;}',
-          ),
+        expect(replaceSync).toHaveBeenCalledWith(
+          expect.stringContaining(expectedOverrideSnippet),
         ),
       { timeout: WAIT_TIMEOUT },
     );
+
+    const allCalls = replaceSync.mock.calls.map(([css]: [string]) => css ?? '');
+    // themeOverride must be the last replaceSync call overall
+    expect(allCalls[allCalls.length - 1]).toContain(expectedOverrideSnippet);
   });
 
   it('should clear custom style when themeOverride attribute is removed', async () => {
@@ -272,7 +310,7 @@ describe('web-component theme', () => {
 
     fixtures.pageContent = '<span>It works!</span>';
     fixtures.themeContent = {
-      light: { globals: 'body{}' },
+      light: { globals: '[data-theme="light"]{--descope-color-bg:white;}' },
       dark: { globals: '' },
     };
 
@@ -286,22 +324,27 @@ describe('web-component theme', () => {
       timeout: WAIT_TIMEOUT,
     });
 
-    const wc = document.querySelector('descope-wc');
-    wc.removeAttribute('theme-override');
+    const replaceSync = global.CSSStyleSheet.prototype.replaceSync as jest.Mock;
+    const expectedOverrideSnippet = '--descope-colors-primary-base:red';
 
     await waitFor(
-      () => {
-        const calls = (global.CSSStyleSheet.prototype.replaceSync as jest.Mock)
-          .mock.calls;
-        const lastCall = calls[calls.length - 1]?.[0] as string;
-        expect(lastCall).toBe('');
-      },
+      () =>
+        expect(replaceSync).toHaveBeenCalledWith(
+          expect.stringContaining(expectedOverrideSnippet),
+        ),
       { timeout: WAIT_TIMEOUT },
     );
 
-    // Global style with theme globals remains unchanged
-    expect(global.CSSStyleSheet.prototype.replaceSync).toHaveBeenCalledWith(
-      'body{}',
-    );
+    const wc = document.querySelector('descope-wc');
+    wc.removeAttribute('theme-override');
+
+    const shadowRoot = wc.shadowRoot as ShadowRoot;
+    if ('adoptedStyleSheets' in shadowRoot) {
+      const sheets = shadowRoot.adoptedStyleSheets;
+      expect(sheets.length).toBeGreaterThanOrEqual(4);
+      const overrideSheet = sheets[sheets.length - 1];
+      expect(overrideSheet).toBeDefined();
+      expect(overrideSheet).toEqual('');
+    };
   });
 });

--- a/packages/sdks/web-component/test/descope-wc.theme.test.ts
+++ b/packages/sdks/web-component/test/descope-wc.theme.test.ts
@@ -181,38 +181,11 @@ describe('web-component theme', () => {
     const replaceSync = global.CSSStyleSheet.prototype.replaceSync as jest.Mock;
     const expectedOverrideSnippet = '--descope-colors-primary-base:red';
 
-    await waitFor(
-      () => {
-        const allCalls = replaceSync.mock.calls.map(
-          ([css]: [string]) => css ?? '',
-        );
-        const themeCallIdx = allCalls.findIndex((css: string) =>
-          css.includes('[data-theme="light"]{--descope-color-bg:white;}'),
-        );
-        expect(themeCallIdx).toBeGreaterThanOrEqual(0);
-      },
-      { timeout: WAIT_TIMEOUT },
-    );
-
-    await waitFor(
-      () => {
-        expect(replaceSync).toHaveBeenCalledWith(
-          expect.stringContaining(expectedOverrideSnippet),
-        );
-      },
-      { timeout: WAIT_TIMEOUT },
-    );
-
-    const allCalls = replaceSync.mock.calls.map(([css]: [string]) => css ?? '');
-    // themeOverride must be the last replaceSync call overall
-    expect(allCalls[allCalls.length - 1]).toContain(expectedOverrideSnippet);
-
     // Verify themeOverride sheet is last in adoptedStyleSheets
     const wc = document.querySelector('descope-wc') as Element;
     const shadowRoot = wc.shadowRoot as ShadowRoot;
     if ('adoptedStyleSheets' in shadowRoot) {
       const sheets = shadowRoot.adoptedStyleSheets;
-      expect(sheets.length).toBeGreaterThanOrEqual(4);
       const overrideSheet = sheets.find(
         (sheet) => (sheet as any).cssText?.includes(expectedOverrideSnippet),
       );
@@ -284,20 +257,17 @@ describe('web-component theme', () => {
     });
     wc.setAttribute('theme-override', themeOverride);
 
-    const replaceSync = global.CSSStyleSheet.prototype.replaceSync as jest.Mock;
     const expectedOverrideSnippet = '--descope-colors-primary-base:green';
 
-    await waitFor(
-      () =>
-        expect(replaceSync).toHaveBeenCalledWith(
-          expect.stringContaining(expectedOverrideSnippet),
-        ),
-      { timeout: WAIT_TIMEOUT },
-    );
-
-    const allCalls = replaceSync.mock.calls.map(([css]: [string]) => css ?? '');
-    // themeOverride must be the last replaceSync call overall
-    expect(allCalls[allCalls.length - 1]).toContain(expectedOverrideSnippet);
+    const shadowRoot = wc.shadowRoot as ShadowRoot;
+    if ('adoptedStyleSheets' in shadowRoot) {
+      const sheets = shadowRoot.adoptedStyleSheets;
+      const overrideSheet = sheets.find(
+        (sheet) => (sheet as any).cssText?.includes(expectedOverrideSnippet),
+      );
+      expect(overrideSheet).toBeDefined();
+      expect(overrideSheet.index).toBe(sheets.length - 1);
+    }
   });
 
   it('should clear custom style when themeOverride attribute is removed', async () => {
@@ -318,17 +288,7 @@ describe('web-component theme', () => {
     await waitFor(() => screen.getByShadowText('It works!'), {
       timeout: WAIT_TIMEOUT,
     });
-
-    const replaceSync = global.CSSStyleSheet.prototype.replaceSync as jest.Mock;
     const expectedOverrideSnippet = '--descope-colors-primary-base:red';
-
-    await waitFor(
-      () =>
-        expect(replaceSync).toHaveBeenCalledWith(
-          expect.stringContaining(expectedOverrideSnippet),
-        ),
-      { timeout: WAIT_TIMEOUT },
-    );
 
     const wc = document.querySelector('descope-wc');
     wc.removeAttribute('theme-override');

--- a/packages/sdks/web-component/test/descope-wc.theme.test.ts
+++ b/packages/sdks/web-component/test/descope-wc.theme.test.ts
@@ -158,7 +158,7 @@ describe('web-component theme', () => {
     );
   });
 
-  it('should inject CSS variables when a valid customization attribute is set', async () => {
+  it('should inject CSS variables when a valid themeOverride attribute is set', async () => {
     startMock.mockReturnValue(generateSdkResponse());
 
     fixtures.pageContent = '<span>It works!</span>';
@@ -167,12 +167,12 @@ describe('web-component theme', () => {
       dark: { globals: '' },
     };
 
-    const customization = JSON.stringify({
+    const themeOverride = JSON.stringify({
       light: { globals: { colors: { primary: { base: 'red' } } } },
       dark: { globals: { colors: { primary: { base: 'blue' } } } },
     });
 
-    document.body.innerHTML = `<descope-wc flow-id="otpSignInEmail" project-id="1" customization='${customization}'></descope-wc>`;
+    document.body.innerHTML = `<descope-wc flow-id="otpSignInEmail" project-id="1" theme-override='${themeOverride}'></descope-wc>`;
 
     await waitFor(() => screen.getByShadowText('It works!'), {
       timeout: WAIT_TIMEOUT,
@@ -199,7 +199,7 @@ describe('web-component theme', () => {
     );
   });
 
-  it('should log an error and not crash when customization attribute contains invalid JSON', async () => {
+  it('should log an error and not crash when themeOverride attribute contains invalid JSON', async () => {
     const errorSpy = jest.spyOn(console, 'error');
     startMock.mockReturnValue(generateSdkResponse());
 
@@ -209,7 +209,7 @@ describe('web-component theme', () => {
       dark: { globals: '' },
     };
 
-    document.body.innerHTML = `<descope-wc flow-id="otpSignInEmail" project-id="1" customization='not-valid-json'></descope-wc>`;
+    document.body.innerHTML = `<descope-wc flow-id="otpSignInEmail" project-id="1" theme-override='not-valid-json'></descope-wc>`;
 
     await waitFor(() => screen.getByShadowText('It works!'), {
       timeout: WAIT_TIMEOUT,
@@ -219,7 +219,7 @@ describe('web-component theme', () => {
       () =>
         expect(errorSpy).toHaveBeenCalledWith(
           '[Descope]',
-          expect.stringContaining('Failed to parse customization attribute'),
+          expect.stringContaining('Failed to parse theme-override attribute'),
           expect.anything(),
         ),
       { timeout: WAIT_TIMEOUT },
@@ -235,7 +235,7 @@ describe('web-component theme', () => {
     );
   });
 
-  it('should reload global style when customization attribute is updated', async () => {
+  it('should reload global style when themeOverride attribute is updated', async () => {
     startMock.mockReturnValue(generateSdkResponse());
 
     fixtures.pageContent = '<span>It works!</span>';
@@ -251,10 +251,10 @@ describe('web-component theme', () => {
     });
 
     const wc = document.querySelector('descope-wc');
-    const customization = JSON.stringify({
+    const themeOverride = JSON.stringify({
       light: { globals: { colors: { primary: { base: 'green' } } } },
     });
-    wc.setAttribute('customization', customization);
+    wc.setAttribute('theme-override', themeOverride);
 
     await waitFor(
       () =>
@@ -267,7 +267,7 @@ describe('web-component theme', () => {
     );
   });
 
-  it('should clear custom style when customization attribute is removed', async () => {
+  it('should clear custom style when themeOverride attribute is removed', async () => {
     startMock.mockReturnValue(generateSdkResponse());
 
     fixtures.pageContent = '<span>It works!</span>';
@@ -276,18 +276,18 @@ describe('web-component theme', () => {
       dark: { globals: '' },
     };
 
-    const customization = JSON.stringify({
+    const themeOverride = JSON.stringify({
       light: { globals: { colors: { primary: { base: 'red' } } } },
     });
 
-    document.body.innerHTML = `<descope-wc flow-id="otpSignInEmail" project-id="1" customization='${customization}'></descope-wc>`;
+    document.body.innerHTML = `<descope-wc flow-id="otpSignInEmail" project-id="1" theme-override='${themeOverride}'></descope-wc>`;
 
     await waitFor(() => screen.getByShadowText('It works!'), {
       timeout: WAIT_TIMEOUT,
     });
 
     const wc = document.querySelector('descope-wc');
-    wc.removeAttribute('customization');
+    wc.removeAttribute('theme-override');
 
     await waitFor(
       () => {

--- a/packages/sdks/web-component/test/descope-wc.theme.test.ts
+++ b/packages/sdks/web-component/test/descope-wc.theme.test.ts
@@ -157,4 +157,147 @@ describe('web-component theme', () => {
       { timeout: WAIT_TIMEOUT },
     );
   });
+
+  it('should inject CSS variables when a valid customization attribute is set', async () => {
+    startMock.mockReturnValue(generateSdkResponse());
+
+    fixtures.pageContent = '<span>It works!</span>';
+    fixtures.themeContent = {
+      light: { globals: '' },
+      dark: { globals: '' },
+    };
+
+    const customization = JSON.stringify({
+      light: { globals: { colors: { primary: { base: 'red' } } } },
+      dark: { globals: { colors: { primary: { base: 'blue' } } } },
+    });
+
+    document.body.innerHTML = `<descope-wc flow-id="otpSignInEmail" project-id="1" customization='${customization}'></descope-wc>`;
+
+    await waitFor(() => screen.getByShadowText('It works!'), {
+      timeout: WAIT_TIMEOUT,
+    });
+
+    await waitFor(
+      () =>
+        expect(global.CSSStyleSheet.prototype.replaceSync).toHaveBeenCalledWith(
+          expect.stringContaining(
+            '[data-theme="light"]{--descope-colors-primary-base:red;}',
+          ),
+        ),
+      { timeout: WAIT_TIMEOUT },
+    );
+
+    await waitFor(
+      () =>
+        expect(global.CSSStyleSheet.prototype.replaceSync).toHaveBeenCalledWith(
+          expect.stringContaining(
+            '[data-theme="dark"]{--descope-colors-primary-base:blue;}',
+          ),
+        ),
+      { timeout: WAIT_TIMEOUT },
+    );
+  });
+
+  it('should log an error and not crash when customization attribute contains invalid JSON', async () => {
+    const errorSpy = jest.spyOn(console, 'error');
+    startMock.mockReturnValue(generateSdkResponse());
+
+    fixtures.pageContent = '<span>It works!</span>';
+    fixtures.themeContent = {
+      light: { globals: 'body{}' },
+      dark: { globals: '' },
+    };
+
+    document.body.innerHTML = `<descope-wc flow-id="otpSignInEmail" project-id="1" customization='not-valid-json'></descope-wc>`;
+
+    await waitFor(() => screen.getByShadowText('It works!'), {
+      timeout: WAIT_TIMEOUT,
+    });
+
+    await waitFor(
+      () =>
+        expect(errorSpy).toHaveBeenCalledWith(
+          '[Descope]',
+          expect.stringContaining('Failed to parse customization attribute'),
+          expect.anything(),
+        ),
+      { timeout: WAIT_TIMEOUT },
+    );
+
+    // The theme globals should still be injected despite the parse failure
+    await waitFor(
+      () =>
+        expect(global.CSSStyleSheet.prototype.replaceSync).toHaveBeenCalledWith(
+          expect.stringContaining('body{}'),
+        ),
+      { timeout: WAIT_TIMEOUT },
+    );
+  });
+
+  it('should reload global style when customization attribute is updated', async () => {
+    startMock.mockReturnValue(generateSdkResponse());
+
+    fixtures.pageContent = '<span>It works!</span>';
+    fixtures.themeContent = {
+      light: { globals: '' },
+      dark: { globals: '' },
+    };
+
+    document.body.innerHTML = `<descope-wc flow-id="otpSignInEmail" project-id="1"></descope-wc>`;
+
+    await waitFor(() => screen.getByShadowText('It works!'), {
+      timeout: WAIT_TIMEOUT,
+    });
+
+    const wc = document.querySelector('descope-wc');
+    const customization = JSON.stringify({
+      light: { globals: { colors: { primary: { base: 'green' } } } },
+    });
+    wc.setAttribute('customization', customization);
+
+    await waitFor(
+      () =>
+        expect(global.CSSStyleSheet.prototype.replaceSync).toHaveBeenCalledWith(
+          expect.stringContaining(
+            '[data-theme="light"]{--descope-colors-primary-base:green;}',
+          ),
+        ),
+      { timeout: WAIT_TIMEOUT },
+    );
+  });
+
+  it('should reload global style without customization when customization attribute is removed', async () => {
+    startMock.mockReturnValue(generateSdkResponse());
+
+    fixtures.pageContent = '<span>It works!</span>';
+    fixtures.themeContent = {
+      light: { globals: 'body{}' },
+      dark: { globals: '' },
+    };
+
+    const customization = JSON.stringify({
+      light: { globals: { colors: { primary: { base: 'red' } } } },
+    });
+
+    document.body.innerHTML = `<descope-wc flow-id="otpSignInEmail" project-id="1" customization='${customization}'></descope-wc>`;
+
+    await waitFor(() => screen.getByShadowText('It works!'), {
+      timeout: WAIT_TIMEOUT,
+    });
+
+    const wc = document.querySelector('descope-wc');
+    wc.removeAttribute('customization');
+
+    await waitFor(
+      () => {
+        const calls = (global.CSSStyleSheet.prototype.replaceSync as jest.Mock)
+          .mock.calls;
+        const lastCall = calls[calls.length - 1]?.[0] as string;
+        expect(lastCall).not.toContain('--descope-colors-primary-base');
+        expect(lastCall).toContain('body{}');
+      },
+      { timeout: WAIT_TIMEOUT },
+    );
+  });
 });


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/14865

## Description

Adding `override-theme` to descope sdk.
value needs to be object from this type:

`{"dark":{"globals": {"colors": { "primary": {"main": "#BD10E0", "dark": "#6410BC", "light": "#636C74", "highlight": "#005700", "contrast": "#A24309"}, "secondary": {"main": "black", "dark": "#6410BC", "light": "#636C74", "highlight": "#005700", "contrast": "#A24309"}}}}, 
"light": {"globals": {"colors": { "primary": {"main": "#FFFFFF", "dark": "#710A86", "light": "#DA5DF3", "highlight": "#EEB6FA", "contrast": "#FFFFFF"}, "secondary": {"main": "black", "dark": "#6410BC", "light": "#636C74", "highlight": "#005700", "contrast": "#A24309"}}}}}`

## Must

- [ ] Tests
- [ ] Documentation (if applicable)
