### PR TITLE
feat(web-component): support 'read-only' componentsState action RELEASE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ tmp
 
 # dependencies
 node_modules
+.pnpm-store
 
 # IDEs and editors
 /.idea

--- a/packages/sdks/web-component/src/lib/helpers/templates.ts
+++ b/packages/sdks/web-component/src/lib/helpers/templates.ts
@@ -285,10 +285,13 @@ const applyComponentsState = (
         case 'hide':
           compEl.classList.add('hidden');
           break;
+        case 'read-only':
+          compEl.setAttribute('readonly', 'true');
+          break;
         default:
           logger?.error(
             `Unknown component state "${state}" for component with id "${componentId}"`,
-            'Valid states are "disable" and "hide"',
+            'Valid states are "disable", "hide", and "read-only"',
           );
           break;
       }

--- a/packages/sdks/web-component/test/descope-wc.customScreen.test.ts
+++ b/packages/sdks/web-component/test/descope-wc.customScreen.test.ts
@@ -423,6 +423,48 @@ describe('web-component', () => {
       expect(disabledInput).toHaveAttribute('disabled', 'true');
       expect(enabledButton).toBeEnabled();
     });
+
+    it('should set readonly on components when componentsState contains read-only state', async () => {
+      startMock.mockReturnValue(
+        generateSdkResponse({
+          screenState: {
+            componentsState: {
+              'test-email-input': 'read-only',
+              'test-totp-input': 'read-only',
+            },
+          },
+        }),
+      );
+
+      fixtures.pageContent = `<div>
+        <input id="test-email-input" />
+        <input id="test-totp-input" />
+        <input id="editable-input" />
+        <descope-button id="submit-button">Submit</descope-button>
+      </div>`;
+
+      document.body.innerHTML = `<h1>Custom element test</h1> <descope-wc flow-id="otpSignInEmail" project-id="1"></descope-wc>`;
+
+      const descopeWc = document.querySelector('descope-wc');
+
+      await waitFor(() => screen.getByShadowText('Submit'), {
+        timeout: WAIT_TIMEOUT,
+      });
+
+      const readonlyEmail =
+        descopeWc.shadowRoot.querySelector('#test-email-input');
+      const readonlyTotp =
+        descopeWc.shadowRoot.querySelector('#test-totp-input');
+      const editableInput =
+        descopeWc.shadowRoot.querySelector('#editable-input');
+
+      expect(readonlyEmail).toHaveAttribute('readonly', 'true');
+      expect(readonlyTotp).toHaveAttribute('readonly', 'true');
+      expect(readonlyEmail).not.toHaveAttribute('disabled');
+      expect(readonlyTotp).not.toHaveAttribute('disabled');
+      expect(editableInput).not.toHaveAttribute('readonly');
+    });
+
     it('should handle empty componentsState gracefully', async () => {
       startMock.mockReturnValue(
         generateSdkResponse({


### PR DESCRIPTION
## Summary
- Add `'read-only'` case to `applyComponentsState` switch in [templates.ts](packages/sdks/web-component/src/lib/helpers/templates.ts) — sets `readonly="true"` on matching components.
- Update the `default` arm error message to include the new state.
- E2E test in [descope-wc.customScreen.test.ts](packages/sdks/web-component/test/descope-wc.customScreen.test.ts) mirroring the existing disable test.

Runtime half of a two-repo change.

## Related issue
descope/etc#15647

## Related PR
Authoring UI / page editor wiring ships from descope/console-app#5287 — this PR should merge first so the runtime can handle the new state before the editor exposes it.

## Test plan
- [x] `pnpm -F @descope/web-component test` — 323 tests pass
- [x] Manual: flow with `read-only` condition renders input non-editable, copy still works
- [ ] iOS WebView (original FAB customer scenario)

🤖 Generated with [Claude Code](https://claude.com/claude-code)