### PR TITLE
fix(react-sdk): defer setIsSessionLoading(false) to a separate render pass

### DIFF
--- a/packages/sdks/react-sdk/src/components/AuthProvider/AuthProvider.tsx
+++ b/packages/sdks/react-sdk/src/components/AuthProvider/AuthProvider.tsx
@@ -150,7 +150,15 @@ const AuthProvider: FC<IAuthProviderProps> = ({
 
     setIsSessionLoading(true);
     withValidation(sdk?.refresh)(undefined, true).then(() => {
-      setIsSessionLoading(false);
+      // Defer to a separate render pass so React doesn't batch this with
+      // the setIsSessionLoading(true) above when refresh() short-circuits
+      // synchronously - downstream consumers (e.g. useSession) need to
+      // observe the false→true→false loading transition (#1393)
+      requestAnimationFrame(() => {
+        setTimeout(() => {
+          setIsSessionLoading(false);
+        }, 0);
+      });
     });
   }, [sdk]);
 

--- a/packages/sdks/react-sdk/test/hooks/useAuth.test.tsx
+++ b/packages/sdks/react-sdk/test/hooks/useAuth.test.tsx
@@ -139,7 +139,9 @@ describe('hooks', () => {
     // render again
     rerender();
 
-    expect(result.current.isSessionLoading).toEqual(false);
+    await waitFor(() => {
+      expect(result.current.isSessionLoading).toEqual(false);
+    });
     expect(refresh).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
## Related Issues
Fixes: https://github.com/descope/descope-js/issues/1393

## Description
When `web-js-sdk@1.49.0` short-circuits `refresh()` for users with no login indicator, both `setIsSessionLoading(true)` and `setIsSessionLoading(false)` land in the same task and get batched into a single render. Downstream consumers (e.g. `useSession`) never observe the loading transition, so the hook reports `isSessionLoading: true` indefinitely and any redirect-to-login guard stays gated.

Defer the `false` update via `requestAnimationFrame` + `setTimeout(0)` so it lands in a distinct render pass.

## Must
- [ ] Tests
- [ ] Documentation (if applicable)