### PR TITLE
fix(access-key-widget): override outdated Permitted IPs pattern at runtime

### DIFF
--- a/packages/widgets/access-key-management-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initCreateAccessKeyModalMixin.ts
+++ b/packages/widgets/access-key-management-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initCreateAccessKeyModalMixin.ts
@@ -14,6 +14,13 @@ import { stateManagementMixin } from '../../stateManagementMixin';
 import { initWidgetRootMixin } from './initWidgetRootMixin';
 import { initCreatedAccessKeyModalMixin } from './initCreatedAccessKeyModalMixin';
 
+// Defense-in-depth: older widget HTML saved on the backend contains a broken
+// HTML5 `pattern` for Permitted IPs (stripped backslashes, JS-literal slashes)
+// so valid IPv4/CIDR values fail checkValidity(). Override at runtime until
+// affected widgets are re-saved. Source-of-truth fix: descope/console-app#5272.
+export const PERMITTED_IPS_PATTERN =
+  '(?:(?:\\d{1,3}\\.){3}\\d{1,3}(?:\\/(?:\\d|[1-2]\\d|3[0-2]))?|(?:[a-fA-F0-9]{1,4}:){1,7}[a-fA-F0-9]{1,4}(?:\\/\\d{1,3})?)';
+
 export const initCreateAccessKeyModalMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) =>
     class InitCreateAccessKeyModalMixinClass extends compose(
@@ -36,6 +43,12 @@ export const initCreateAccessKeyModalMixin = createSingletonMixin(
             await this.fetchWidgetPage('create-access-key-modal.html'),
           ),
         );
+
+        // Override the Permitted IPs pattern for widgets whose saved HTML still
+        // carries the broken regex. No-op when the input is absent.
+        this.createAccessKeyModal.ele
+          ?.querySelector('[data-id="ips-multiselect"]')
+          ?.setAttribute('pattern', PERMITTED_IPS_PATTERN);
 
         const cancelButton = new ButtonDriver(
           () =>

--- a/packages/widgets/access-key-management-widget/test/access-key-management-widget.test.ts
+++ b/packages/widgets/access-key-management-widget/test/access-key-management-widget.test.ts
@@ -11,6 +11,7 @@ import {
 } from '../src/lib/widget/state/selectors';
 import { State } from '../src/lib/widget/state/types';
 import '../src/lib/index';
+import { PERMITTED_IPS_PATTERN } from '../src/lib/widget/mixins/initMixin/initComponentsMixins/initCreateAccessKeyModalMixin';
 import rootMock from './mocks/rootMock';
 import createAccessKeyModalMock from './mocks/createAccessKeyModalMock';
 import createdAccessKeyModalMock from './mocks/createdAccessKeyModalMock';
@@ -257,6 +258,21 @@ describe('access-key-management-widget', () => {
           's',
         ]} deleted successfully`,
       ).toEqual('2 access keys deleted successfully');
+    });
+  });
+
+  describe('PERMITTED_IPS_PATTERN', () => {
+    const re = new RegExp(`^(?:${PERMITTED_IPS_PATTERN})$`);
+
+    it.each(['108.216.155.228', '192.168.1.1', '10.0.0.0/24', '1.2.3.4/32'])(
+      'accepts %s',
+      (value) => {
+        expect(re.test(value)).toBe(true);
+      },
+    );
+
+    it.each(['abc', '999', '1.2.3', ''])('rejects %s', (value) => {
+      expect(re.test(value)).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary

Defense-in-depth fix for a customer-reported bug where valid IPv4/CIDR values fail `checkValidity()` on the **Permitted IPs** MultiSelect in the access-key creation modal (e.g. `108.216.155.228` rejected).

## Root cause

The console-app widget editor template at `src/components/Widgets/editor/accessKeysModalInputs.tsx` shipped a broken HTML5 `pattern` for that input:

- `\d` lost its backslash (matches the literal letter `d`)
- The pattern was wrapped in JS regex-literal `/.../` delimiters, which are not valid in an HTML5 `pattern` attribute

Source-of-truth fix lives in console-app: **descope/console-app#5272**.

## Why a descope-js side fix is still needed

The console-app PR only affects **newly saved** widgets. Existing access-key widgets have the broken pattern baked into their saved HTML on the backend. Until a customer re-saves (or a backend migration runs), the rendered runtime widget keeps blocking valid IPs.

## What this PR does

In `initCreateAccessKeyModalMixin.ts`, immediately after the modal's `setContent(...)`, look up `[data-id="ips-multiselect"]` and override its `pattern` attribute with a corrected expression that accepts IPv4, IPv4/CIDR (0-32), and IPv6 (optional prefix). No-op when the element is absent (older widgets without the IPs input).

A module-level `PERMITTED_IPS_PATTERN` constant holds the regex string so it can be unit-tested.

## Verification

- Unit test added in `access-key-management-widget.test.ts` asserting the regex accepts `108.216.155.228`, `192.168.1.1`, `10.0.0.0/24`, `1.2.3.4/32` and rejects `abc`, `999`, `1.2.3`, ``.
- `nx test access-key-management-widget` -> 20/20 passing.
- `nx lint access-key-management-widget` -> clean.

## Test plan

- [ ] Open a customer tenant whose access-key widget still has the broken saved HTML.
- [ ] Open the **Create access key** modal, enter `108.216.155.228` (and `10.0.0.0/24`) in Permitted IPs.
- [ ] Submit -> should succeed (previously failed `checkValidity`).

## References

- console-app source-of-truth fix: descope/console-app#5272
- Slack thread: https://descopeio.slack.com/archives/C039BJZVC05/p1779462154647579
