### PR TITLE
feat(widgets): add widget localization

### DIFF
--- a/packages/libs/sdk-helpers/src/index.ts
+++ b/packages/libs/sdk-helpers/src/index.ts
@@ -5,3 +5,4 @@ export * from './mixins';
 export * from './state';
 export * from './jwt';
 export * from './csv';
+export * from './locale';

--- a/packages/libs/sdk-helpers/src/locale.spec.ts
+++ b/packages/libs/sdk-helpers/src/locale.spec.ts
@@ -1,0 +1,32 @@
+import { getUserLocale } from './locale';
+
+const setNavigatorLanguage = (value: string) => {
+  Object.defineProperty(navigator, 'language', {
+    value,
+    configurable: true,
+  });
+};
+
+describe('getUserLocale', () => {
+  it('lowercases an explicit locale (used as its own fallback)', () => {
+    expect(getUserLocale('en-US')).toEqual({
+      locale: 'en-us',
+      fallback: 'en-us',
+    });
+  });
+
+  it('falls back to navigator.language with the language part as fallback for xx-YY', () => {
+    setNavigatorLanguage('fr-FR');
+    expect(getUserLocale('')).toEqual({ locale: 'fr-fr', fallback: 'fr' });
+  });
+
+  it('uses navigator.language as-is when it has no region', () => {
+    setNavigatorLanguage('de');
+    expect(getUserLocale('')).toEqual({ locale: 'de', fallback: 'de' });
+  });
+
+  it('returns empty strings when there is no locale and no navigator.language', () => {
+    setNavigatorLanguage('');
+    expect(getUserLocale('')).toEqual({ locale: '', fallback: '' });
+  });
+});

--- a/packages/libs/sdk-helpers/src/locale.ts
+++ b/packages/libs/sdk-helpers/src/locale.ts
@@ -4,13 +4,13 @@ export type Locale = {
 };
 
 /**
- * Resolves the user-facing locale. Mirrors web-component's getUserLocale exactly so widget
- * locale resolution matches the flow runtime byte-for-byte.
+ * Resolves the user-facing locale, shared by the web-component flow runtime and the widget mixins
+ * so both resolve locale identically.
  *
  * Order:
- *  1. Explicit locale argument (lowercased)
+ *  1. Explicit locale argument (lowercased), used as its own fallback
  *  2. navigator.language (lowercased), with the language part as fallback for 'xx-YY' forms
- *  3. Empty string
+ *  3. Empty strings
  */
 export function getUserLocale(locale: string): Locale {
   if (locale) {

--- a/packages/libs/sdk-mixins/src/index.ts
+++ b/packages/libs/sdk-mixins/src/index.ts
@@ -27,6 +27,7 @@ export * from './mixins/projectIdMixin';
 export * from './mixins/widgetIdMixin';
 export * from './mixins/widgetConfigMixin';
 export * from './mixins/localeMixin';
+export * from './mixins/fetchWidgetPagesMixin';
 export * from './mixins/baseUrlMixin';
 export * from './mixins/cookieConfigMixin';
 export * from './mixins/injectNpmLibMixin';

--- a/packages/libs/sdk-mixins/src/index.ts
+++ b/packages/libs/sdk-mixins/src/index.ts
@@ -26,6 +26,7 @@ export * from './mixins/initLifecycleMixin';
 export * from './mixins/projectIdMixin';
 export * from './mixins/widgetIdMixin';
 export * from './mixins/widgetConfigMixin';
+export * from './mixins/localeMixin';
 export * from './mixins/baseUrlMixin';
 export * from './mixins/cookieConfigMixin';
 export * from './mixins/injectNpmLibMixin';

--- a/packages/libs/sdk-mixins/src/mixins/configMixin/types.ts
+++ b/packages/libs/sdk-mixins/src/mixins/configMixin/types.ts
@@ -77,6 +77,8 @@ export type FlowConfig = {
 
 export type WidgetConfig = {
   allowSubTenants?: boolean;
+  version?: number;
+  targetLocales?: string[];
 };
 
 export type ProjectConfiguration = {

--- a/packages/libs/sdk-mixins/src/mixins/fetchWidgetPagesMixin/createFetchWidgetPagesMixin.ts
+++ b/packages/libs/sdk-mixins/src/mixins/fetchWidgetPagesMixin/createFetchWidgetPagesMixin.ts
@@ -1,0 +1,68 @@
+import { compose, createSingletonMixin } from '@descope/sdk-helpers';
+import { localeMixin } from '../localeMixin';
+import { staticResourcesMixin } from '../staticResourcesMixin';
+import { widgetConfigMixin } from '../widgetConfigMixin';
+import { widgetIdMixin } from '../widgetIdMixin';
+
+/**
+ * Builds a widget's fetchWidgetPagesMixin. Every widget shares identical logic and differs only by
+ * its published base directory (the widget type/name under which its screens live in S3), so each
+ * widget calls this with its own dir:
+ *
+ *   export const fetchWidgetPagesMixin = createFetchWidgetPagesMixin('user-profile-widget');
+ *
+ * `fetchWidgetPage` fetches `<base>/<widgetId>/<file>`, transparently preferring a localized
+ * `<file>-<locale>.html` variant when the widget publishes that locale (config.json targetLocales),
+ * and falling back to the default page otherwise.
+ */
+export const createFetchWidgetPagesMixin = (widgetPagesBaseDir: string) =>
+  createSingletonMixin(<T extends CustomElementConstructor>(superclass: T) => {
+    const BaseClass = compose(
+      staticResourcesMixin,
+      widgetIdMixin,
+      widgetConfigMixin,
+      localeMixin,
+    )(superclass);
+    return class FetchWidgetPagesMixinClass extends BaseClass {
+      // Keep `init` typed as a method across the package boundary (mirrors widgetConfigMixin):
+      // without it, the emitted .d.ts widens the inherited `init` to a property, and a widget
+      // composing this alongside another init-providing mixin (e.g. initLifecycleMixin) hits TS2425.
+      async init() {
+        await super.init?.();
+      }
+
+      async fetchWidgetPage(filename: string) {
+        const localized = await this.#tryFetchLocalized(filename);
+        if (localized !== undefined) return localized;
+
+        const res = await this.fetchStaticResource(
+          `${widgetPagesBaseDir}/${this.widgetId}/${filename}`,
+          'text',
+        );
+        return res?.body;
+      }
+
+      // Fetch <page>-<locale>.html when the widget publishes that locale (config.json
+      // targetLocales); otherwise return undefined so the caller falls back to the default page.
+      async #tryFetchLocalized(filename: string): Promise<string | undefined> {
+        const userLocale = await this.firstAvailableLocale(
+          this.localeCandidates,
+        );
+        if (!userLocale) return undefined;
+
+        const ext = '.html';
+        const base = filename.endsWith(ext)
+          ? filename.slice(0, -ext.length)
+          : filename;
+        try {
+          const res = await this.fetchStaticResource(
+            `${widgetPagesBaseDir}/${this.widgetId}/${base}-${userLocale}${ext}`,
+            'text',
+          );
+          return res?.body;
+        } catch {
+          return undefined;
+        }
+      }
+    };
+  });

--- a/packages/libs/sdk-mixins/src/mixins/fetchWidgetPagesMixin/createFetchWidgetPagesMixin.ts
+++ b/packages/libs/sdk-mixins/src/mixins/fetchWidgetPagesMixin/createFetchWidgetPagesMixin.ts
@@ -45,8 +45,9 @@ export const createFetchWidgetPagesMixin = (widgetPagesBaseDir: string) =>
       // Fetch <page>-<locale>.html when the widget publishes that locale (config.json
       // targetLocales); otherwise return undefined so the caller falls back to the default page.
       async #tryFetchLocalized(filename: string): Promise<string | undefined> {
-        const userLocale = await this.firstAvailableLocale(
-          this.localeCandidates,
+        const widgetConfig = await this.getWidgetConfig();
+        const userLocale = this.firstAvailableLocale(
+          widgetConfig?.targetLocales ?? [],
         );
         if (!userLocale) return undefined;
 

--- a/packages/libs/sdk-mixins/src/mixins/fetchWidgetPagesMixin/index.ts
+++ b/packages/libs/sdk-mixins/src/mixins/fetchWidgetPagesMixin/index.ts
@@ -1,0 +1,1 @@
+export * from './createFetchWidgetPagesMixin';

--- a/packages/libs/sdk-mixins/src/mixins/localeMixin/helpers.ts
+++ b/packages/libs/sdk-mixins/src/mixins/localeMixin/helpers.ts
@@ -1,0 +1,32 @@
+export type Locale = {
+  locale: string;
+  fallback: string;
+};
+
+/**
+ * Resolves the user-facing locale. Mirrors web-component's getUserLocale exactly so widget
+ * locale resolution matches the flow runtime byte-for-byte.
+ *
+ * Order:
+ *  1. Explicit locale argument (lowercased)
+ *  2. navigator.language (lowercased), with the language part as fallback for 'xx-YY' forms
+ *  3. Empty string
+ */
+export function getUserLocale(locale: string): Locale {
+  if (locale) {
+    return { locale: locale.toLowerCase(), fallback: locale.toLowerCase() };
+  }
+  const nl = navigator.language;
+  if (!nl) {
+    return { locale: '', fallback: '' };
+  }
+
+  if (nl.includes('-')) {
+    return {
+      locale: nl.toLowerCase(),
+      fallback: nl.split('-')[0].toLowerCase(),
+    };
+  }
+
+  return { locale: nl.toLowerCase(), fallback: nl.toLowerCase() };
+}

--- a/packages/libs/sdk-mixins/src/mixins/localeMixin/index.ts
+++ b/packages/libs/sdk-mixins/src/mixins/localeMixin/index.ts
@@ -1,0 +1,3 @@
+export * from './localeMixin';
+export { getUserLocale } from './helpers';
+export type { Locale } from './helpers';

--- a/packages/libs/sdk-mixins/src/mixins/localeMixin/index.ts
+++ b/packages/libs/sdk-mixins/src/mixins/localeMixin/index.ts
@@ -1,3 +1,1 @@
 export * from './localeMixin';
-export { getUserLocale } from './helpers';
-export type { Locale } from './helpers';

--- a/packages/libs/sdk-mixins/src/mixins/localeMixin/localeMixin.ts
+++ b/packages/libs/sdk-mixins/src/mixins/localeMixin/localeMixin.ts
@@ -1,0 +1,21 @@
+import { createSingletonMixin } from '@descope/sdk-helpers';
+import { getUserLocale } from './helpers';
+
+/**
+ * Exposes the widget's locale to mixins that need it (HTML fetching, flow propagation).
+ * Mirrors web-component's BaseDescopeWc locale handling:
+ *  - `locale` getter returns the raw attribute value (undefined if unset/empty)
+ *  - `resolvedLocale` returns the lowercased final locale, falling back to navigator.language
+ */
+export const localeMixin = createSingletonMixin(
+  <T extends CustomElementConstructor>(superclass: T) =>
+    class LocaleMixinClass extends superclass {
+      get locale(): string | undefined {
+        return this.getAttribute('locale') || undefined;
+      }
+
+      get resolvedLocale(): string {
+        return getUserLocale(this.locale || '').locale;
+      }
+    },
+);

--- a/packages/libs/sdk-mixins/src/mixins/localeMixin/localeMixin.ts
+++ b/packages/libs/sdk-mixins/src/mixins/localeMixin/localeMixin.ts
@@ -1,5 +1,4 @@
-import { createSingletonMixin } from '@descope/sdk-helpers';
-import { getUserLocale } from './helpers';
+import { createSingletonMixin, getUserLocale } from '@descope/sdk-helpers';
 
 /**
  * Exposes the widget's locale to mixins that need it (HTML fetching, flow propagation).

--- a/packages/libs/sdk-mixins/src/mixins/localeMixin/localeMixin.ts
+++ b/packages/libs/sdk-mixins/src/mixins/localeMixin/localeMixin.ts
@@ -4,7 +4,8 @@ import { getUserLocale } from './helpers';
 /**
  * Exposes the widget's locale to mixins that need it (HTML fetching, flow propagation).
  * Mirrors web-component's BaseDescopeWc locale handling:
- *  - `locale` getter returns the raw attribute value (undefined if unset/empty)
+ *  - `locale` getter returns the raw attribute value, defaulting to '' when unset (like themeMixin's
+ *    theme/styleId), so callers can pass it straight to setAttribute without emitting "undefined".
  *  - `localeCandidates` returns the lowercased locales to try, most-specific first: the resolved
  *    locale and then its language-only fallback (e.g. 'en-us' then 'en'), matching the
  *    web-component's getHtmlFilenameWithLocale probe order. Falls back to navigator.language.
@@ -12,12 +13,12 @@ import { getUserLocale } from './helpers';
 export const localeMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) =>
     class LocaleMixinClass extends superclass {
-      get locale(): string | undefined {
-        return this.getAttribute('locale') || undefined;
+      get locale(): string {
+        return this.getAttribute('locale') || '';
       }
 
       get localeCandidates(): string[] {
-        const { locale, fallback } = getUserLocale(this.locale || '');
+        const { locale, fallback } = getUserLocale(this.locale);
         return [...new Set([locale, fallback].filter(Boolean))];
       }
     },

--- a/packages/libs/sdk-mixins/src/mixins/localeMixin/localeMixin.ts
+++ b/packages/libs/sdk-mixins/src/mixins/localeMixin/localeMixin.ts
@@ -5,7 +5,9 @@ import { getUserLocale } from './helpers';
  * Exposes the widget's locale to mixins that need it (HTML fetching, flow propagation).
  * Mirrors web-component's BaseDescopeWc locale handling:
  *  - `locale` getter returns the raw attribute value (undefined if unset/empty)
- *  - `resolvedLocale` returns the lowercased final locale, falling back to navigator.language
+ *  - `localeCandidates` returns the lowercased locales to try, most-specific first: the resolved
+ *    locale and then its language-only fallback (e.g. 'en-us' then 'en'), matching the
+ *    web-component's getHtmlFilenameWithLocale probe order. Falls back to navigator.language.
  */
 export const localeMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) =>
@@ -14,8 +16,9 @@ export const localeMixin = createSingletonMixin(
         return this.getAttribute('locale') || undefined;
       }
 
-      get resolvedLocale(): string {
-        return getUserLocale(this.locale || '').locale;
+      get localeCandidates(): string[] {
+        const { locale, fallback } = getUserLocale(this.locale || '');
+        return [...new Set([locale, fallback].filter(Boolean))];
       }
     },
 );

--- a/packages/libs/sdk-mixins/src/mixins/localeMixin/localeMixin.ts
+++ b/packages/libs/sdk-mixins/src/mixins/localeMixin/localeMixin.ts
@@ -8,6 +8,8 @@ import { createSingletonMixin, getUserLocale } from '@descope/sdk-helpers';
  *  - `localeCandidates` returns the lowercased locales to try, most-specific first: the resolved
  *    locale and then its language-only fallback (e.g. 'en-us' then 'en'), matching the
  *    web-component's getHtmlFilenameWithLocale probe order. Falls back to navigator.language.
+ *  - `firstAvailableLocale(availableLocales)` returns the most-specific candidate that the consumer
+ *    actually publishes (e.g. a widget's config.json targetLocales), or '' when none match.
  */
 export const localeMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) =>
@@ -19,6 +21,12 @@ export const localeMixin = createSingletonMixin(
       get localeCandidates(): string[] {
         const { locale, fallback } = getUserLocale(this.locale);
         return [...new Set([locale, fallback].filter(Boolean))];
+      }
+
+      firstAvailableLocale(availableLocales: string[]): string {
+        const available = (availableLocales ?? []).map((l) => l.toLowerCase());
+        // localeCandidates are already lowercased, most-specific first.
+        return this.localeCandidates.find((c) => available.includes(c)) ?? '';
       }
     },
 );

--- a/packages/libs/sdk-mixins/src/mixins/widgetConfigMixin/widgetConfigMixin.ts
+++ b/packages/libs/sdk-mixins/src/mixins/widgetConfigMixin/widgetConfigMixin.ts
@@ -20,6 +20,17 @@ export const widgetConfigMixin = createSingletonMixin(
         const config = await this.config;
         return config?.projectConfig?.widgets?.[this.widgetId];
       }
+
+      // Whether the widget has published localized screens for the given locale (case-insensitive),
+      // per the widget's targetLocales in config.json.
+      async isLocaleAvailable(locale: string): Promise<boolean> {
+        if (!locale) return false;
+        const widgetConfig = await this.getWidgetConfig();
+        const target = locale.toLowerCase();
+        return !!widgetConfig?.targetLocales
+          ?.map((l) => l.toLowerCase())
+          .includes(target);
+      }
     };
   },
 );

--- a/packages/libs/sdk-mixins/src/mixins/widgetConfigMixin/widgetConfigMixin.ts
+++ b/packages/libs/sdk-mixins/src/mixins/widgetConfigMixin/widgetConfigMixin.ts
@@ -34,13 +34,6 @@ export const widgetConfigMixin = createSingletonMixin(
           candidates.find((c) => !!c && targets.includes(c.toLowerCase())) ?? ''
         );
       }
-
-      // Whether the widget has published localized screens for the given locale (case-insensitive),
-      // per the widget's targetLocales in config.json.
-      async isLocaleAvailable(locale: string): Promise<boolean> {
-        if (!locale) return false;
-        return (await this.firstAvailableLocale([locale])) !== '';
-      }
     };
   },
 );

--- a/packages/libs/sdk-mixins/src/mixins/widgetConfigMixin/widgetConfigMixin.ts
+++ b/packages/libs/sdk-mixins/src/mixins/widgetConfigMixin/widgetConfigMixin.ts
@@ -21,15 +21,25 @@ export const widgetConfigMixin = createSingletonMixin(
         return config?.projectConfig?.widgets?.[this.widgetId];
       }
 
+      // The first candidate locale for which the widget has published localized screens
+      // (case-insensitive), per the widget's targetLocales in config.json. Returns '' when none
+      // match. Callers pass candidates most-specific first (e.g. ['en-us', 'en']) so a region
+      // locale falls back to its language, mirroring the web-component's resolution.
+      async firstAvailableLocale(candidates: string[]): Promise<string> {
+        const widgetConfig = await this.getWidgetConfig();
+        const targets = (widgetConfig?.targetLocales ?? []).map((l) =>
+          l.toLowerCase(),
+        );
+        return (
+          candidates.find((c) => !!c && targets.includes(c.toLowerCase())) ?? ''
+        );
+      }
+
       // Whether the widget has published localized screens for the given locale (case-insensitive),
       // per the widget's targetLocales in config.json.
       async isLocaleAvailable(locale: string): Promise<boolean> {
         if (!locale) return false;
-        const widgetConfig = await this.getWidgetConfig();
-        const target = locale.toLowerCase();
-        return !!widgetConfig?.targetLocales
-          ?.map((l) => l.toLowerCase())
-          .includes(target);
+        return (await this.firstAvailableLocale([locale])) !== '';
       }
     };
   },

--- a/packages/libs/sdk-mixins/src/mixins/widgetConfigMixin/widgetConfigMixin.ts
+++ b/packages/libs/sdk-mixins/src/mixins/widgetConfigMixin/widgetConfigMixin.ts
@@ -20,20 +20,6 @@ export const widgetConfigMixin = createSingletonMixin(
         const config = await this.config;
         return config?.projectConfig?.widgets?.[this.widgetId];
       }
-
-      // The first candidate locale for which the widget has published localized screens
-      // (case-insensitive), per the widget's targetLocales in config.json. Returns '' when none
-      // match. Callers pass candidates most-specific first (e.g. ['en-us', 'en']) so a region
-      // locale falls back to its language, mirroring the web-component's resolution.
-      async firstAvailableLocale(candidates: string[]): Promise<string> {
-        const widgetConfig = await this.getWidgetConfig();
-        const targets = (widgetConfig?.targetLocales ?? []).map((l) =>
-          l.toLowerCase(),
-        );
-        return (
-          candidates.find((c) => !!c && targets.includes(c.toLowerCase())) ?? ''
-        );
-      }
     };
   },
 );

--- a/packages/libs/sdk-mixins/test/fetchWidgetPagesMixin.test.ts
+++ b/packages/libs/sdk-mixins/test/fetchWidgetPagesMixin.test.ts
@@ -1,4 +1,6 @@
-import { fetchWidgetPagesMixin } from '../src/lib/widget/mixins/fetchWidgetPagesMixin';
+import { createFetchWidgetPagesMixin } from '../src';
+
+const BASE = 'test-widget';
 
 // configMixin reads config.json and exposes it as `this.config.projectConfig`.
 const configBody = (targetLocales?: string[]) => ({
@@ -20,9 +22,8 @@ const createMixin = (
   attrs: Record<string, string | undefined>,
   { targetLocales, localized, localizedThrows }: FetchOpts = {},
 ) => {
-  const MixinClass = fetchWidgetPagesMixin(
+  const MixinClass = createFetchWidgetPagesMixin(BASE)(
     class {
-      // eslint-disable-next-line class-methods-use-this
       getAttribute(attr: string) {
         return attrs[attr];
       }
@@ -42,7 +43,7 @@ const createMixin = (
   return { m, fetchSpy };
 };
 
-describe('user-profile fetchWidgetPagesMixin (locale-aware fetching)', () => {
+describe('createFetchWidgetPagesMixin (locale-aware fetching)', () => {
   it('fetches the locale-specific page when the locale is available', async () => {
     const { m, fetchSpy } = createMixin(
       { 'widget-id': 'w1', locale: 'es' },
@@ -50,10 +51,7 @@ describe('user-profile fetchWidgetPagesMixin (locale-aware fetching)', () => {
     );
 
     await expect(m.fetchWidgetPage('page.html')).resolves.toBe('LOCALIZED');
-    expect(fetchSpy).toHaveBeenCalledWith(
-      'user-profile-widget/w1/page-es.html',
-      'text',
-    );
+    expect(fetchSpy).toHaveBeenCalledWith(`${BASE}/w1/page-es.html`, 'text');
   });
 
   it('matches the target locale case-insensitively', async () => {
@@ -72,10 +70,7 @@ describe('user-profile fetchWidgetPagesMixin (locale-aware fetching)', () => {
     );
 
     await expect(m.fetchWidgetPage('page.html')).resolves.toBe('DEFAULT');
-    expect(fetchSpy).toHaveBeenCalledWith(
-      'user-profile-widget/w1/page.html',
-      'text',
-    );
+    expect(fetchSpy).toHaveBeenCalledWith(`${BASE}/w1/page.html`, 'text');
   });
 
   it('falls back to the default page when the localized fetch throws', async () => {
@@ -88,7 +83,7 @@ describe('user-profile fetchWidgetPagesMixin (locale-aware fetching)', () => {
   });
 
   // Regression: navigator.language='en-US' against targetLocales=['en'] must use the language
-  // fallback ('en') rather than serving the default page (see resolvedLocale fallback-drop bug).
+  // fallback ('en') rather than serving the default page.
   it('falls back to the language candidate of navigator.language (en-US -> en)', async () => {
     setNavigatorLanguage('en-US');
     const { m, fetchSpy } = createMixin(
@@ -97,9 +92,6 @@ describe('user-profile fetchWidgetPagesMixin (locale-aware fetching)', () => {
     );
 
     await expect(m.fetchWidgetPage('page.html')).resolves.toBe('LOCALIZED');
-    expect(fetchSpy).toHaveBeenCalledWith(
-      'user-profile-widget/w1/page-en.html',
-      'text',
-    );
+    expect(fetchSpy).toHaveBeenCalledWith(`${BASE}/w1/page-en.html`, 'text');
   });
 });

--- a/packages/libs/sdk-mixins/test/localeMixin.test.ts
+++ b/packages/libs/sdk-mixins/test/localeMixin.test.ts
@@ -47,8 +47,8 @@ describe('localeMixin', () => {
     expect(createLocaleMixin({ locale: 'en-US' }).locale).toBe('en-US');
   });
 
-  it('returns undefined when the locale attribute is unset', () => {
-    expect(createLocaleMixin().locale).toBeUndefined();
+  it('returns an empty string when the locale attribute is unset', () => {
+    expect(createLocaleMixin().locale).toBe('');
   });
 
   it('localeCandidates returns only the lowercased explicit locale (no language split for an explicit attr)', () => {

--- a/packages/libs/sdk-mixins/test/localeMixin.test.ts
+++ b/packages/libs/sdk-mixins/test/localeMixin.test.ts
@@ -1,0 +1,62 @@
+import { getUserLocale, localeMixin } from '../src';
+
+const createLocaleMixin = (attrs: Record<string, string | undefined> = {}) => {
+  const MixinClass = localeMixin(
+    class {
+      getAttribute(attr: string) {
+        return attrs[attr];
+      }
+    } as any,
+  );
+  return new MixinClass() as any;
+};
+
+const setNavigatorLanguage = (value: string) => {
+  Object.defineProperty(navigator, 'language', {
+    value,
+    configurable: true,
+  });
+};
+
+describe('getUserLocale', () => {
+  it('lowercases an explicit locale (used as its own fallback)', () => {
+    expect(getUserLocale('en-US')).toEqual({
+      locale: 'en-us',
+      fallback: 'en-us',
+    });
+  });
+
+  it('falls back to navigator.language with the language part as fallback for xx-YY', () => {
+    setNavigatorLanguage('fr-FR');
+    expect(getUserLocale('')).toEqual({ locale: 'fr-fr', fallback: 'fr' });
+  });
+
+  it('uses navigator.language as-is when it has no region', () => {
+    setNavigatorLanguage('de');
+    expect(getUserLocale('')).toEqual({ locale: 'de', fallback: 'de' });
+  });
+
+  it('returns empty strings when there is no locale and no navigator.language', () => {
+    setNavigatorLanguage('');
+    expect(getUserLocale('')).toEqual({ locale: '', fallback: '' });
+  });
+});
+
+describe('localeMixin', () => {
+  it('exposes the raw locale attribute', () => {
+    expect(createLocaleMixin({ locale: 'en-US' }).locale).toBe('en-US');
+  });
+
+  it('returns undefined when the locale attribute is unset', () => {
+    expect(createLocaleMixin().locale).toBeUndefined();
+  });
+
+  it('resolvedLocale lowercases the attribute locale', () => {
+    expect(createLocaleMixin({ locale: 'en-US' }).resolvedLocale).toBe('en-us');
+  });
+
+  it('resolvedLocale falls back to navigator.language when no attribute is set', () => {
+    setNavigatorLanguage('es-ES');
+    expect(createLocaleMixin().resolvedLocale).toBe('es-es');
+  });
+});

--- a/packages/libs/sdk-mixins/test/localeMixin.test.ts
+++ b/packages/libs/sdk-mixins/test/localeMixin.test.ts
@@ -51,12 +51,24 @@ describe('localeMixin', () => {
     expect(createLocaleMixin().locale).toBeUndefined();
   });
 
-  it('resolvedLocale lowercases the attribute locale', () => {
-    expect(createLocaleMixin({ locale: 'en-US' }).resolvedLocale).toBe('en-us');
+  it('localeCandidates returns only the lowercased explicit locale (no language split for an explicit attr)', () => {
+    expect(createLocaleMixin({ locale: 'en-US' }).localeCandidates).toEqual([
+      'en-us',
+    ]);
   });
 
-  it('resolvedLocale falls back to navigator.language when no attribute is set', () => {
-    setNavigatorLanguage('es-ES');
-    expect(createLocaleMixin().resolvedLocale).toBe('es-es');
+  it('localeCandidates falls back to the language part for a region navigator.language', () => {
+    setNavigatorLanguage('en-US');
+    expect(createLocaleMixin().localeCandidates).toEqual(['en-us', 'en']);
+  });
+
+  it('localeCandidates is a single entry when navigator.language has no region', () => {
+    setNavigatorLanguage('de');
+    expect(createLocaleMixin().localeCandidates).toEqual(['de']);
+  });
+
+  it('localeCandidates is empty when there is no locale and no navigator.language', () => {
+    setNavigatorLanguage('');
+    expect(createLocaleMixin().localeCandidates).toEqual([]);
   });
 });

--- a/packages/libs/sdk-mixins/test/localeMixin.test.ts
+++ b/packages/libs/sdk-mixins/test/localeMixin.test.ts
@@ -1,4 +1,4 @@
-import { getUserLocale, localeMixin } from '../src';
+import { localeMixin } from '../src';
 
 const createLocaleMixin = (attrs: Record<string, string | undefined> = {}) => {
   const MixinClass = localeMixin(
@@ -17,30 +17,6 @@ const setNavigatorLanguage = (value: string) => {
     configurable: true,
   });
 };
-
-describe('getUserLocale', () => {
-  it('lowercases an explicit locale (used as its own fallback)', () => {
-    expect(getUserLocale('en-US')).toEqual({
-      locale: 'en-us',
-      fallback: 'en-us',
-    });
-  });
-
-  it('falls back to navigator.language with the language part as fallback for xx-YY', () => {
-    setNavigatorLanguage('fr-FR');
-    expect(getUserLocale('')).toEqual({ locale: 'fr-fr', fallback: 'fr' });
-  });
-
-  it('uses navigator.language as-is when it has no region', () => {
-    setNavigatorLanguage('de');
-    expect(getUserLocale('')).toEqual({ locale: 'de', fallback: 'de' });
-  });
-
-  it('returns empty strings when there is no locale and no navigator.language', () => {
-    setNavigatorLanguage('');
-    expect(getUserLocale('')).toEqual({ locale: '', fallback: '' });
-  });
-});
 
 describe('localeMixin', () => {
   it('exposes the raw locale attribute', () => {

--- a/packages/libs/sdk-mixins/test/localeMixin.test.ts
+++ b/packages/libs/sdk-mixins/test/localeMixin.test.ts
@@ -47,4 +47,29 @@ describe('localeMixin', () => {
     setNavigatorLanguage('');
     expect(createLocaleMixin().localeCandidates).toEqual([]);
   });
+
+  describe('firstAvailableLocale', () => {
+    it('returns the matching candidate present in the available locales (case-insensitive)', () => {
+      expect(
+        createLocaleMixin({ locale: 'fr' }).firstAvailableLocale(['ES', 'FR']),
+      ).toBe('fr');
+    });
+
+    it('falls back from a region locale to its language candidate', () => {
+      setNavigatorLanguage('en-US'); // candidates: ['en-us', 'en']
+      expect(createLocaleMixin().firstAvailableLocale(['en'])).toBe('en');
+    });
+
+    it('returns empty string when no candidate is available', () => {
+      expect(
+        createLocaleMixin({ locale: 'de' }).firstAvailableLocale(['es', 'fr']),
+      ).toBe('');
+    });
+
+    it('returns empty string when there are no available locales', () => {
+      expect(createLocaleMixin({ locale: 'es' }).firstAvailableLocale([])).toBe(
+        '',
+      );
+    });
+  });
 });

--- a/packages/libs/sdk-mixins/test/widgetConfigMixin.test.ts
+++ b/packages/libs/sdk-mixins/test/widgetConfigMixin.test.ts
@@ -39,28 +39,6 @@ describe('widgetConfigMixin', () => {
     });
   });
 
-  describe('isLocaleAvailable', () => {
-    it('matches a target locale case-insensitively', async () => {
-      const m = createMixin('w1');
-      await expect(m.isLocaleAvailable('ES')).resolves.toBe(true);
-    });
-
-    it('is false for a locale not in targetLocales', async () => {
-      const m = createMixin('w1');
-      await expect(m.isLocaleAvailable('de')).resolves.toBe(false);
-    });
-
-    it('is false for an empty locale', async () => {
-      const m = createMixin('w1');
-      await expect(m.isLocaleAvailable('')).resolves.toBe(false);
-    });
-
-    it('is false when the widget has no targetLocales', async () => {
-      const m = createMixin('w2');
-      await expect(m.isLocaleAvailable('es')).resolves.toBe(false);
-    });
-  });
-
   describe('firstAvailableLocale', () => {
     it('returns the first candidate present in targetLocales (case-insensitive)', async () => {
       const m = createMixin('w1'); // targetLocales: ['es', 'fr']

--- a/packages/libs/sdk-mixins/test/widgetConfigMixin.test.ts
+++ b/packages/libs/sdk-mixins/test/widgetConfigMixin.test.ts
@@ -38,26 +38,4 @@ describe('widgetConfigMixin', () => {
       await expect(m.getWidgetConfig()).resolves.toBeUndefined();
     });
   });
-
-  describe('firstAvailableLocale', () => {
-    it('returns the first candidate present in targetLocales (case-insensitive)', async () => {
-      const m = createMixin('w1'); // targetLocales: ['es', 'fr']
-      await expect(m.firstAvailableLocale(['EN', 'FR'])).resolves.toBe('FR');
-    });
-
-    it('falls back from a region locale to its language candidate', async () => {
-      const m = createMixin('w1'); // targetLocales: ['es', 'fr']
-      await expect(m.firstAvailableLocale(['es-es', 'es'])).resolves.toBe('es');
-    });
-
-    it('returns empty string when no candidate is available', async () => {
-      const m = createMixin('w1');
-      await expect(m.firstAvailableLocale(['de', 'it'])).resolves.toBe('');
-    });
-
-    it('returns empty string when the widget has no targetLocales', async () => {
-      const m = createMixin('w2');
-      await expect(m.firstAvailableLocale(['es', 'en'])).resolves.toBe('');
-    });
-  });
 });

--- a/packages/libs/sdk-mixins/test/widgetConfigMixin.test.ts
+++ b/packages/libs/sdk-mixins/test/widgetConfigMixin.test.ts
@@ -60,4 +60,26 @@ describe('widgetConfigMixin', () => {
       await expect(m.isLocaleAvailable('es')).resolves.toBe(false);
     });
   });
+
+  describe('firstAvailableLocale', () => {
+    it('returns the first candidate present in targetLocales (case-insensitive)', async () => {
+      const m = createMixin('w1'); // targetLocales: ['es', 'fr']
+      await expect(m.firstAvailableLocale(['EN', 'FR'])).resolves.toBe('FR');
+    });
+
+    it('falls back from a region locale to its language candidate', async () => {
+      const m = createMixin('w1'); // targetLocales: ['es', 'fr']
+      await expect(m.firstAvailableLocale(['es-es', 'es'])).resolves.toBe('es');
+    });
+
+    it('returns empty string when no candidate is available', async () => {
+      const m = createMixin('w1');
+      await expect(m.firstAvailableLocale(['de', 'it'])).resolves.toBe('');
+    });
+
+    it('returns empty string when the widget has no targetLocales', async () => {
+      const m = createMixin('w2');
+      await expect(m.firstAvailableLocale(['es', 'en'])).resolves.toBe('');
+    });
+  });
 });

--- a/packages/libs/sdk-mixins/test/widgetConfigMixin.test.ts
+++ b/packages/libs/sdk-mixins/test/widgetConfigMixin.test.ts
@@ -1,0 +1,63 @@
+import { widgetConfigMixin } from '../src';
+
+const projectConfig = {
+  widgets: {
+    w1: { version: 2, targetLocales: ['es', 'fr'] },
+    w2: { allowSubTenants: true },
+  },
+};
+
+const createMixin = (widgetId: string | undefined) => {
+  const MixinClass = widgetConfigMixin(
+    class {
+      getAttribute(attr: string) {
+        return attr === 'widget-id' ? widgetId : undefined;
+      }
+    } as any,
+  );
+  const m = new MixinClass() as any;
+  // configMixin reads config.json via fetchStaticResource and exposes it as `this.config`.
+  m.fetchStaticResource = jest
+    .fn()
+    .mockResolvedValue({ body: projectConfig, headers: {} });
+  return m;
+};
+
+describe('widgetConfigMixin', () => {
+  describe('getWidgetConfig', () => {
+    it('returns the per-widget entry from config.json', async () => {
+      const m = createMixin('w1');
+      await expect(m.getWidgetConfig()).resolves.toEqual({
+        version: 2,
+        targetLocales: ['es', 'fr'],
+      });
+    });
+
+    it('returns undefined for an unknown widget id', async () => {
+      const m = createMixin('nope');
+      await expect(m.getWidgetConfig()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('isLocaleAvailable', () => {
+    it('matches a target locale case-insensitively', async () => {
+      const m = createMixin('w1');
+      await expect(m.isLocaleAvailable('ES')).resolves.toBe(true);
+    });
+
+    it('is false for a locale not in targetLocales', async () => {
+      const m = createMixin('w1');
+      await expect(m.isLocaleAvailable('de')).resolves.toBe(false);
+    });
+
+    it('is false for an empty locale', async () => {
+      const m = createMixin('w1');
+      await expect(m.isLocaleAvailable('')).resolves.toBe(false);
+    });
+
+    it('is false when the widget has no targetLocales', async () => {
+      const m = createMixin('w2');
+      await expect(m.isLocaleAvailable('es')).resolves.toBe(false);
+    });
+  });
+});

--- a/packages/sdks/angular-sdk/README.md
+++ b/packages/sdks/angular-sdk/README.md
@@ -526,6 +526,16 @@ Important Note:
 
 - For the user to be able to use the widget, they need to be assigned the `Tenant Admin` Role.
 
+All widget components accept an optional `locale` input. It can be any supported locale the widget's screens are translated to; if not provided, the locale is taken from the browser's locale.
+
+```html
+<user-management
+  tenant="tenant-id"
+  widgetId="user-management-widget"
+  locale="en"
+/>
+```
+
 #### User Management
 
 The `UserManagement` widget will let you embed a user table in your site to view and take action.

--- a/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/access-key-management/access-key-management.component.ts
+++ b/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/access-key-management/access-key-management.component.ts
@@ -26,6 +26,8 @@ export class AccessKeyManagementComponent extends BaseLazyWidgetComponent {
   @Input() widgetId: string;
 
   @Input() theme: 'light' | 'dark' | 'os';
+
+  @Input() locale: string;
   @Input() debug: boolean;
   @Input() logger: ILogger;
   @Input() styleId: string;
@@ -75,6 +77,9 @@ export class AccessKeyManagementComponent extends BaseLazyWidgetComponent {
     }
     if (this.theme) {
       this.webComponent.setAttribute('theme', this.theme);
+    }
+    if (this.locale) {
+      this.webComponent.setAttribute('locale', this.locale);
     }
     if (this.debug) {
       this.webComponent.setAttribute('debug', this.debug.toString());

--- a/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/applications-portal/applications-portal.component.ts
+++ b/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/applications-portal/applications-portal.component.ts
@@ -23,6 +23,8 @@ export class ApplicationsPortalComponent extends BaseLazyWidgetComponent {
   @Input() widgetId: string;
 
   @Input() theme: 'light' | 'dark' | 'os';
+
+  @Input() locale: string;
   @Input() debug: boolean;
   @Input() logger: ILogger;
   @Input() styleId: string;
@@ -71,6 +73,9 @@ export class ApplicationsPortalComponent extends BaseLazyWidgetComponent {
     }
     if (this.theme) {
       this.webComponent.setAttribute('theme', this.theme);
+    }
+    if (this.locale) {
+      this.webComponent.setAttribute('locale', this.locale);
     }
     if (this.debug) {
       this.webComponent.setAttribute('debug', this.debug.toString());

--- a/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/audit-management/audit-management.component.ts
+++ b/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/audit-management/audit-management.component.ts
@@ -26,6 +26,8 @@ export class AuditManagementComponent extends BaseLazyWidgetComponent {
   @Input() widgetId: string;
 
   @Input() theme: 'light' | 'dark' | 'os';
+
+  @Input() locale: string;
   @Input() debug: boolean;
   @Input() logger: ILogger;
   @Input() styleId: string;
@@ -73,6 +75,9 @@ export class AuditManagementComponent extends BaseLazyWidgetComponent {
     }
     if (this.theme) {
       this.webComponent.setAttribute('theme', this.theme);
+    }
+    if (this.locale) {
+      this.webComponent.setAttribute('locale', this.locale);
     }
     if (this.debug) {
       this.webComponent.setAttribute('debug', this.debug.toString());

--- a/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/role-management/role-management.component.ts
+++ b/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/role-management/role-management.component.ts
@@ -26,6 +26,8 @@ export class RoleManagementComponent extends BaseLazyWidgetComponent {
   @Input() widgetId: string;
 
   @Input() theme: 'light' | 'dark' | 'os';
+
+  @Input() locale: string;
   @Input() debug: boolean;
   @Input() logger: ILogger;
   @Input() styleId: string;
@@ -73,6 +75,9 @@ export class RoleManagementComponent extends BaseLazyWidgetComponent {
     }
     if (this.theme) {
       this.webComponent.setAttribute('theme', this.theme);
+    }
+    if (this.locale) {
+      this.webComponent.setAttribute('locale', this.locale);
     }
     if (this.debug) {
       this.webComponent.setAttribute('debug', this.debug.toString());

--- a/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/user-management/user-management.component.ts
+++ b/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/user-management/user-management.component.ts
@@ -26,6 +26,8 @@ export class UserManagementComponent extends BaseLazyWidgetComponent {
   @Input() widgetId: string;
 
   @Input() theme: 'light' | 'dark' | 'os';
+
+  @Input() locale: string;
   @Input() debug: boolean;
   @Input() logger: ILogger;
   @Input() styleId: string;
@@ -74,6 +76,9 @@ export class UserManagementComponent extends BaseLazyWidgetComponent {
     }
     if (this.theme) {
       this.webComponent.setAttribute('theme', this.theme);
+    }
+    if (this.locale) {
+      this.webComponent.setAttribute('locale', this.locale);
     }
     if (this.debug) {
       this.webComponent.setAttribute('debug', this.debug.toString());

--- a/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/user-profile/user-profile.component.ts
+++ b/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/user-profile/user-profile.component.ts
@@ -24,6 +24,8 @@ export class UserProfileComponent extends BaseLazyWidgetComponent {
   @Input() widgetId: string;
 
   @Input() theme: 'light' | 'dark' | 'os';
+
+  @Input() locale: string;
   @Input() debug: boolean;
   @Input() logger: ILogger;
   @Input() styleId: string;
@@ -73,6 +75,9 @@ export class UserProfileComponent extends BaseLazyWidgetComponent {
     }
     if (this.theme) {
       this.webComponent.setAttribute('theme', this.theme);
+    }
+    if (this.locale) {
+      this.webComponent.setAttribute('locale', this.locale);
     }
     if (this.debug) {
       this.webComponent.setAttribute('debug', this.debug.toString());

--- a/packages/sdks/react-sdk/README.md
+++ b/packages/sdks/react-sdk/README.md
@@ -615,6 +615,12 @@ Important Note:
 
 - For the user to be able to use the widget, they need to be assigned the `Tenant Admin` Role.
 
+All widget components accept an optional `locale` prop. It can be any supported locale the widget's screens are translated to; if not provided, the locale is taken from the browser's locale.
+
+```jsx
+<UserManagement widgetId="user-management-widget" tenant="tenant-id" locale="en" />
+```
+
 #### User Management
 
 The `UserManagement` widget lets you embed a user table in your site to view and take action.

--- a/packages/sdks/react-sdk/src/components/AccessKeyManagement.tsx
+++ b/packages/sdks/react-sdk/src/components/AccessKeyManagement.tsx
@@ -16,7 +16,7 @@ const AccessKeyManagementWC = lazy(async () => {
   return {
     default: withPropsMapping(
       React.forwardRef<HTMLElement>((props, ref) => (
-	<descope-access-key-management-widget ref={ref} {...props} />
+        <descope-access-key-management-widget ref={ref} {...props} />
       )),
     ),
   };
@@ -25,45 +25,51 @@ const AccessKeyManagementWC = lazy(async () => {
 const AccessKeyManagement = React.forwardRef<
   HTMLElement,
   AccessKeyManagementProps
->(({ logger, tenant, theme, debug, widgetId, styleId, onReady }, ref) => {
-  const [innerRef, setInnerRef] = useState(null);
+>(
+  (
+    { logger, tenant, theme, locale, debug, widgetId, styleId, onReady },
+    ref,
+  ) => {
+    const [innerRef, setInnerRef] = useState(null);
 
-  useImperativeHandle(ref, () => innerRef);
+    useImperativeHandle(ref, () => innerRef);
 
-  const { projectId, baseUrl, baseStaticUrl, baseCdnUrl, refreshCookieName } =
-    React.useContext(Context);
+    const { projectId, baseUrl, baseStaticUrl, baseCdnUrl, refreshCookieName } =
+      React.useContext(Context);
 
-  useEffect(() => {
-    const ele = innerRef;
-    if (onReady) ele?.addEventListener('ready', onReady);
+    useEffect(() => {
+      const ele = innerRef;
+      if (onReady) ele?.addEventListener('ready', onReady);
 
-    return () => {
-      if (onReady) ele?.removeEventListener('ready', onReady);
-    };
-  }, [innerRef, onReady]);
+      return () => {
+        if (onReady) ele?.removeEventListener('ready', onReady);
+      };
+    }, [innerRef, onReady]);
 
-  return (
-	<Suspense fallback={null}>
-		<AccessKeyManagementWC
-        ref={setInnerRef}
-        projectId={projectId}
-        widgetId={widgetId}
-        tenant={tenant}
-        baseUrl={baseUrl}
-        baseStaticUrl={baseStaticUrl}
-        baseCdnUrl={baseCdnUrl}
-        {...{
-          // attributes
-          'theme.attr': theme,
-          'debug.attr': debug,
-          'styleId.attr': styleId,
-          'refreshCookieName.attr': refreshCookieName,
-          // props
-          'logger.prop': logger,
-        }}
-      />
-	</Suspense>
-  );
-});
+    return (
+      <Suspense fallback={null}>
+        <AccessKeyManagementWC
+          ref={setInnerRef}
+          projectId={projectId}
+          widgetId={widgetId}
+          tenant={tenant}
+          baseUrl={baseUrl}
+          baseStaticUrl={baseStaticUrl}
+          baseCdnUrl={baseCdnUrl}
+          {...{
+            // attributes
+            'theme.attr': theme,
+            'locale.attr': locale,
+            'debug.attr': debug,
+            'styleId.attr': styleId,
+            'refreshCookieName.attr': refreshCookieName,
+            // props
+            'logger.prop': logger,
+          }}
+        />
+      </Suspense>
+    );
+  },
+);
 
 export default AccessKeyManagement;

--- a/packages/sdks/react-sdk/src/components/ApplicationsPortal.tsx
+++ b/packages/sdks/react-sdk/src/components/ApplicationsPortal.tsx
@@ -25,7 +25,7 @@ const ApplicationsPortalWC = lazy(async () => {
 const ApplicationsPortal = React.forwardRef<
   HTMLElement,
   ApplicationsPortalProps
->(({ logger, theme, debug, widgetId, styleId, onReady }, ref) => {
+>(({ logger, theme, locale, debug, widgetId, styleId, onReady }, ref) => {
   const [innerRef, setInnerRef] = useState(null);
 
   useImperativeHandle(ref, () => innerRef);
@@ -54,6 +54,7 @@ const ApplicationsPortal = React.forwardRef<
         {...{
           // attributes
           'theme.attr': theme,
+          'locale.attr': locale,
           'debug.attr': debug,
           'styleId.attr': styleId,
           'refreshCookieName.attr': refreshCookieName,

--- a/packages/sdks/react-sdk/src/components/AuditManagement.tsx
+++ b/packages/sdks/react-sdk/src/components/AuditManagement.tsx
@@ -23,7 +23,10 @@ const AuditManagementWC = lazy(async () => {
 });
 
 const AuditManagement = React.forwardRef<HTMLElement, AuditManagementProps>(
-  ({ logger, tenant, theme, debug, widgetId, styleId, onReady }, ref) => {
+  (
+    { logger, tenant, theme, locale, debug, widgetId, styleId, onReady },
+    ref,
+  ) => {
     const [innerRef, setInnerRef] = useState(null);
 
     useImperativeHandle(ref, () => innerRef);
@@ -53,6 +56,7 @@ const AuditManagement = React.forwardRef<HTMLElement, AuditManagementProps>(
           {...{
             // attributes
             'theme.attr': theme,
+            'locale.attr': locale,
             'debug.attr': debug,
             'styleId.attr': styleId,
             'refreshCookieName.attr': refreshCookieName,

--- a/packages/sdks/react-sdk/src/components/OutboundApplications.tsx
+++ b/packages/sdks/react-sdk/src/components/OutboundApplications.tsx
@@ -16,7 +16,7 @@ const OutboundApplicationsWC = lazy(async () => {
   return {
     default: withPropsMapping(
       React.forwardRef<HTMLElement>((props, ref) => (
-        <descope-outbound-applications-widget ref={ref} {...props} />
+	<descope-outbound-applications-widget ref={ref} {...props} />
       )),
     ),
   };
@@ -25,7 +25,7 @@ const OutboundApplicationsWC = lazy(async () => {
 const OutboundApplications = React.forwardRef<
   HTMLElement,
   OutboundApplicationsProps
->(({ logger, theme, debug, widgetId, styleId, onReady }, ref) => {
+>(({ logger, theme, locale, debug, widgetId, styleId, onReady }, ref) => {
   const [innerRef, setInnerRef] = useState(null);
 
   useImperativeHandle(ref, () => innerRef);
@@ -43,8 +43,8 @@ const OutboundApplications = React.forwardRef<
   }, [innerRef, onReady]);
 
   return (
-    <Suspense fallback={null}>
-      <OutboundApplicationsWC
+	<Suspense fallback={null}>
+		<OutboundApplicationsWC
         ref={setInnerRef}
         projectId={projectId}
         widgetId={widgetId}
@@ -54,6 +54,7 @@ const OutboundApplications = React.forwardRef<
         {...{
           // attributes
           'theme.attr': theme,
+          'locale.attr': locale,
           'debug.attr': debug,
           'styleId.attr': styleId,
           'refreshCookieName.attr': refreshCookieName,
@@ -61,7 +62,7 @@ const OutboundApplications = React.forwardRef<
           'logger.prop': logger,
         }}
       />
-    </Suspense>
+	</Suspense>
   );
 });
 

--- a/packages/sdks/react-sdk/src/components/RoleManagement.tsx
+++ b/packages/sdks/react-sdk/src/components/RoleManagement.tsx
@@ -23,7 +23,10 @@ const RoleManagementWC = lazy(async () => {
 });
 
 const RoleManagement = React.forwardRef<HTMLElement, RoleManagementProps>(
-  ({ logger, tenant, theme, debug, widgetId, styleId, onReady }, ref) => {
+  (
+    { logger, tenant, theme, locale, debug, widgetId, styleId, onReady },
+    ref,
+  ) => {
     const [innerRef, setInnerRef] = useState(null);
 
     useImperativeHandle(ref, () => innerRef);
@@ -53,6 +56,7 @@ const RoleManagement = React.forwardRef<HTMLElement, RoleManagementProps>(
           {...{
             // attributes
             'theme.attr': theme,
+            'locale.attr': locale,
             'debug.attr': debug,
             'styleId.attr': styleId,
             'refreshCookieName.attr': refreshCookieName,

--- a/packages/sdks/react-sdk/src/components/TenantProfile.tsx
+++ b/packages/sdks/react-sdk/src/components/TenantProfile.tsx
@@ -22,7 +22,10 @@ const TenantProfileWC = lazy(async () => {
 });
 
 const TenantProfile = React.forwardRef<HTMLElement, TenantProfileProps>(
-  ({ logger, theme, debug, widgetId, styleId, tenant, onReady }, ref) => {
+  (
+    { logger, theme, locale, debug, widgetId, styleId, tenant, onReady },
+    ref,
+  ) => {
     const [innerRef, setInnerRef] = useState(null);
 
     useImperativeHandle(ref, () => innerRef);
@@ -52,6 +55,7 @@ const TenantProfile = React.forwardRef<HTMLElement, TenantProfileProps>(
           ref={setInnerRef}
           {...{
             'theme.attr': theme,
+            'locale.attr': locale,
             'debug.attr': debug,
             'styleId.attr': styleId,
             'tenant.attr': tenant,

--- a/packages/sdks/react-sdk/src/components/UserManagement.tsx
+++ b/packages/sdks/react-sdk/src/components/UserManagement.tsx
@@ -23,7 +23,10 @@ const UserManagementWC = lazy(async () => {
 });
 
 const UserManagement = React.forwardRef<HTMLElement, UserManagementProps>(
-  ({ logger, tenant, theme, debug, widgetId, styleId, onReady }, ref) => {
+  (
+    { logger, tenant, theme, locale, debug, widgetId, styleId, onReady },
+    ref,
+  ) => {
     const [innerRef, setInnerRef] = useState(null);
 
     useImperativeHandle(ref, () => innerRef);
@@ -53,6 +56,7 @@ const UserManagement = React.forwardRef<HTMLElement, UserManagementProps>(
           {...{
             // attributes
             'theme.attr': theme,
+            'locale.attr': locale,
             'debug.attr': debug,
             'styleId.attr': styleId,
             'refreshCookieName.attr': refreshCookieName,

--- a/packages/sdks/react-sdk/src/components/UserProfile.tsx
+++ b/packages/sdks/react-sdk/src/components/UserProfile.tsx
@@ -24,7 +24,10 @@ const UserProfileWC = lazy(async () => {
 });
 
 const UserProfile = React.forwardRef<HTMLElement, UserProfileProps>(
-  ({ logger, theme, debug, widgetId, onLogout, styleId, onReady }, ref) => {
+  (
+    { logger, theme, locale, debug, widgetId, onLogout, styleId, onReady },
+    ref,
+  ) => {
     const [innerRef, setInnerRef] = useState(null);
 
     useImperativeHandle(ref, () => innerRef);
@@ -83,6 +86,7 @@ const UserProfile = React.forwardRef<HTMLElement, UserProfileProps>(
           {...{
             // attributes
             'theme.attr': theme,
+            'locale.attr': locale,
             'debug.attr': debug,
             'styleId.attr': styleId,
             'refreshCookieName.attr': refreshCookieName,

--- a/packages/sdks/react-sdk/src/types.ts
+++ b/packages/sdks/react-sdk/src/types.ts
@@ -41,6 +41,8 @@ type WidgetProps = {
   widgetId: string;
   // If theme is not provided - the OS theme will be used
   theme?: ThemeOptions;
+  // If locale is not provided - the browser's locale will be used
+  locale?: string;
   debug?: boolean;
   styleId?: string;
   onReady?: CustomEventCb<{}>;

--- a/packages/sdks/vue-sdk/README.md
+++ b/packages/sdks/vue-sdk/README.md
@@ -316,6 +316,12 @@ Important Note:
 
 - For the user to be able to use the widget, they need to be assigned the `Tenant Admin` Role.
 
+All widget components accept an optional `locale` prop. It can be any supported locale the widget's screens are translated to; if not provided, the locale is taken from the browser's locale.
+
+```html
+<UserManagement widget-id="user-management-widget" tenant="tenant-id" locale="en" />
+```
+
 #### User Management
 
 The `UserManagement` widget lets you embed a user table in your site to view and take action.

--- a/packages/sdks/vue-sdk/src/AccessKeyManagement.vue
+++ b/packages/sdks/vue-sdk/src/AccessKeyManagement.vue
@@ -7,6 +7,7 @@
       :base-static-url="baseStaticUrl"
       :base-cdn-url="baseCdnUrl"
       :theme.attr="theme"
+      :locale.attr="locale"
       :tenant.attr="tenant"
       :debug.attr="debug"
       :widget-id="widgetId"
@@ -30,6 +31,9 @@ defineProps({
     required: true,
   },
   theme: {
+    type: String,
+  },
+  locale: {
     type: String,
   },
   styleId: {

--- a/packages/sdks/vue-sdk/src/ApplicationsPortal.vue
+++ b/packages/sdks/vue-sdk/src/ApplicationsPortal.vue
@@ -7,6 +7,7 @@
       :base-static-url="baseStaticUrl"
       :base-cdn-url="baseCdnUrl"
       :theme.attr="theme"
+      :locale.attr="locale"
       :debug.attr="debug"
       :widget-id="widgetId"
       :style-id="styleId"
@@ -25,6 +26,9 @@ defineProps({
     required: true,
   },
   theme: {
+    type: String,
+  },
+  locale: {
     type: String,
   },
   styleId: {

--- a/packages/sdks/vue-sdk/src/AuditManagement.vue
+++ b/packages/sdks/vue-sdk/src/AuditManagement.vue
@@ -7,6 +7,7 @@
       :base-static-url="baseStaticUrl"
       :base-cdn-url="baseCdnUrl"
       :theme.attr="theme"
+      :locale.attr="locale"
       :tenant.attr="tenant"
       :debug.attr="debug"
       :widget-id="widgetId"
@@ -30,6 +31,9 @@ defineProps({
     required: true,
   },
   theme: {
+    type: String,
+  },
+  locale: {
     type: String,
   },
   styleId: {

--- a/packages/sdks/vue-sdk/src/RoleManagement.vue
+++ b/packages/sdks/vue-sdk/src/RoleManagement.vue
@@ -7,6 +7,7 @@
       :base-cdn-url="baseCdnUrl"
       :base-static-url="baseStaticUrl"
       :theme.attr="theme"
+      :locale.attr="locale"
       :tenant.attr="tenant"
       :debug.attr="debug"
       :widget-id="widgetId"
@@ -30,6 +31,9 @@ defineProps({
     required: true,
   },
   theme: {
+    type: String,
+  },
+  locale: {
     type: String,
   },
   styleId: {

--- a/packages/sdks/vue-sdk/src/UserManagement.vue
+++ b/packages/sdks/vue-sdk/src/UserManagement.vue
@@ -7,6 +7,7 @@
       :base-static-url="baseStaticUrl"
       :base-cdn-url="baseCdnUrl"
       :theme.attr="theme"
+      :locale.attr="locale"
       :tenant.attr="tenant"
       :debug.attr="debug"
       :widget-id="widgetId"
@@ -30,6 +31,9 @@ defineProps({
     required: true,
   },
   theme: {
+    type: String,
+  },
+  locale: {
     type: String,
   },
   styleId: {

--- a/packages/sdks/vue-sdk/src/UserProfile.vue
+++ b/packages/sdks/vue-sdk/src/UserProfile.vue
@@ -7,6 +7,7 @@
       :base-static-url="baseStaticUrl"
       :base-cdn-url="baseCdnUrl"
       :theme.attr="theme"
+      :locale.attr="locale"
       :debug.attr="debug"
       :widget-id="widgetId"
       :style-id="styleId"
@@ -40,6 +41,9 @@ defineProps({
     required: true,
   },
   theme: {
+    type: String,
+  },
+  locale: {
     type: String,
   },
   styleId: {

--- a/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
+++ b/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
@@ -1,3 +1,4 @@
+import { getUserLocale } from '@descope/sdk-helpers';
 import {
   clearFingerprintData,
   ensureFingerprintIds,
@@ -27,7 +28,6 @@ import {
   getElementDescopeAttributes,
   getFirstNonEmptyValue,
   getScriptResultPath,
-  getUserLocale,
   handleAutoFocus,
   handleReportValidityOnBlur,
   injectSamlIdpForm,

--- a/packages/sdks/web-component/src/lib/helpers/helpers.ts
+++ b/packages/sdks/web-component/src/lib/helpers/helpers.ts
@@ -33,10 +33,10 @@ import {
   AutoFocusOptions,
   CustomScreenState,
   Direction,
-  Locale,
   SSOQueryParams,
   StepState,
 } from '../types';
+export { getUserLocale } from '@descope/sdk-helpers';
 
 const MD_COMPONENTS = ['descope-enriched-text'];
 
@@ -814,25 +814,6 @@ export const leadingDebounce = <T extends (...args: any[]) => void>(
     }, wait);
   } as T;
 };
-
-export function getUserLocale(locale: string): Locale {
-  if (locale) {
-    return { locale: locale.toLowerCase(), fallback: locale.toLowerCase() };
-  }
-  const nl = navigator.language;
-  if (!nl) {
-    return { locale: '', fallback: '' };
-  }
-
-  if (nl.includes('-')) {
-    return {
-      locale: nl.toLowerCase(),
-      fallback: nl.split('-')[0].toLowerCase(),
-    };
-  }
-
-  return { locale: nl.toLowerCase(), fallback: nl.toLowerCase() };
-}
 
 export const clearPreviousExternalInputs = () => {
   document

--- a/packages/sdks/web-component/src/lib/helpers/helpers.ts
+++ b/packages/sdks/web-component/src/lib/helpers/helpers.ts
@@ -36,7 +36,6 @@ import {
   SSOQueryParams,
   StepState,
 } from '../types';
-export { getUserLocale } from '@descope/sdk-helpers';
 
 const MD_COMPONENTS = ['descope-enriched-text'];
 

--- a/packages/sdks/web-component/src/lib/types.ts
+++ b/packages/sdks/web-component/src/lib/types.ts
@@ -91,8 +91,6 @@ export type OIDCOptions = {
   oidcResource?: string;
 };
 
-export type { Locale } from '@descope/sdk-helpers';
-
 export type FlowState = {
   flowId: string;
   projectId: string;

--- a/packages/sdks/web-component/src/lib/types.ts
+++ b/packages/sdks/web-component/src/lib/types.ts
@@ -91,10 +91,7 @@ export type OIDCOptions = {
   oidcResource?: string;
 };
 
-export type Locale = {
-  locale: string;
-  fallback: string;
-};
+export type { Locale } from '@descope/sdk-helpers';
 
 export type FlowState = {
   flowId: string;

--- a/packages/widgets/access-key-management-widget/rollup.config.app.mjs
+++ b/packages/widgets/access-key-management-widget/rollup.config.app.mjs
@@ -29,6 +29,7 @@ export default {
         ),
         DESCOPE_TENANT: JSON.stringify(process.env.DESCOPE_TENANT || ''),
         DESCOPE_WIDGET_ID: JSON.stringify(process.env.DESCOPE_WIDGET_ID || ''),
+        DESCOPE_LOCALE: JSON.stringify(process.env.DESCOPE_LOCALE || ''),
       },
     }),
     del({ targets: 'build' }),

--- a/packages/widgets/access-key-management-widget/src/app/index.html
+++ b/packages/widgets/access-key-management-widget/src/app/index.html
@@ -83,6 +83,9 @@
         widgetEle.setAttribute('base-static-url', DESCOPE_BASE_STATIC_URL);
         widgetEle.setAttribute('tenant', DESCOPE_TENANT);
         widgetEle.setAttribute('widget-id', DESCOPE_WIDGET_ID);
+        if (DESCOPE_LOCALE) {
+          widgetEle.setAttribute('locale', DESCOPE_LOCALE);
+        }
         widgetEle.setAttribute('debug', 'false');
         if (isMock) {
           widgetEle.setAttribute('mock', 'true');
@@ -97,6 +100,9 @@
           flowEle.setAttribute('project-id', DESCOPE_PROJECT_ID);
           flowEle.setAttribute('base-url', DESCOPE_BASE_URL);
           flowEle.setAttribute('flow-id', 'sign-up-or-in');
+          if (DESCOPE_LOCALE) {
+            flowEle.setAttribute('locale', DESCOPE_LOCALE);
+          }
           flowEle.setAttribute('debug', 'false');
           flowEle.addEventListener('success', () => {
             flowEle.remove();

--- a/packages/widgets/access-key-management-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
+++ b/packages/widgets/access-key-management-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
@@ -1,7 +1,9 @@
 import { compose, createSingletonMixin } from '@descope/sdk-helpers';
 import {
-  createValidateAttributesMixin,
+  localeMixin,
   staticResourcesMixin,
+  widgetConfigMixin,
+  widgetIdMixin,
 } from '@descope/sdk-mixins';
 
 const WIDGET_PAGES_BASE_DIR = 'access-key-management-widget';
@@ -10,21 +12,42 @@ export const fetchWidgetPagesMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) => {
     const BaseClass = compose(
       staticResourcesMixin,
-      createValidateAttributesMixin({
-        'widget-id': createValidateAttributesMixin.missingAttrValidator,
-      }),
+      widgetIdMixin,
+      widgetConfigMixin,
+      localeMixin,
     )(superclass);
     return class FetchWidgetPagesMixinClass extends BaseClass {
-      get widgetId() {
-        return this.getAttribute('widget-id');
-      }
-
       async fetchWidgetPage(filename: string) {
+        const localized = await this.#tryFetchLocalized(filename);
+        if (localized !== undefined) return localized;
+
         const res = await this.fetchStaticResource(
           `${WIDGET_PAGES_BASE_DIR}/${this.widgetId}/${filename}`,
           'text',
         );
         return res?.body;
+      }
+
+      // Fetch <page>-<locale>.html when the widget publishes that locale (config.json
+      // targetLocales); otherwise return undefined so the caller falls back to the default page.
+      async #tryFetchLocalized(filename: string): Promise<string | undefined> {
+        const userLocale = this.resolvedLocale;
+        if (!userLocale) return undefined;
+        if (!(await this.isLocaleAvailable(userLocale))) return undefined;
+
+        const ext = '.html';
+        const base = filename.endsWith(ext)
+          ? filename.slice(0, -ext.length)
+          : filename;
+        try {
+          const res = await this.fetchStaticResource(
+            `${WIDGET_PAGES_BASE_DIR}/${this.widgetId}/${base}-${userLocale}${ext}`,
+            'text',
+          );
+          return res?.body;
+        } catch {
+          return undefined;
+        }
       }
     };
   },

--- a/packages/widgets/access-key-management-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
+++ b/packages/widgets/access-key-management-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
@@ -1,5 +1,0 @@
-import { createFetchWidgetPagesMixin } from '@descope/sdk-mixins';
-
-export const fetchWidgetPagesMixin = createFetchWidgetPagesMixin(
-  'access-key-management-widget',
-);

--- a/packages/widgets/access-key-management-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
+++ b/packages/widgets/access-key-management-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
@@ -1,55 +1,5 @@
-import { compose, createSingletonMixin } from '@descope/sdk-helpers';
-import {
-  localeMixin,
-  staticResourcesMixin,
-  widgetConfigMixin,
-  widgetIdMixin,
-} from '@descope/sdk-mixins';
+import { createFetchWidgetPagesMixin } from '@descope/sdk-mixins';
 
-const WIDGET_PAGES_BASE_DIR = 'access-key-management-widget';
-
-export const fetchWidgetPagesMixin = createSingletonMixin(
-  <T extends CustomElementConstructor>(superclass: T) => {
-    const BaseClass = compose(
-      staticResourcesMixin,
-      widgetIdMixin,
-      widgetConfigMixin,
-      localeMixin,
-    )(superclass);
-    return class FetchWidgetPagesMixinClass extends BaseClass {
-      async fetchWidgetPage(filename: string) {
-        const localized = await this.#tryFetchLocalized(filename);
-        if (localized !== undefined) return localized;
-
-        const res = await this.fetchStaticResource(
-          `${WIDGET_PAGES_BASE_DIR}/${this.widgetId}/${filename}`,
-          'text',
-        );
-        return res?.body;
-      }
-
-      // Fetch <page>-<locale>.html when the widget publishes that locale (config.json
-      // targetLocales); otherwise return undefined so the caller falls back to the default page.
-      async #tryFetchLocalized(filename: string): Promise<string | undefined> {
-        const userLocale = await this.firstAvailableLocale(
-          this.localeCandidates,
-        );
-        if (!userLocale) return undefined;
-
-        const ext = '.html';
-        const base = filename.endsWith(ext)
-          ? filename.slice(0, -ext.length)
-          : filename;
-        try {
-          const res = await this.fetchStaticResource(
-            `${WIDGET_PAGES_BASE_DIR}/${this.widgetId}/${base}-${userLocale}${ext}`,
-            'text',
-          );
-          return res?.body;
-        } catch {
-          return undefined;
-        }
-      }
-    };
-  },
+export const fetchWidgetPagesMixin = createFetchWidgetPagesMixin(
+  'access-key-management-widget',
 );

--- a/packages/widgets/access-key-management-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
+++ b/packages/widgets/access-key-management-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
@@ -31,9 +31,10 @@ export const fetchWidgetPagesMixin = createSingletonMixin(
       // Fetch <page>-<locale>.html when the widget publishes that locale (config.json
       // targetLocales); otherwise return undefined so the caller falls back to the default page.
       async #tryFetchLocalized(filename: string): Promise<string | undefined> {
-        const userLocale = this.resolvedLocale;
+        const userLocale = await this.firstAvailableLocale(
+          this.localeCandidates,
+        );
         if (!userLocale) return undefined;
-        if (!(await this.isLocaleAvailable(userLocale))) return undefined;
 
         const ext = '.html';
         const base = filename.endsWith(ext)

--- a/packages/widgets/access-key-management-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initWidgetRootMixin.ts
+++ b/packages/widgets/access-key-management-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initWidgetRootMixin.ts
@@ -4,13 +4,15 @@ import {
   createTemplate,
 } from '@descope/sdk-helpers';
 import {
+  createFetchWidgetPagesMixin,
   descopeUiMixin,
   initElementMixin,
   initLifecycleMixin,
   loggerMixin,
 } from '@descope/sdk-mixins';
-import { fetchWidgetPagesMixin } from '../../fetchWidgetPagesMixin';
 import { stateManagementMixin } from '../../stateManagementMixin';
+
+const WIDGET_PAGES_BASE_DIR = 'access-key-management-widget';
 
 export const initWidgetRootMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) =>
@@ -19,7 +21,7 @@ export const initWidgetRootMixin = createSingletonMixin(
       initLifecycleMixin,
       descopeUiMixin,
       initElementMixin,
-      fetchWidgetPagesMixin,
+      createFetchWidgetPagesMixin(WIDGET_PAGES_BASE_DIR),
       stateManagementMixin,
     )(superclass) {
       async #initWidgetRoot() {

--- a/packages/widgets/applications-portal-widget/rollup.config.app.mjs
+++ b/packages/widgets/applications-portal-widget/rollup.config.app.mjs
@@ -28,6 +28,7 @@ export default {
           process.env.DESCOPE_BASE_STATIC_URL || '',
         ),
         DESCOPE_WIDGET_ID: JSON.stringify(process.env.DESCOPE_WIDGET_ID || ''),
+        DESCOPE_LOCALE: JSON.stringify(process.env.DESCOPE_LOCALE || ''),
         DESCOPE_TENANT: JSON.stringify(process.env.DESCOPE_TENANT || ''),
       },
     }),

--- a/packages/widgets/applications-portal-widget/src/app/index.html
+++ b/packages/widgets/applications-portal-widget/src/app/index.html
@@ -70,6 +70,9 @@
         widgetEle.setAttribute('base-url', DESCOPE_BASE_URL);
         widgetEle.setAttribute('base-static-url', DESCOPE_BASE_STATIC_URL);
         widgetEle.setAttribute('widget-id', DESCOPE_WIDGET_ID);
+        if (DESCOPE_LOCALE) {
+          widgetEle.setAttribute('locale', DESCOPE_LOCALE);
+        }
         widgetEle.setAttribute('tenant', DESCOPE_TENANT);
         widgetEle.setAttribute('debug', 'false');
         widgetEle.setAttribute('theme', 'light');
@@ -86,6 +89,9 @@
           flowEle.setAttribute('project-id', DESCOPE_PROJECT_ID);
           flowEle.setAttribute('base-url', DESCOPE_BASE_URL);
           flowEle.setAttribute('flow-id', 'sign-up-or-in');
+          if (DESCOPE_LOCALE) {
+            flowEle.setAttribute('locale', DESCOPE_LOCALE);
+          }
           flowEle.setAttribute('debug', 'false');
           flowEle.addEventListener('success', () => {
             flowEle.remove();

--- a/packages/widgets/applications-portal-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
+++ b/packages/widgets/applications-portal-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
@@ -1,7 +1,9 @@
 import { compose, createSingletonMixin } from '@descope/sdk-helpers';
 import {
-  createValidateAttributesMixin,
+  localeMixin,
   staticResourcesMixin,
+  widgetConfigMixin,
+  widgetIdMixin,
 } from '@descope/sdk-mixins';
 
 const WIDGET_PAGES_BASE_DIR = 'applications-portal-widget';
@@ -10,21 +12,42 @@ export const fetchWidgetPagesMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) => {
     const BaseClass = compose(
       staticResourcesMixin,
-      createValidateAttributesMixin({
-        'widget-id': createValidateAttributesMixin.missingAttrValidator,
-      }),
+      widgetIdMixin,
+      widgetConfigMixin,
+      localeMixin,
     )(superclass);
     return class FetchWidgetPagesMixinClass extends BaseClass {
-      get widgetId() {
-        return this.getAttribute('widget-id');
-      }
-
       async fetchWidgetPage(filename: string) {
+        const localized = await this.#tryFetchLocalized(filename);
+        if (localized !== undefined) return localized;
+
         const res = await this.fetchStaticResource(
           `${WIDGET_PAGES_BASE_DIR}/${this.widgetId}/${filename}`,
           'text',
         );
-        return res.body;
+        return res?.body;
+      }
+
+      // Fetch <page>-<locale>.html when the widget publishes that locale (config.json
+      // targetLocales); otherwise return undefined so the caller falls back to the default page.
+      async #tryFetchLocalized(filename: string): Promise<string | undefined> {
+        const userLocale = this.resolvedLocale;
+        if (!userLocale) return undefined;
+        if (!(await this.isLocaleAvailable(userLocale))) return undefined;
+
+        const ext = '.html';
+        const base = filename.endsWith(ext)
+          ? filename.slice(0, -ext.length)
+          : filename;
+        try {
+          const res = await this.fetchStaticResource(
+            `${WIDGET_PAGES_BASE_DIR}/${this.widgetId}/${base}-${userLocale}${ext}`,
+            'text',
+          );
+          return res?.body;
+        } catch {
+          return undefined;
+        }
       }
     };
   },

--- a/packages/widgets/applications-portal-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
+++ b/packages/widgets/applications-portal-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
@@ -1,5 +1,0 @@
-import { createFetchWidgetPagesMixin } from '@descope/sdk-mixins';
-
-export const fetchWidgetPagesMixin = createFetchWidgetPagesMixin(
-  'applications-portal-widget',
-);

--- a/packages/widgets/applications-portal-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
+++ b/packages/widgets/applications-portal-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
@@ -1,55 +1,5 @@
-import { compose, createSingletonMixin } from '@descope/sdk-helpers';
-import {
-  localeMixin,
-  staticResourcesMixin,
-  widgetConfigMixin,
-  widgetIdMixin,
-} from '@descope/sdk-mixins';
+import { createFetchWidgetPagesMixin } from '@descope/sdk-mixins';
 
-const WIDGET_PAGES_BASE_DIR = 'applications-portal-widget';
-
-export const fetchWidgetPagesMixin = createSingletonMixin(
-  <T extends CustomElementConstructor>(superclass: T) => {
-    const BaseClass = compose(
-      staticResourcesMixin,
-      widgetIdMixin,
-      widgetConfigMixin,
-      localeMixin,
-    )(superclass);
-    return class FetchWidgetPagesMixinClass extends BaseClass {
-      async fetchWidgetPage(filename: string) {
-        const localized = await this.#tryFetchLocalized(filename);
-        if (localized !== undefined) return localized;
-
-        const res = await this.fetchStaticResource(
-          `${WIDGET_PAGES_BASE_DIR}/${this.widgetId}/${filename}`,
-          'text',
-        );
-        return res?.body;
-      }
-
-      // Fetch <page>-<locale>.html when the widget publishes that locale (config.json
-      // targetLocales); otherwise return undefined so the caller falls back to the default page.
-      async #tryFetchLocalized(filename: string): Promise<string | undefined> {
-        const userLocale = await this.firstAvailableLocale(
-          this.localeCandidates,
-        );
-        if (!userLocale) return undefined;
-
-        const ext = '.html';
-        const base = filename.endsWith(ext)
-          ? filename.slice(0, -ext.length)
-          : filename;
-        try {
-          const res = await this.fetchStaticResource(
-            `${WIDGET_PAGES_BASE_DIR}/${this.widgetId}/${base}-${userLocale}${ext}`,
-            'text',
-          );
-          return res?.body;
-        } catch {
-          return undefined;
-        }
-      }
-    };
-  },
+export const fetchWidgetPagesMixin = createFetchWidgetPagesMixin(
+  'applications-portal-widget',
 );

--- a/packages/widgets/applications-portal-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
+++ b/packages/widgets/applications-portal-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
@@ -31,9 +31,10 @@ export const fetchWidgetPagesMixin = createSingletonMixin(
       // Fetch <page>-<locale>.html when the widget publishes that locale (config.json
       // targetLocales); otherwise return undefined so the caller falls back to the default page.
       async #tryFetchLocalized(filename: string): Promise<string | undefined> {
-        const userLocale = this.resolvedLocale;
+        const userLocale = await this.firstAvailableLocale(
+          this.localeCandidates,
+        );
         if (!userLocale) return undefined;
-        if (!(await this.isLocaleAvailable(userLocale))) return undefined;
 
         const ext = '.html';
         const base = filename.endsWith(ext)

--- a/packages/widgets/applications-portal-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initWidgetRootMixin.ts
+++ b/packages/widgets/applications-portal-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initWidgetRootMixin.ts
@@ -4,13 +4,15 @@ import {
   createTemplate,
 } from '@descope/sdk-helpers';
 import {
+  createFetchWidgetPagesMixin,
   descopeUiMixin,
   initElementMixin,
   initLifecycleMixin,
   loggerMixin,
 } from '@descope/sdk-mixins';
-import { fetchWidgetPagesMixin } from '../../fetchWidgetPagesMixin';
 import { stateManagementMixin } from '../../stateManagementMixin';
+
+const WIDGET_PAGES_BASE_DIR = 'applications-portal-widget';
 
 export const initWidgetRootMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) =>
@@ -19,7 +21,7 @@ export const initWidgetRootMixin = createSingletonMixin(
       initLifecycleMixin,
       descopeUiMixin,
       initElementMixin,
-      fetchWidgetPagesMixin,
+      createFetchWidgetPagesMixin(WIDGET_PAGES_BASE_DIR),
       stateManagementMixin,
     )(superclass) {
       async #initWidgetRoot() {

--- a/packages/widgets/audit-management-widget/rollup.config.app.mjs
+++ b/packages/widgets/audit-management-widget/rollup.config.app.mjs
@@ -29,6 +29,7 @@ export default {
         ),
         DESCOPE_TENANT: JSON.stringify(process.env.DESCOPE_TENANT || ''),
         DESCOPE_WIDGET_ID: JSON.stringify(process.env.DESCOPE_WIDGET_ID || ''),
+        DESCOPE_LOCALE: JSON.stringify(process.env.DESCOPE_LOCALE || ''),
       },
     }),
     del({ targets: 'build' }),

--- a/packages/widgets/audit-management-widget/src/app/index.html
+++ b/packages/widgets/audit-management-widget/src/app/index.html
@@ -81,6 +81,9 @@
         widgetEle.setAttribute('base-static-url', DESCOPE_BASE_STATIC_URL);
         widgetEle.setAttribute('tenant', DESCOPE_TENANT);
         widgetEle.setAttribute('widget-id', DESCOPE_WIDGET_ID);
+        if (DESCOPE_LOCALE) {
+          widgetEle.setAttribute('locale', DESCOPE_LOCALE);
+        }
         widgetEle.setAttribute('debug', 'false');
         if (isMock) {
           widgetEle.setAttribute('mock', 'true');
@@ -95,6 +98,9 @@
           flowEle.setAttribute('project-id', DESCOPE_PROJECT_ID);
           flowEle.setAttribute('base-url', DESCOPE_BASE_URL);
           flowEle.setAttribute('flow-id', 'sign-up-or-in');
+          if (DESCOPE_LOCALE) {
+            flowEle.setAttribute('locale', DESCOPE_LOCALE);
+          }
           flowEle.setAttribute('debug', 'false');
           flowEle.addEventListener('success', () => {
             flowEle.remove();

--- a/packages/widgets/audit-management-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
+++ b/packages/widgets/audit-management-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
@@ -1,7 +1,9 @@
 import { compose, createSingletonMixin } from '@descope/sdk-helpers';
 import {
-  createValidateAttributesMixin,
+  localeMixin,
   staticResourcesMixin,
+  widgetConfigMixin,
+  widgetIdMixin,
 } from '@descope/sdk-mixins';
 
 const WIDGET_PAGES_BASE_DIR = 'audit-management-widget';
@@ -10,21 +12,42 @@ export const fetchWidgetPagesMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) => {
     const BaseClass = compose(
       staticResourcesMixin,
-      createValidateAttributesMixin({
-        'widget-id': createValidateAttributesMixin.missingAttrValidator,
-      }),
+      widgetIdMixin,
+      widgetConfigMixin,
+      localeMixin,
     )(superclass);
     return class FetchWidgetPagesMixinClass extends BaseClass {
-      get widgetId() {
-        return this.getAttribute('widget-id');
-      }
-
       async fetchWidgetPage(filename: string) {
+        const localized = await this.#tryFetchLocalized(filename);
+        if (localized !== undefined) return localized;
+
         const res = await this.fetchStaticResource(
           `${WIDGET_PAGES_BASE_DIR}/${this.widgetId}/${filename}`,
           'text',
         );
-        return res.body;
+        return res?.body;
+      }
+
+      // Fetch <page>-<locale>.html when the widget publishes that locale (config.json
+      // targetLocales); otherwise return undefined so the caller falls back to the default page.
+      async #tryFetchLocalized(filename: string): Promise<string | undefined> {
+        const userLocale = this.resolvedLocale;
+        if (!userLocale) return undefined;
+        if (!(await this.isLocaleAvailable(userLocale))) return undefined;
+
+        const ext = '.html';
+        const base = filename.endsWith(ext)
+          ? filename.slice(0, -ext.length)
+          : filename;
+        try {
+          const res = await this.fetchStaticResource(
+            `${WIDGET_PAGES_BASE_DIR}/${this.widgetId}/${base}-${userLocale}${ext}`,
+            'text',
+          );
+          return res?.body;
+        } catch {
+          return undefined;
+        }
       }
     };
   },

--- a/packages/widgets/audit-management-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
+++ b/packages/widgets/audit-management-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
@@ -1,5 +1,0 @@
-import { createFetchWidgetPagesMixin } from '@descope/sdk-mixins';
-
-export const fetchWidgetPagesMixin = createFetchWidgetPagesMixin(
-  'audit-management-widget',
-);

--- a/packages/widgets/audit-management-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
+++ b/packages/widgets/audit-management-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
@@ -31,9 +31,10 @@ export const fetchWidgetPagesMixin = createSingletonMixin(
       // Fetch <page>-<locale>.html when the widget publishes that locale (config.json
       // targetLocales); otherwise return undefined so the caller falls back to the default page.
       async #tryFetchLocalized(filename: string): Promise<string | undefined> {
-        const userLocale = this.resolvedLocale;
+        const userLocale = await this.firstAvailableLocale(
+          this.localeCandidates,
+        );
         if (!userLocale) return undefined;
-        if (!(await this.isLocaleAvailable(userLocale))) return undefined;
 
         const ext = '.html';
         const base = filename.endsWith(ext)

--- a/packages/widgets/audit-management-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
+++ b/packages/widgets/audit-management-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
@@ -1,55 +1,5 @@
-import { compose, createSingletonMixin } from '@descope/sdk-helpers';
-import {
-  localeMixin,
-  staticResourcesMixin,
-  widgetConfigMixin,
-  widgetIdMixin,
-} from '@descope/sdk-mixins';
+import { createFetchWidgetPagesMixin } from '@descope/sdk-mixins';
 
-const WIDGET_PAGES_BASE_DIR = 'audit-management-widget';
-
-export const fetchWidgetPagesMixin = createSingletonMixin(
-  <T extends CustomElementConstructor>(superclass: T) => {
-    const BaseClass = compose(
-      staticResourcesMixin,
-      widgetIdMixin,
-      widgetConfigMixin,
-      localeMixin,
-    )(superclass);
-    return class FetchWidgetPagesMixinClass extends BaseClass {
-      async fetchWidgetPage(filename: string) {
-        const localized = await this.#tryFetchLocalized(filename);
-        if (localized !== undefined) return localized;
-
-        const res = await this.fetchStaticResource(
-          `${WIDGET_PAGES_BASE_DIR}/${this.widgetId}/${filename}`,
-          'text',
-        );
-        return res?.body;
-      }
-
-      // Fetch <page>-<locale>.html when the widget publishes that locale (config.json
-      // targetLocales); otherwise return undefined so the caller falls back to the default page.
-      async #tryFetchLocalized(filename: string): Promise<string | undefined> {
-        const userLocale = await this.firstAvailableLocale(
-          this.localeCandidates,
-        );
-        if (!userLocale) return undefined;
-
-        const ext = '.html';
-        const base = filename.endsWith(ext)
-          ? filename.slice(0, -ext.length)
-          : filename;
-        try {
-          const res = await this.fetchStaticResource(
-            `${WIDGET_PAGES_BASE_DIR}/${this.widgetId}/${base}-${userLocale}${ext}`,
-            'text',
-          );
-          return res?.body;
-        } catch {
-          return undefined;
-        }
-      }
-    };
-  },
+export const fetchWidgetPagesMixin = createFetchWidgetPagesMixin(
+  'audit-management-widget',
 );

--- a/packages/widgets/audit-management-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initWidgetRootMixin.ts
+++ b/packages/widgets/audit-management-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initWidgetRootMixin.ts
@@ -4,13 +4,15 @@ import {
   createTemplate,
 } from '@descope/sdk-helpers';
 import {
+  createFetchWidgetPagesMixin,
   descopeUiMixin,
   initElementMixin,
   initLifecycleMixin,
   loggerMixin,
 } from '@descope/sdk-mixins';
-import { fetchWidgetPagesMixin } from '../../fetchWidgetPagesMixin';
 import { stateManagementMixin } from '../../stateManagementMixin';
+
+const WIDGET_PAGES_BASE_DIR = 'audit-management-widget';
 
 export const initWidgetRootMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) =>
@@ -19,7 +21,7 @@ export const initWidgetRootMixin = createSingletonMixin(
       initLifecycleMixin,
       descopeUiMixin,
       initElementMixin,
-      fetchWidgetPagesMixin,
+      createFetchWidgetPagesMixin(WIDGET_PAGES_BASE_DIR),
       stateManagementMixin,
     )(superclass) {
       async #initWidgetRoot() {

--- a/packages/widgets/outbound-applications-widget/rollup.config.app.mjs
+++ b/packages/widgets/outbound-applications-widget/rollup.config.app.mjs
@@ -28,6 +28,7 @@ export default {
           process.env.DESCOPE_BASE_STATIC_URL || '',
         ),
         DESCOPE_WIDGET_ID: JSON.stringify(process.env.DESCOPE_WIDGET_ID || ''),
+        DESCOPE_LOCALE: JSON.stringify(process.env.DESCOPE_LOCALE || ''),
         DESCOPE_TENANT: JSON.stringify(process.env.DESCOPE_TENANT || ''),
       },
     }),

--- a/packages/widgets/outbound-applications-widget/src/app/index.html
+++ b/packages/widgets/outbound-applications-widget/src/app/index.html
@@ -72,6 +72,9 @@
         widgetEle.setAttribute('base-url', DESCOPE_BASE_URL);
         widgetEle.setAttribute('base-static-url', DESCOPE_BASE_STATIC_URL);
         widgetEle.setAttribute('widget-id', DESCOPE_WIDGET_ID);
+        if (DESCOPE_LOCALE) {
+          widgetEle.setAttribute('locale', DESCOPE_LOCALE);
+        }
         widgetEle.setAttribute('tenant', DESCOPE_TENANT);
         widgetEle.setAttribute('debug', 'false');
         widgetEle.setAttribute('theme', 'light');
@@ -94,6 +97,9 @@
           flowEle.setAttribute('project-id', DESCOPE_PROJECT_ID);
           flowEle.setAttribute('base-url', DESCOPE_BASE_URL);
           flowEle.setAttribute('flow-id', 'sign-up-or-in');
+          if (DESCOPE_LOCALE) {
+            flowEle.setAttribute('locale', DESCOPE_LOCALE);
+          }
           flowEle.setAttribute('debug', 'false');
           flowEle.addEventListener('success', () => {
             flowEle.remove();

--- a/packages/widgets/outbound-applications-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
+++ b/packages/widgets/outbound-applications-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
@@ -1,5 +1,0 @@
-import { createFetchWidgetPagesMixin } from '@descope/sdk-mixins';
-
-export const fetchWidgetPagesMixin = createFetchWidgetPagesMixin(
-  'outbound-applications-widget',
-);

--- a/packages/widgets/outbound-applications-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
+++ b/packages/widgets/outbound-applications-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
@@ -1,55 +1,5 @@
-import { compose, createSingletonMixin } from '@descope/sdk-helpers';
-import {
-  localeMixin,
-  staticResourcesMixin,
-  widgetConfigMixin,
-  widgetIdMixin,
-} from '@descope/sdk-mixins';
+import { createFetchWidgetPagesMixin } from '@descope/sdk-mixins';
 
-const WIDGET_PAGES_BASE_DIR = 'outbound-applications-widget';
-
-export const fetchWidgetPagesMixin = createSingletonMixin(
-  <T extends CustomElementConstructor>(superclass: T) => {
-    const BaseClass = compose(
-      staticResourcesMixin,
-      widgetIdMixin,
-      widgetConfigMixin,
-      localeMixin,
-    )(superclass);
-    return class FetchWidgetPagesMixinClass extends BaseClass {
-      async fetchWidgetPage(filename: string) {
-        const localized = await this.#tryFetchLocalized(filename);
-        if (localized !== undefined) return localized;
-
-        const res = await this.fetchStaticResource(
-          `${WIDGET_PAGES_BASE_DIR}/${this.widgetId}/${filename}`,
-          'text',
-        );
-        return res?.body;
-      }
-
-      // Fetch <page>-<locale>.html when the widget publishes that locale (config.json
-      // targetLocales); otherwise return undefined so the caller falls back to the default page.
-      async #tryFetchLocalized(filename: string): Promise<string | undefined> {
-        const userLocale = await this.firstAvailableLocale(
-          this.localeCandidates,
-        );
-        if (!userLocale) return undefined;
-
-        const ext = '.html';
-        const base = filename.endsWith(ext)
-          ? filename.slice(0, -ext.length)
-          : filename;
-        try {
-          const res = await this.fetchStaticResource(
-            `${WIDGET_PAGES_BASE_DIR}/${this.widgetId}/${base}-${userLocale}${ext}`,
-            'text',
-          );
-          return res?.body;
-        } catch {
-          return undefined;
-        }
-      }
-    };
-  },
+export const fetchWidgetPagesMixin = createFetchWidgetPagesMixin(
+  'outbound-applications-widget',
 );

--- a/packages/widgets/outbound-applications-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
+++ b/packages/widgets/outbound-applications-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
@@ -31,9 +31,10 @@ export const fetchWidgetPagesMixin = createSingletonMixin(
       // Fetch <page>-<locale>.html when the widget publishes that locale (config.json
       // targetLocales); otherwise return undefined so the caller falls back to the default page.
       async #tryFetchLocalized(filename: string): Promise<string | undefined> {
-        const userLocale = this.resolvedLocale;
+        const userLocale = await this.firstAvailableLocale(
+          this.localeCandidates,
+        );
         if (!userLocale) return undefined;
-        if (!(await this.isLocaleAvailable(userLocale))) return undefined;
 
         const ext = '.html';
         const base = filename.endsWith(ext)

--- a/packages/widgets/outbound-applications-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
+++ b/packages/widgets/outbound-applications-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
@@ -1,7 +1,9 @@
 import { compose, createSingletonMixin } from '@descope/sdk-helpers';
 import {
-  createValidateAttributesMixin,
+  localeMixin,
   staticResourcesMixin,
+  widgetConfigMixin,
+  widgetIdMixin,
 } from '@descope/sdk-mixins';
 
 const WIDGET_PAGES_BASE_DIR = 'outbound-applications-widget';
@@ -10,21 +12,42 @@ export const fetchWidgetPagesMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) => {
     const BaseClass = compose(
       staticResourcesMixin,
-      createValidateAttributesMixin({
-        'widget-id': createValidateAttributesMixin.missingAttrValidator,
-      }),
+      widgetIdMixin,
+      widgetConfigMixin,
+      localeMixin,
     )(superclass);
     return class FetchWidgetPagesMixinClass extends BaseClass {
-      get widgetId() {
-        return this.getAttribute('widget-id');
-      }
-
       async fetchWidgetPage(filename: string) {
+        const localized = await this.#tryFetchLocalized(filename);
+        if (localized !== undefined) return localized;
+
         const res = await this.fetchStaticResource(
           `${WIDGET_PAGES_BASE_DIR}/${this.widgetId}/${filename}`,
           'text',
         );
-        return res.body;
+        return res?.body;
+      }
+
+      // Fetch <page>-<locale>.html when the widget publishes that locale (config.json
+      // targetLocales); otherwise return undefined so the caller falls back to the default page.
+      async #tryFetchLocalized(filename: string): Promise<string | undefined> {
+        const userLocale = this.resolvedLocale;
+        if (!userLocale) return undefined;
+        if (!(await this.isLocaleAvailable(userLocale))) return undefined;
+
+        const ext = '.html';
+        const base = filename.endsWith(ext)
+          ? filename.slice(0, -ext.length)
+          : filename;
+        try {
+          const res = await this.fetchStaticResource(
+            `${WIDGET_PAGES_BASE_DIR}/${this.widgetId}/${base}-${userLocale}${ext}`,
+            'text',
+          );
+          return res?.body;
+        } catch {
+          return undefined;
+        }
       }
     };
   },

--- a/packages/widgets/outbound-applications-widget/src/lib/widget/mixins/flowRedirectUrlMixin.ts
+++ b/packages/widgets/outbound-applications-widget/src/lib/widget/mixins/flowRedirectUrlMixin.ts
@@ -1,6 +1,7 @@
 import { FlowDriver } from '@descope/sdk-component-drivers';
 import { compose, createSingletonMixin } from '@descope/sdk-helpers';
 import {
+  localeMixin,
   initLifecycleMixin,
   loggerMixin,
   modalMixin,
@@ -15,6 +16,7 @@ const REDIRECT_FLOW_NAME_QUERY_PARAM = 'widget-flow';
 export const flowRedirectUrlMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) =>
     class FlowRedirectUrlMixinClass extends compose(
+      localeMixin,
       initLifecycleMixin,
       modalMixin,
       stateManagementMixin,
@@ -37,6 +39,7 @@ export const flowRedirectUrlMixin = createSingletonMixin(
         const modal = this.createModal({ 'data-id': 'redirect-flow' });
         modal.setContent(
           createFlowTemplate({
+            locale: this.locale,
             projectId: this.projectId,
             flowId: widgetFlow,
             baseUrl: this.baseUrl,

--- a/packages/widgets/outbound-applications-widget/src/lib/widget/mixins/helpers.ts
+++ b/packages/widgets/outbound-applications-widget/src/lib/widget/mixins/helpers.ts
@@ -11,6 +11,7 @@ type FlowConfig = {
   'style-id'?: string;
   form?: string;
   outboundAppId?: string;
+  locale?: string;
 };
 
 export const createFlowTemplate = (
@@ -19,6 +20,7 @@ export const createFlowTemplate = (
   const template = createTemplate(`<descope-wc></descope-wc>`);
 
   Object.entries(flowConfig).forEach(([key, value]) => {
+    if (value === undefined || value === null) return;
     template.content
       .querySelector('descope-wc')
       .setAttribute(kebabCase(key), value);

--- a/packages/widgets/outbound-applications-widget/src/lib/widget/mixins/helpers.ts
+++ b/packages/widgets/outbound-applications-widget/src/lib/widget/mixins/helpers.ts
@@ -20,7 +20,6 @@ export const createFlowTemplate = (
   const template = createTemplate(`<descope-wc></descope-wc>`);
 
   Object.entries(flowConfig).forEach(([key, value]) => {
-    if (value === undefined || value === null) return;
     template.content
       .querySelector('descope-wc')
       .setAttribute(kebabCase(key), value);

--- a/packages/widgets/outbound-applications-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initOutboundAppsListMixin.ts
+++ b/packages/widgets/outbound-applications-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initOutboundAppsListMixin.ts
@@ -8,7 +8,7 @@ import {
   createSingletonMixin,
   withMemCache,
 } from '@descope/sdk-helpers';
-import { loggerMixin, modalMixin } from '@descope/sdk-mixins';
+import { localeMixin, loggerMixin, modalMixin } from '@descope/sdk-mixins';
 import { getAppsList, getUserId } from '../../../state/selectors';
 import { stateManagementMixin } from '../../stateManagementMixin';
 import { initWidgetRootMixin } from './initWidgetRootMixin';
@@ -18,6 +18,7 @@ import { flowSyncThemeMixin } from '../../flowSyncThemeMixin';
 export const initOutboundAppsListMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) =>
     class InitAppsListMixinClass extends compose(
+      localeMixin,
       flowSyncThemeMixin,
       stateManagementMixin,
       loggerMixin,
@@ -105,6 +106,7 @@ export const initOutboundAppsListMixin = createSingletonMixin(
       #initConnectModalContent(appId: string) {
         this.#connectModal.setContent(
           createFlowTemplate({
+            locale: this.locale,
             projectId: this.projectId,
             flowId: this.#obAppsList.connectFlowId,
             baseUrl: this.baseUrl,
@@ -131,6 +133,7 @@ export const initOutboundAppsListMixin = createSingletonMixin(
       #initDisconnectModalContent(appId: string) {
         this.#disconnectModal.setContent(
           createFlowTemplate({
+            locale: this.locale,
             projectId: this.projectId,
             flowId: this.#obAppsList.disconnectFlowId,
             baseUrl: this.baseUrl,

--- a/packages/widgets/outbound-applications-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initWidgetRootMixin.ts
+++ b/packages/widgets/outbound-applications-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initWidgetRootMixin.ts
@@ -4,14 +4,16 @@ import {
   createTemplate,
 } from '@descope/sdk-helpers';
 import {
+  createFetchWidgetPagesMixin,
   descopeUiMixin,
   initElementMixin,
   initLifecycleMixin,
   loggerMixin,
 } from '@descope/sdk-mixins';
-import { fetchWidgetPagesMixin } from '../../fetchWidgetPagesMixin';
 import { stateManagementMixin } from '../../stateManagementMixin';
 import { getUserId } from '../../../state/selectors';
+
+const WIDGET_PAGES_BASE_DIR = 'outbound-applications-widget';
 
 export const initWidgetRootMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) =>
@@ -20,7 +22,7 @@ export const initWidgetRootMixin = createSingletonMixin(
       initLifecycleMixin,
       descopeUiMixin,
       initElementMixin,
-      fetchWidgetPagesMixin,
+      createFetchWidgetPagesMixin(WIDGET_PAGES_BASE_DIR),
       stateManagementMixin,
     )(superclass) {
       static get observedAttributes() {

--- a/packages/widgets/role-management-widget/rollup.config.app.mjs
+++ b/packages/widgets/role-management-widget/rollup.config.app.mjs
@@ -29,6 +29,7 @@ export default {
         ),
         DESCOPE_TENANT: JSON.stringify(process.env.DESCOPE_TENANT || ''),
         DESCOPE_WIDGET_ID: JSON.stringify(process.env.DESCOPE_WIDGET_ID || ''),
+        DESCOPE_LOCALE: JSON.stringify(process.env.DESCOPE_LOCALE || ''),
       },
     }),
     del({ targets: 'build' }),

--- a/packages/widgets/role-management-widget/src/app/index.html
+++ b/packages/widgets/role-management-widget/src/app/index.html
@@ -81,6 +81,9 @@
         widgetEle.setAttribute('base-static-url', DESCOPE_BASE_STATIC_URL);
         widgetEle.setAttribute('tenant', DESCOPE_TENANT);
         widgetEle.setAttribute('widget-id', DESCOPE_WIDGET_ID);
+        if (DESCOPE_LOCALE) {
+          widgetEle.setAttribute('locale', DESCOPE_LOCALE);
+        }
         widgetEle.setAttribute('debug', 'false');
         if (isMock) {
           widgetEle.setAttribute('mock', 'true');
@@ -95,6 +98,9 @@
           flowEle.setAttribute('project-id', DESCOPE_PROJECT_ID);
           flowEle.setAttribute('base-url', DESCOPE_BASE_URL);
           flowEle.setAttribute('flow-id', 'sign-up-or-in');
+          if (DESCOPE_LOCALE) {
+            flowEle.setAttribute('locale', DESCOPE_LOCALE);
+          }
           flowEle.setAttribute('debug', 'false');
           flowEle.addEventListener('success', () => {
             flowEle.remove();

--- a/packages/widgets/role-management-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
+++ b/packages/widgets/role-management-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
@@ -1,7 +1,9 @@
 import { compose, createSingletonMixin } from '@descope/sdk-helpers';
 import {
-  createValidateAttributesMixin,
+  localeMixin,
   staticResourcesMixin,
+  widgetConfigMixin,
+  widgetIdMixin,
 } from '@descope/sdk-mixins';
 
 const WIDGET_PAGES_BASE_DIR = 'role-management-widget';
@@ -10,21 +12,42 @@ export const fetchWidgetPagesMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) => {
     const BaseClass = compose(
       staticResourcesMixin,
-      createValidateAttributesMixin({
-        'widget-id': createValidateAttributesMixin.missingAttrValidator,
-      }),
+      widgetIdMixin,
+      widgetConfigMixin,
+      localeMixin,
     )(superclass);
     return class FetchWidgetPagesMixinClass extends BaseClass {
-      get widgetId() {
-        return this.getAttribute('widget-id');
-      }
-
       async fetchWidgetPage(filename: string) {
+        const localized = await this.#tryFetchLocalized(filename);
+        if (localized !== undefined) return localized;
+
         const res = await this.fetchStaticResource(
           `${WIDGET_PAGES_BASE_DIR}/${this.widgetId}/${filename}`,
           'text',
         );
-        return res.body;
+        return res?.body;
+      }
+
+      // Fetch <page>-<locale>.html when the widget publishes that locale (config.json
+      // targetLocales); otherwise return undefined so the caller falls back to the default page.
+      async #tryFetchLocalized(filename: string): Promise<string | undefined> {
+        const userLocale = this.resolvedLocale;
+        if (!userLocale) return undefined;
+        if (!(await this.isLocaleAvailable(userLocale))) return undefined;
+
+        const ext = '.html';
+        const base = filename.endsWith(ext)
+          ? filename.slice(0, -ext.length)
+          : filename;
+        try {
+          const res = await this.fetchStaticResource(
+            `${WIDGET_PAGES_BASE_DIR}/${this.widgetId}/${base}-${userLocale}${ext}`,
+            'text',
+          );
+          return res?.body;
+        } catch {
+          return undefined;
+        }
       }
     };
   },

--- a/packages/widgets/role-management-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
+++ b/packages/widgets/role-management-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
@@ -1,5 +1,0 @@
-import { createFetchWidgetPagesMixin } from '@descope/sdk-mixins';
-
-export const fetchWidgetPagesMixin = createFetchWidgetPagesMixin(
-  'role-management-widget',
-);

--- a/packages/widgets/role-management-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
+++ b/packages/widgets/role-management-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
@@ -1,55 +1,5 @@
-import { compose, createSingletonMixin } from '@descope/sdk-helpers';
-import {
-  localeMixin,
-  staticResourcesMixin,
-  widgetConfigMixin,
-  widgetIdMixin,
-} from '@descope/sdk-mixins';
+import { createFetchWidgetPagesMixin } from '@descope/sdk-mixins';
 
-const WIDGET_PAGES_BASE_DIR = 'role-management-widget';
-
-export const fetchWidgetPagesMixin = createSingletonMixin(
-  <T extends CustomElementConstructor>(superclass: T) => {
-    const BaseClass = compose(
-      staticResourcesMixin,
-      widgetIdMixin,
-      widgetConfigMixin,
-      localeMixin,
-    )(superclass);
-    return class FetchWidgetPagesMixinClass extends BaseClass {
-      async fetchWidgetPage(filename: string) {
-        const localized = await this.#tryFetchLocalized(filename);
-        if (localized !== undefined) return localized;
-
-        const res = await this.fetchStaticResource(
-          `${WIDGET_PAGES_BASE_DIR}/${this.widgetId}/${filename}`,
-          'text',
-        );
-        return res?.body;
-      }
-
-      // Fetch <page>-<locale>.html when the widget publishes that locale (config.json
-      // targetLocales); otherwise return undefined so the caller falls back to the default page.
-      async #tryFetchLocalized(filename: string): Promise<string | undefined> {
-        const userLocale = await this.firstAvailableLocale(
-          this.localeCandidates,
-        );
-        if (!userLocale) return undefined;
-
-        const ext = '.html';
-        const base = filename.endsWith(ext)
-          ? filename.slice(0, -ext.length)
-          : filename;
-        try {
-          const res = await this.fetchStaticResource(
-            `${WIDGET_PAGES_BASE_DIR}/${this.widgetId}/${base}-${userLocale}${ext}`,
-            'text',
-          );
-          return res?.body;
-        } catch {
-          return undefined;
-        }
-      }
-    };
-  },
+export const fetchWidgetPagesMixin = createFetchWidgetPagesMixin(
+  'role-management-widget',
 );

--- a/packages/widgets/role-management-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
+++ b/packages/widgets/role-management-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
@@ -31,9 +31,10 @@ export const fetchWidgetPagesMixin = createSingletonMixin(
       // Fetch <page>-<locale>.html when the widget publishes that locale (config.json
       // targetLocales); otherwise return undefined so the caller falls back to the default page.
       async #tryFetchLocalized(filename: string): Promise<string | undefined> {
-        const userLocale = this.resolvedLocale;
+        const userLocale = await this.firstAvailableLocale(
+          this.localeCandidates,
+        );
         if (!userLocale) return undefined;
-        if (!(await this.isLocaleAvailable(userLocale))) return undefined;
 
         const ext = '.html';
         const base = filename.endsWith(ext)

--- a/packages/widgets/role-management-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initWidgetRootMixin.ts
+++ b/packages/widgets/role-management-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initWidgetRootMixin.ts
@@ -4,13 +4,15 @@ import {
   createTemplate,
 } from '@descope/sdk-helpers';
 import {
+  createFetchWidgetPagesMixin,
   descopeUiMixin,
   initElementMixin,
   initLifecycleMixin,
   loggerMixin,
 } from '@descope/sdk-mixins';
-import { fetchWidgetPagesMixin } from '../../fetchWidgetPagesMixin';
 import { stateManagementMixin } from '../../stateManagementMixin';
+
+const WIDGET_PAGES_BASE_DIR = 'role-management-widget';
 
 export const initWidgetRootMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) =>
@@ -19,7 +21,7 @@ export const initWidgetRootMixin = createSingletonMixin(
       initLifecycleMixin,
       descopeUiMixin,
       initElementMixin,
-      fetchWidgetPagesMixin,
+      createFetchWidgetPagesMixin(WIDGET_PAGES_BASE_DIR),
       stateManagementMixin,
     )(superclass) {
       async #initWidgetRoot() {

--- a/packages/widgets/tenant-profile-widget/rollup.config.app.mjs
+++ b/packages/widgets/tenant-profile-widget/rollup.config.app.mjs
@@ -28,6 +28,7 @@ export default {
           process.env.DESCOPE_BASE_STATIC_URL || '',
         ),
         DESCOPE_WIDGET_ID: JSON.stringify(process.env.DESCOPE_WIDGET_ID || ''),
+        DESCOPE_LOCALE: JSON.stringify(process.env.DESCOPE_LOCALE || ''),
         DESCOPE_TENANT_ID: JSON.stringify(process.env.DESCOPE_TENANT_ID || ''),
       },
     }),

--- a/packages/widgets/tenant-profile-widget/src/app/index.html
+++ b/packages/widgets/tenant-profile-widget/src/app/index.html
@@ -70,6 +70,9 @@
         widgetEle.setAttribute('base-static-url', DESCOPE_BASE_STATIC_URL);
         // widgetEle.setAttribute('base-cdn-url', DESCOPE_BASE_CDN_URL);
         widgetEle.setAttribute('widget-id', DESCOPE_WIDGET_ID);
+        if (DESCOPE_LOCALE) {
+          widgetEle.setAttribute('locale', DESCOPE_LOCALE);
+        }
         widgetEle.setAttribute('tenant', DESCOPE_TENANT_ID);
         widgetEle.setAttribute('debug', 'false');
         widgetEle.setAttribute('theme', 'dark');
@@ -90,6 +93,9 @@
           flowEle.setAttribute('base-url', DESCOPE_BASE_URL);
           flowEle.setAttribute('base-static-url', DESCOPE_BASE_STATIC_URL);
           flowEle.setAttribute('flow-id', 'sign-up-or-in');
+          if (DESCOPE_LOCALE) {
+            flowEle.setAttribute('locale', DESCOPE_LOCALE);
+          }
           flowEle.setAttribute('debug', 'false');
           flowEle.addEventListener('success', () => {
             flowEle.remove();

--- a/packages/widgets/tenant-profile-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
+++ b/packages/widgets/tenant-profile-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
@@ -1,5 +1,0 @@
-import { createFetchWidgetPagesMixin } from '@descope/sdk-mixins';
-
-export const fetchWidgetPagesMixin = createFetchWidgetPagesMixin(
-  'tenant-profile-widget',
-);

--- a/packages/widgets/tenant-profile-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
+++ b/packages/widgets/tenant-profile-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
@@ -1,7 +1,9 @@
 import { compose, createSingletonMixin } from '@descope/sdk-helpers';
 import {
-  createValidateAttributesMixin,
+  localeMixin,
   staticResourcesMixin,
+  widgetConfigMixin,
+  widgetIdMixin,
 } from '@descope/sdk-mixins';
 
 const WIDGET_PAGES_BASE_DIR = 'tenant-profile-widget';
@@ -10,21 +12,42 @@ export const fetchWidgetPagesMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) => {
     const BaseClass = compose(
       staticResourcesMixin,
-      createValidateAttributesMixin({
-        'widget-id': createValidateAttributesMixin.missingAttrValidator,
-      }),
+      widgetIdMixin,
+      widgetConfigMixin,
+      localeMixin,
     )(superclass);
     return class FetchWidgetPagesMixinClass extends BaseClass {
-      get widgetId() {
-        return this.getAttribute('widget-id');
-      }
-
       async fetchWidgetPage(filename: string) {
+        const localized = await this.#tryFetchLocalized(filename);
+        if (localized !== undefined) return localized;
+
         const res = await this.fetchStaticResource(
           `${WIDGET_PAGES_BASE_DIR}/${this.widgetId}/${filename}`,
           'text',
         );
-        return res.body;
+        return res?.body;
+      }
+
+      // Fetch <page>-<locale>.html when the widget publishes that locale (config.json
+      // targetLocales); otherwise return undefined so the caller falls back to the default page.
+      async #tryFetchLocalized(filename: string): Promise<string | undefined> {
+        const userLocale = this.resolvedLocale;
+        if (!userLocale) return undefined;
+        if (!(await this.isLocaleAvailable(userLocale))) return undefined;
+
+        const ext = '.html';
+        const base = filename.endsWith(ext)
+          ? filename.slice(0, -ext.length)
+          : filename;
+        try {
+          const res = await this.fetchStaticResource(
+            `${WIDGET_PAGES_BASE_DIR}/${this.widgetId}/${base}-${userLocale}${ext}`,
+            'text',
+          );
+          return res?.body;
+        } catch {
+          return undefined;
+        }
       }
     };
   },

--- a/packages/widgets/tenant-profile-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
+++ b/packages/widgets/tenant-profile-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
@@ -1,55 +1,5 @@
-import { compose, createSingletonMixin } from '@descope/sdk-helpers';
-import {
-  localeMixin,
-  staticResourcesMixin,
-  widgetConfigMixin,
-  widgetIdMixin,
-} from '@descope/sdk-mixins';
+import { createFetchWidgetPagesMixin } from '@descope/sdk-mixins';
 
-const WIDGET_PAGES_BASE_DIR = 'tenant-profile-widget';
-
-export const fetchWidgetPagesMixin = createSingletonMixin(
-  <T extends CustomElementConstructor>(superclass: T) => {
-    const BaseClass = compose(
-      staticResourcesMixin,
-      widgetIdMixin,
-      widgetConfigMixin,
-      localeMixin,
-    )(superclass);
-    return class FetchWidgetPagesMixinClass extends BaseClass {
-      async fetchWidgetPage(filename: string) {
-        const localized = await this.#tryFetchLocalized(filename);
-        if (localized !== undefined) return localized;
-
-        const res = await this.fetchStaticResource(
-          `${WIDGET_PAGES_BASE_DIR}/${this.widgetId}/${filename}`,
-          'text',
-        );
-        return res?.body;
-      }
-
-      // Fetch <page>-<locale>.html when the widget publishes that locale (config.json
-      // targetLocales); otherwise return undefined so the caller falls back to the default page.
-      async #tryFetchLocalized(filename: string): Promise<string | undefined> {
-        const userLocale = await this.firstAvailableLocale(
-          this.localeCandidates,
-        );
-        if (!userLocale) return undefined;
-
-        const ext = '.html';
-        const base = filename.endsWith(ext)
-          ? filename.slice(0, -ext.length)
-          : filename;
-        try {
-          const res = await this.fetchStaticResource(
-            `${WIDGET_PAGES_BASE_DIR}/${this.widgetId}/${base}-${userLocale}${ext}`,
-            'text',
-          );
-          return res?.body;
-        } catch {
-          return undefined;
-        }
-      }
-    };
-  },
+export const fetchWidgetPagesMixin = createFetchWidgetPagesMixin(
+  'tenant-profile-widget',
 );

--- a/packages/widgets/tenant-profile-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
+++ b/packages/widgets/tenant-profile-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
@@ -31,9 +31,10 @@ export const fetchWidgetPagesMixin = createSingletonMixin(
       // Fetch <page>-<locale>.html when the widget publishes that locale (config.json
       // targetLocales); otherwise return undefined so the caller falls back to the default page.
       async #tryFetchLocalized(filename: string): Promise<string | undefined> {
-        const userLocale = this.resolvedLocale;
+        const userLocale = await this.firstAvailableLocale(
+          this.localeCandidates,
+        );
         if (!userLocale) return undefined;
-        if (!(await this.isLocaleAvailable(userLocale))) return undefined;
 
         const ext = '.html';
         const base = filename.endsWith(ext)

--- a/packages/widgets/tenant-profile-widget/src/lib/widget/mixins/flowRedirectUrlMixin.ts
+++ b/packages/widgets/tenant-profile-widget/src/lib/widget/mixins/flowRedirectUrlMixin.ts
@@ -1,6 +1,7 @@
 import { FlowDriver } from '@descope/sdk-component-drivers';
 import { compose, createSingletonMixin } from '@descope/sdk-helpers';
 import {
+  localeMixin,
   cookieConfigMixin,
   initLifecycleMixin,
   loggerMixin,
@@ -15,6 +16,7 @@ const REDIRECT_FLOW_NAME_QUERY_PARAM = 'widget-flow';
 export const flowRedirectUrlMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) =>
     class FlowRedirectUrlMixinClass extends compose(
+      localeMixin,
       initLifecycleMixin,
       modalMixin,
       stateManagementMixin,
@@ -37,6 +39,7 @@ export const flowRedirectUrlMixin = createSingletonMixin(
         const modal = this.createModal({ 'data-id': 'redirect-flow' });
         modal.setContent(
           createFlowTemplate({
+            locale: this.locale,
             projectId: this.projectId,
             flowId: widgetFlow,
             tenant: this.tenantId,

--- a/packages/widgets/tenant-profile-widget/src/lib/widget/mixins/helpers.ts
+++ b/packages/widgets/tenant-profile-widget/src/lib/widget/mixins/helpers.ts
@@ -11,6 +11,7 @@ type FlowConfig = {
   theme?: string;
   form?: string;
   'style-id'?: string;
+  locale?: string;
 };
 
 export const createFlowTemplate = (
@@ -19,6 +20,7 @@ export const createFlowTemplate = (
   const template = createTemplate(`<descope-wc></descope-wc>`);
 
   Object.entries(flowConfig).forEach(([key, value]) => {
+    if (value === undefined || value === null) return;
     template.content
       .querySelector('descope-wc')
       .setAttribute(kebabCase(key), value);

--- a/packages/widgets/tenant-profile-widget/src/lib/widget/mixins/helpers.ts
+++ b/packages/widgets/tenant-profile-widget/src/lib/widget/mixins/helpers.ts
@@ -20,7 +20,6 @@ export const createFlowTemplate = (
   const template = createTemplate(`<descope-wc></descope-wc>`);
 
   Object.entries(flowConfig).forEach(([key, value]) => {
-    if (value === undefined || value === null) return;
     template.content
       .querySelector('descope-wc')
       .setAttribute(kebabCase(key), value);

--- a/packages/widgets/tenant-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initTenantCustomAttributesMixin.ts
+++ b/packages/widgets/tenant-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initTenantCustomAttributesMixin.ts
@@ -9,6 +9,7 @@ import {
   withMemCache,
 } from '@descope/sdk-helpers';
 import {
+  localeMixin,
   cookieConfigMixin,
   loggerMixin,
   modalMixin,
@@ -33,6 +34,7 @@ const getFormattedValue = (type: string, val: any) => {
 export const initTenantCustomAttributesMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) =>
     class TenantCustomAttributesMixinClass extends compose(
+      localeMixin,
       flowSyncThemeMixin,
       stateManagementMixin,
       loggerMixin,
@@ -56,6 +58,7 @@ export const initTenantCustomAttributesMixin = createSingletonMixin(
 
         this.#editModals[flowId]?.setContent(
           createFlowTemplate({
+            locale: this.locale,
             projectId: this.projectId,
             flowId,
             tenant: this.tenantId,
@@ -82,6 +85,7 @@ export const initTenantCustomAttributesMixin = createSingletonMixin(
       #initDeleteModalContent(flowId: string) {
         this.#deleteModals[flowId]?.setContent(
           createFlowTemplate({
+            locale: this.locale,
             projectId: this.projectId,
             flowId,
             tenant: this.tenantId,

--- a/packages/widgets/tenant-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initTenantEmailDomainsMixin.ts
+++ b/packages/widgets/tenant-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initTenantEmailDomainsMixin.ts
@@ -9,6 +9,7 @@ import {
   withMemCache,
 } from '@descope/sdk-helpers';
 import {
+  localeMixin,
   cookieConfigMixin,
   loggerMixin,
   modalMixin,
@@ -22,6 +23,7 @@ import { initWidgetRootMixin } from './initWidgetRootMixin';
 export const initTenantEmailDomainsMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) =>
     class TenantEmailDomainsMixinClass extends compose(
+      localeMixin,
       flowSyncThemeMixin,
       stateManagementMixin,
       loggerMixin,
@@ -57,6 +59,7 @@ export const initTenantEmailDomainsMixin = createSingletonMixin(
       #initEditModalContent() {
         this.#editModal.setContent(
           createFlowTemplate({
+            locale: this.locale,
             projectId: this.projectId,
             flowId: this.tenantEmailDomainsDriver.editFlowId,
             tenant: this.tenantId,
@@ -95,6 +98,7 @@ export const initTenantEmailDomainsMixin = createSingletonMixin(
       #initDeleteModalContent() {
         this.#deleteModal.setContent(
           createFlowTemplate({
+            locale: this.locale,
             projectId: this.projectId,
             flowId: this.tenantEmailDomainsDriver.deleteFlowId,
             tenant: this.tenantId,

--- a/packages/widgets/tenant-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initTenantEnforceSSOMixin.ts
+++ b/packages/widgets/tenant-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initTenantEnforceSSOMixin.ts
@@ -9,6 +9,7 @@ import {
   withMemCache,
 } from '@descope/sdk-helpers';
 import {
+  localeMixin,
   cookieConfigMixin,
   loggerMixin,
   modalMixin,
@@ -22,6 +23,7 @@ import { initWidgetRootMixin } from './initWidgetRootMixin';
 export const initTenantEnforceSSOMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) =>
     class TenantEnforceSSOMixinClass extends compose(
+      localeMixin,
       flowSyncThemeMixin,
       stateManagementMixin,
       loggerMixin,
@@ -57,6 +59,7 @@ export const initTenantEnforceSSOMixin = createSingletonMixin(
       #initEditModalContent() {
         this.#editModal.setContent(
           createFlowTemplate({
+            locale: this.locale,
             projectId: this.projectId,
             flowId: this.tenantEnforceSSODriver.editFlowId,
             tenant: this.tenantId,
@@ -95,6 +98,7 @@ export const initTenantEnforceSSOMixin = createSingletonMixin(
       #initDeleteModalContent() {
         this.#deleteModal.setContent(
           createFlowTemplate({
+            locale: this.locale,
             projectId: this.projectId,
             flowId: this.tenantEnforceSSODriver.deleteFlowId,
             tenant: this.tenantId,

--- a/packages/widgets/tenant-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initTenantNameMixin.ts
+++ b/packages/widgets/tenant-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initTenantNameMixin.ts
@@ -9,6 +9,7 @@ import {
   withMemCache,
 } from '@descope/sdk-helpers';
 import {
+  localeMixin,
   cookieConfigMixin,
   loggerMixin,
   modalMixin,
@@ -22,6 +23,7 @@ import { initWidgetRootMixin } from './initWidgetRootMixin';
 export const initTenantNameMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) =>
     class TenantNameMixinClass extends compose(
+      localeMixin,
       flowSyncThemeMixin,
       stateManagementMixin,
       loggerMixin,
@@ -53,6 +55,7 @@ export const initTenantNameMixin = createSingletonMixin(
       #initEditModalContent() {
         this.#editModal.setContent(
           createFlowTemplate({
+            locale: this.locale,
             projectId: this.projectId,
             flowId: this.tenantNameDriver.editFlowId,
             tenant: this.tenantId,

--- a/packages/widgets/tenant-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initTenantPasswordPolicyUserAuthMethodMixin.ts
+++ b/packages/widgets/tenant-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initTenantPasswordPolicyUserAuthMethodMixin.ts
@@ -5,6 +5,7 @@ import {
 } from '@descope/sdk-component-drivers';
 import { compose, createSingletonMixin } from '@descope/sdk-helpers';
 import {
+  localeMixin,
   cookieConfigMixin,
   loggerMixin,
   modalMixin,
@@ -17,6 +18,7 @@ import { initWidgetRootMixin } from './initWidgetRootMixin';
 export const initTenantPasswordPolicyUserAuthMethodMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) =>
     class TenantPasswordPolicyUserAuthMethodMixinClass extends compose(
+      localeMixin,
       flowSyncThemeMixin,
       stateManagementMixin,
       loggerMixin,
@@ -48,6 +50,7 @@ export const initTenantPasswordPolicyUserAuthMethodMixin = createSingletonMixin(
       #initModalContent() {
         this.#modal.setContent(
           createFlowTemplate({
+            locale: this.locale,
             projectId: this.projectId,
             flowId: this.TenantPasswordPolicyUserAuthMethodDriver.flowId,
             tenant: this.tenantId,

--- a/packages/widgets/tenant-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initTenantSSOExclusionsMixin.ts
+++ b/packages/widgets/tenant-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initTenantSSOExclusionsMixin.ts
@@ -9,6 +9,7 @@ import {
   withMemCache,
 } from '@descope/sdk-helpers';
 import {
+  localeMixin,
   cookieConfigMixin,
   loggerMixin,
   modalMixin,
@@ -22,6 +23,7 @@ import { initWidgetRootMixin } from './initWidgetRootMixin';
 export const initTenantSSOExclusionsMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) =>
     class TenantSSOExclusionsMixinClass extends compose(
+      localeMixin,
       flowSyncThemeMixin,
       stateManagementMixin,
       loggerMixin,
@@ -57,6 +59,7 @@ export const initTenantSSOExclusionsMixin = createSingletonMixin(
       #initEditModalContent() {
         this.#editModal.setContent(
           createFlowTemplate({
+            locale: this.locale,
             projectId: this.projectId,
             flowId: this.tenantSSOExclusionsDriver.editFlowId,
             tenant: this.tenantId,
@@ -95,6 +98,7 @@ export const initTenantSSOExclusionsMixin = createSingletonMixin(
       #initDeleteModalContent() {
         this.#deleteModal.setContent(
           createFlowTemplate({
+            locale: this.locale,
             projectId: this.projectId,
             flowId: this.tenantSSOExclusionsDriver.deleteFlowId,
             tenant: this.tenantId,

--- a/packages/widgets/tenant-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initTenantSessionSettingsUserAuthMethodMixin.ts
+++ b/packages/widgets/tenant-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initTenantSessionSettingsUserAuthMethodMixin.ts
@@ -5,6 +5,7 @@ import {
 } from '@descope/sdk-component-drivers';
 import { compose, createSingletonMixin } from '@descope/sdk-helpers';
 import {
+  localeMixin,
   cookieConfigMixin,
   loggerMixin,
   modalMixin,
@@ -18,6 +19,7 @@ export const initTenantSessionSettingsUserAuthMethodMixin =
   createSingletonMixin(
     <T extends CustomElementConstructor>(superclass: T) =>
       class TenantSessionSettingsUserAuthMethodMixinClass extends compose(
+        localeMixin,
         flowSyncThemeMixin,
         stateManagementMixin,
         loggerMixin,
@@ -49,6 +51,7 @@ export const initTenantSessionSettingsUserAuthMethodMixin =
         #initModalContent() {
           this.#modal.setContent(
             createFlowTemplate({
+              locale: this.locale,
               projectId: this.projectId,
               flowId: this.TenantSessionSettingsUserAuthMethodDriver.flowId,
               tenant: this.tenantId,

--- a/packages/widgets/tenant-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initWidgetRootMixin.ts
+++ b/packages/widgets/tenant-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initWidgetRootMixin.ts
@@ -4,6 +4,7 @@ import {
   createTemplate,
 } from '@descope/sdk-helpers';
 import {
+  createFetchWidgetPagesMixin,
   descopeUiMixin,
   initElementMixin,
   initLifecycleMixin,
@@ -14,9 +15,10 @@ import {
   getTenantAdminLinkSSOError,
   getTenantError,
 } from '../../../state/selectors';
-import { fetchWidgetPagesMixin } from '../../fetchWidgetPagesMixin';
 import { stateManagementMixin } from '../../stateManagementMixin';
 import { createErrorComponent } from './ErrorComponent';
+
+const WIDGET_PAGES_BASE_DIR = 'tenant-profile-widget';
 
 export const initWidgetRootMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) =>
@@ -25,7 +27,7 @@ export const initWidgetRootMixin = createSingletonMixin(
       initLifecycleMixin,
       descopeUiMixin,
       initElementMixin,
-      fetchWidgetPagesMixin,
+      createFetchWidgetPagesMixin(WIDGET_PAGES_BASE_DIR),
       stateManagementMixin,
     )(superclass) {
       async #initWidgetRoot() {

--- a/packages/widgets/user-management-widget/rollup.config.app.mjs
+++ b/packages/widgets/user-management-widget/rollup.config.app.mjs
@@ -29,6 +29,7 @@ export default {
         ),
         DESCOPE_TENANT: JSON.stringify(process.env.DESCOPE_TENANT || ''),
         DESCOPE_WIDGET_ID: JSON.stringify(process.env.DESCOPE_WIDGET_ID || ''),
+        DESCOPE_LOCALE: JSON.stringify(process.env.DESCOPE_LOCALE || ''),
       },
     }),
     del({ targets: 'build' }),

--- a/packages/widgets/user-management-widget/src/app/index.html
+++ b/packages/widgets/user-management-widget/src/app/index.html
@@ -81,6 +81,9 @@
         widgetEle.setAttribute('base-static-url', DESCOPE_BASE_STATIC_URL);
         widgetEle.setAttribute('tenant', DESCOPE_TENANT);
         widgetEle.setAttribute('widget-id', DESCOPE_WIDGET_ID);
+        if (DESCOPE_LOCALE) {
+          widgetEle.setAttribute('locale', DESCOPE_LOCALE);
+        }
         widgetEle.setAttribute('debug', 'false');
         if (isMock) {
           widgetEle.setAttribute('mock', 'true');
@@ -95,6 +98,9 @@
           flowEle.setAttribute('project-id', DESCOPE_PROJECT_ID);
           flowEle.setAttribute('base-url', DESCOPE_BASE_URL);
           flowEle.setAttribute('flow-id', 'sign-up-or-in');
+          if (DESCOPE_LOCALE) {
+            flowEle.setAttribute('locale', DESCOPE_LOCALE);
+          }
           flowEle.setAttribute('debug', 'false');
           flowEle.addEventListener('success', () => {
             flowEle.remove();

--- a/packages/widgets/user-management-widget/src/lib/helpers.ts
+++ b/packages/widgets/user-management-widget/src/lib/helpers.ts
@@ -68,7 +68,6 @@ export const createFlowTemplate = (
   const template = createTemplate(`<descope-wc></descope-wc>`);
 
   Object.entries(flowConfig).forEach(([key, value]) => {
-    if (value === undefined || value === null) return;
     template.content
       .querySelector('descope-wc')
       .setAttribute(kebabCase(key), value as string);

--- a/packages/widgets/user-management-widget/src/lib/helpers.ts
+++ b/packages/widgets/user-management-widget/src/lib/helpers.ts
@@ -16,6 +16,7 @@ type FlowConfig = {
   'style-id'?: string;
   client?: string;
   tenant?: string;
+  locale?: string;
 };
 
 export const unflatten = (formData: Partial<User>, keyPrefix: string) =>
@@ -67,6 +68,7 @@ export const createFlowTemplate = (
   const template = createTemplate(`<descope-wc></descope-wc>`);
 
   Object.entries(flowConfig).forEach(([key, value]) => {
+    if (value === undefined || value === null) return;
     template.content
       .querySelector('descope-wc')
       .setAttribute(kebabCase(key), value as string);

--- a/packages/widgets/user-management-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
+++ b/packages/widgets/user-management-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
@@ -1,5 +1,0 @@
-import { createFetchWidgetPagesMixin } from '@descope/sdk-mixins';
-
-export const fetchWidgetPagesMixin = createFetchWidgetPagesMixin(
-  'user-management-widget',
-);

--- a/packages/widgets/user-management-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
+++ b/packages/widgets/user-management-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
@@ -1,55 +1,5 @@
-import { compose, createSingletonMixin } from '@descope/sdk-helpers';
-import {
-  localeMixin,
-  staticResourcesMixin,
-  widgetConfigMixin,
-  widgetIdMixin,
-} from '@descope/sdk-mixins';
+import { createFetchWidgetPagesMixin } from '@descope/sdk-mixins';
 
-const WIDGET_PAGES_BASE_DIR = 'user-management-widget';
-
-export const fetchWidgetPagesMixin = createSingletonMixin(
-  <T extends CustomElementConstructor>(superclass: T) => {
-    const BaseClass = compose(
-      staticResourcesMixin,
-      widgetIdMixin,
-      widgetConfigMixin,
-      localeMixin,
-    )(superclass);
-    return class FetchWidgetPagesMixinClass extends BaseClass {
-      async fetchWidgetPage(filename: string) {
-        const localized = await this.#tryFetchLocalized(filename);
-        if (localized !== undefined) return localized;
-
-        const res = await this.fetchStaticResource(
-          `${WIDGET_PAGES_BASE_DIR}/${this.widgetId}/${filename}`,
-          'text',
-        );
-        return res?.body;
-      }
-
-      // Fetch <page>-<locale>.html when the widget publishes that locale (config.json
-      // targetLocales); otherwise return undefined so the caller falls back to the default page.
-      async #tryFetchLocalized(filename: string): Promise<string | undefined> {
-        const userLocale = await this.firstAvailableLocale(
-          this.localeCandidates,
-        );
-        if (!userLocale) return undefined;
-
-        const ext = '.html';
-        const base = filename.endsWith(ext)
-          ? filename.slice(0, -ext.length)
-          : filename;
-        try {
-          const res = await this.fetchStaticResource(
-            `${WIDGET_PAGES_BASE_DIR}/${this.widgetId}/${base}-${userLocale}${ext}`,
-            'text',
-          );
-          return res?.body;
-        } catch {
-          return undefined;
-        }
-      }
-    };
-  },
+export const fetchWidgetPagesMixin = createFetchWidgetPagesMixin(
+  'user-management-widget',
 );

--- a/packages/widgets/user-management-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
+++ b/packages/widgets/user-management-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
@@ -1,18 +1,53 @@
 import { compose, createSingletonMixin } from '@descope/sdk-helpers';
-import { staticResourcesMixin, widgetIdMixin } from '@descope/sdk-mixins';
+import {
+  localeMixin,
+  staticResourcesMixin,
+  widgetConfigMixin,
+  widgetIdMixin,
+} from '@descope/sdk-mixins';
 
 const WIDGET_PAGES_BASE_DIR = 'user-management-widget';
 
 export const fetchWidgetPagesMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) => {
-    const BaseClass = compose(staticResourcesMixin, widgetIdMixin)(superclass);
+    const BaseClass = compose(
+      staticResourcesMixin,
+      widgetIdMixin,
+      widgetConfigMixin,
+      localeMixin,
+    )(superclass);
     return class FetchWidgetPagesMixinClass extends BaseClass {
       async fetchWidgetPage(filename: string) {
+        const localized = await this.#tryFetchLocalized(filename);
+        if (localized !== undefined) return localized;
+
         const res = await this.fetchStaticResource(
           `${WIDGET_PAGES_BASE_DIR}/${this.widgetId}/${filename}`,
           'text',
         );
-        return res.body;
+        return res?.body;
+      }
+
+      // Fetch <page>-<locale>.html when the widget publishes that locale (config.json
+      // targetLocales); otherwise return undefined so the caller falls back to the default page.
+      async #tryFetchLocalized(filename: string): Promise<string | undefined> {
+        const userLocale = this.resolvedLocale;
+        if (!userLocale) return undefined;
+        if (!(await this.isLocaleAvailable(userLocale))) return undefined;
+
+        const ext = '.html';
+        const base = filename.endsWith(ext)
+          ? filename.slice(0, -ext.length)
+          : filename;
+        try {
+          const res = await this.fetchStaticResource(
+            `${WIDGET_PAGES_BASE_DIR}/${this.widgetId}/${base}-${userLocale}${ext}`,
+            'text',
+          );
+          return res?.body;
+        } catch {
+          return undefined;
+        }
       }
     };
   },

--- a/packages/widgets/user-management-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
+++ b/packages/widgets/user-management-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
@@ -31,9 +31,10 @@ export const fetchWidgetPagesMixin = createSingletonMixin(
       // Fetch <page>-<locale>.html when the widget publishes that locale (config.json
       // targetLocales); otherwise return undefined so the caller falls back to the default page.
       async #tryFetchLocalized(filename: string): Promise<string | undefined> {
-        const userLocale = this.resolvedLocale;
+        const userLocale = await this.firstAvailableLocale(
+          this.localeCandidates,
+        );
         if (!userLocale) return undefined;
-        if (!(await this.isLocaleAvailable(userLocale))) return undefined;
 
         const ext = '.html';
         const base = filename.endsWith(ext)

--- a/packages/widgets/user-management-widget/src/lib/widget/mixins/flowRedirectUrlMixin.ts
+++ b/packages/widgets/user-management-widget/src/lib/widget/mixins/flowRedirectUrlMixin.ts
@@ -1,6 +1,7 @@
 import { FlowDriver } from '@descope/sdk-component-drivers';
 import { compose, createSingletonMixin } from '@descope/sdk-helpers';
 import {
+  localeMixin,
   initLifecycleMixin,
   loggerMixin,
   modalMixin,
@@ -15,6 +16,7 @@ const REDIRECT_FLOW_NAME_QUERY_PARAM = 'widget-flow';
 export const flowRedirectUrlMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) =>
     class FlowRedirectUrlMixinClass extends compose(
+      localeMixin,
       initLifecycleMixin,
       modalMixin,
       stateManagementMixin,
@@ -37,6 +39,7 @@ export const flowRedirectUrlMixin = createSingletonMixin(
         const modal = this.createModal({ 'data-id': 'redirect-flow' });
         modal.setContent(
           createFlowTemplate({
+            locale: this.locale,
             projectId: this.projectId,
             flowId: widgetFlow,
             baseUrl: this.baseUrl,

--- a/packages/widgets/user-management-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initGenericFlowButtonMixin.ts
+++ b/packages/widgets/user-management-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initGenericFlowButtonMixin.ts
@@ -8,7 +8,12 @@ import {
   createSingletonMixin,
   withMemCache,
 } from '@descope/sdk-helpers';
-import { formMixin, loggerMixin, modalMixin } from '@descope/sdk-mixins';
+import {
+  localeMixin,
+  formMixin,
+  loggerMixin,
+  modalMixin,
+} from '@descope/sdk-mixins';
 import { flowSyncThemeMixin } from '../../flowSyncThemeMixin';
 import { initWidgetRootMixin } from './initWidgetRootMixin';
 import { stateManagementMixin } from '../../stateManagementMixin';
@@ -23,6 +28,7 @@ import {
 export const initGenericFlowButtonMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) =>
     class InitGenericFlowButtonMixinClass extends compose(
+      localeMixin,
       flowSyncThemeMixin,
       stateManagementMixin,
       modalMixin,
@@ -94,6 +100,7 @@ export const initGenericFlowButtonMixin = createSingletonMixin(
       #initModalContent(flowId: string) {
         this.#modal.setContent(
           createFlowTemplate({
+            locale: this.locale,
             projectId: this.projectId,
             flowId,
             baseUrl: this.baseUrl,

--- a/packages/widgets/user-management-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initWidgetRootMixin.ts
+++ b/packages/widgets/user-management-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initWidgetRootMixin.ts
@@ -4,14 +4,16 @@ import {
   createTemplate,
 } from '@descope/sdk-helpers';
 import {
+  createFetchWidgetPagesMixin,
   descopeUiMixin,
   initElementMixin,
   initLifecycleMixin,
   loggerMixin,
   widgetConfigMixin,
 } from '@descope/sdk-mixins';
-import { fetchWidgetPagesMixin } from '../../fetchWidgetPagesMixin';
 import { stateManagementMixin } from '../../stateManagementMixin';
+
+const WIDGET_PAGES_BASE_DIR = 'user-management-widget';
 
 export const initWidgetRootMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) =>
@@ -20,7 +22,7 @@ export const initWidgetRootMixin = createSingletonMixin(
       initLifecycleMixin,
       descopeUiMixin,
       initElementMixin,
-      fetchWidgetPagesMixin,
+      createFetchWidgetPagesMixin(WIDGET_PAGES_BASE_DIR),
       stateManagementMixin,
       widgetConfigMixin,
     )(superclass) {

--- a/packages/widgets/user-profile-widget/rollup.config.app.mjs
+++ b/packages/widgets/user-profile-widget/rollup.config.app.mjs
@@ -28,6 +28,7 @@ export default {
           process.env.DESCOPE_BASE_STATIC_URL || '',
         ),
         DESCOPE_WIDGET_ID: JSON.stringify(process.env.DESCOPE_WIDGET_ID || ''),
+        DESCOPE_LOCALE: JSON.stringify(process.env.DESCOPE_LOCALE || ''),
       },
     }),
     del({ targets: 'build' }),

--- a/packages/widgets/user-profile-widget/src/app/index.html
+++ b/packages/widgets/user-profile-widget/src/app/index.html
@@ -69,6 +69,9 @@
         widgetEle.setAttribute('widget-id', DESCOPE_WIDGET_ID);
         widgetEle.setAttribute('debug', 'false');
         widgetEle.setAttribute('theme', 'dark');
+        if (DESCOPE_LOCALE) {
+          widgetEle.setAttribute('locale', DESCOPE_LOCALE);
+        }
         widgetEle.addEventListener('logout', () => {
           window.location.reload();
         });
@@ -87,6 +90,9 @@
           flowEle.setAttribute('base-static-url', DESCOPE_BASE_STATIC_URL);
           flowEle.setAttribute('flow-id', 'sign-up-or-in');
           flowEle.setAttribute('debug', 'false');
+          if (DESCOPE_LOCALE) {
+            flowEle.setAttribute('locale', DESCOPE_LOCALE);
+          }
           flowEle.addEventListener('success', () => {
             flowEle.remove();
             rootEle.appendChild(widgetEle);

--- a/packages/widgets/user-profile-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
+++ b/packages/widgets/user-profile-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
@@ -1,55 +1,5 @@
-import { compose, createSingletonMixin } from '@descope/sdk-helpers';
-import {
-  localeMixin,
-  staticResourcesMixin,
-  widgetConfigMixin,
-  widgetIdMixin,
-} from '@descope/sdk-mixins';
+import { createFetchWidgetPagesMixin } from '@descope/sdk-mixins';
 
-const WIDGET_PAGES_BASE_DIR = 'user-profile-widget';
-
-export const fetchWidgetPagesMixin = createSingletonMixin(
-  <T extends CustomElementConstructor>(superclass: T) => {
-    const BaseClass = compose(
-      staticResourcesMixin,
-      widgetIdMixin,
-      widgetConfigMixin,
-      localeMixin,
-    )(superclass);
-    return class FetchWidgetPagesMixinClass extends BaseClass {
-      async fetchWidgetPage(filename: string) {
-        const localized = await this.#tryFetchLocalized(filename);
-        if (localized !== undefined) return localized;
-
-        const res = await this.fetchStaticResource(
-          `${WIDGET_PAGES_BASE_DIR}/${this.widgetId}/${filename}`,
-          'text',
-        );
-        return res?.body;
-      }
-
-      // Fetch <page>-<locale>.html when the widget publishes that locale (config.json
-      // targetLocales); otherwise return undefined so the caller falls back to the default page.
-      async #tryFetchLocalized(filename: string): Promise<string | undefined> {
-        const userLocale = await this.firstAvailableLocale(
-          this.localeCandidates,
-        );
-        if (!userLocale) return undefined;
-
-        const ext = '.html';
-        const base = filename.endsWith(ext)
-          ? filename.slice(0, -ext.length)
-          : filename;
-        try {
-          const res = await this.fetchStaticResource(
-            `${WIDGET_PAGES_BASE_DIR}/${this.widgetId}/${base}-${userLocale}${ext}`,
-            'text',
-          );
-          return res?.body;
-        } catch {
-          return undefined;
-        }
-      }
-    };
-  },
+export const fetchWidgetPagesMixin = createFetchWidgetPagesMixin(
+  'user-profile-widget',
 );

--- a/packages/widgets/user-profile-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
+++ b/packages/widgets/user-profile-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
@@ -1,7 +1,9 @@
 import { compose, createSingletonMixin } from '@descope/sdk-helpers';
 import {
-  createValidateAttributesMixin,
+  localeMixin,
   staticResourcesMixin,
+  widgetConfigMixin,
+  widgetIdMixin,
 } from '@descope/sdk-mixins';
 
 const WIDGET_PAGES_BASE_DIR = 'user-profile-widget';
@@ -10,21 +12,42 @@ export const fetchWidgetPagesMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) => {
     const BaseClass = compose(
       staticResourcesMixin,
-      createValidateAttributesMixin({
-        'widget-id': createValidateAttributesMixin.missingAttrValidator,
-      }),
+      widgetIdMixin,
+      widgetConfigMixin,
+      localeMixin,
     )(superclass);
     return class FetchWidgetPagesMixinClass extends BaseClass {
-      get widgetId() {
-        return this.getAttribute('widget-id');
-      }
-
       async fetchWidgetPage(filename: string) {
+        const localized = await this.#tryFetchLocalized(filename);
+        if (localized !== undefined) return localized;
+
         const res = await this.fetchStaticResource(
           `${WIDGET_PAGES_BASE_DIR}/${this.widgetId}/${filename}`,
           'text',
         );
-        return res.body;
+        return res?.body;
+      }
+
+      // Fetch <page>-<locale>.html when the widget publishes that locale (config.json
+      // targetLocales); otherwise return undefined so the caller falls back to the default page.
+      async #tryFetchLocalized(filename: string): Promise<string | undefined> {
+        const userLocale = this.resolvedLocale;
+        if (!userLocale) return undefined;
+        if (!(await this.isLocaleAvailable(userLocale))) return undefined;
+
+        const ext = '.html';
+        const base = filename.endsWith(ext)
+          ? filename.slice(0, -ext.length)
+          : filename;
+        try {
+          const res = await this.fetchStaticResource(
+            `${WIDGET_PAGES_BASE_DIR}/${this.widgetId}/${base}-${userLocale}${ext}`,
+            'text',
+          );
+          return res?.body;
+        } catch {
+          return undefined;
+        }
       }
     };
   },

--- a/packages/widgets/user-profile-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
+++ b/packages/widgets/user-profile-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
@@ -1,5 +1,0 @@
-import { createFetchWidgetPagesMixin } from '@descope/sdk-mixins';
-
-export const fetchWidgetPagesMixin = createFetchWidgetPagesMixin(
-  'user-profile-widget',
-);

--- a/packages/widgets/user-profile-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
+++ b/packages/widgets/user-profile-widget/src/lib/widget/mixins/fetchWidgetPagesMixin.ts
@@ -31,9 +31,10 @@ export const fetchWidgetPagesMixin = createSingletonMixin(
       // Fetch <page>-<locale>.html when the widget publishes that locale (config.json
       // targetLocales); otherwise return undefined so the caller falls back to the default page.
       async #tryFetchLocalized(filename: string): Promise<string | undefined> {
-        const userLocale = this.resolvedLocale;
+        const userLocale = await this.firstAvailableLocale(
+          this.localeCandidates,
+        );
         if (!userLocale) return undefined;
-        if (!(await this.isLocaleAvailable(userLocale))) return undefined;
 
         const ext = '.html';
         const base = filename.endsWith(ext)

--- a/packages/widgets/user-profile-widget/src/lib/widget/mixins/flowRedirectUrlMixin.ts
+++ b/packages/widgets/user-profile-widget/src/lib/widget/mixins/flowRedirectUrlMixin.ts
@@ -1,6 +1,7 @@
 import { FlowDriver } from '@descope/sdk-component-drivers';
 import { compose, createSingletonMixin } from '@descope/sdk-helpers';
 import {
+  localeMixin,
   initLifecycleMixin,
   loggerMixin,
   modalMixin,
@@ -15,6 +16,7 @@ const REDIRECT_FLOW_NAME_QUERY_PARAM = 'widget-flow';
 export const flowRedirectUrlMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) =>
     class FlowRedirectUrlMixinClass extends compose(
+      localeMixin,
       initLifecycleMixin,
       modalMixin,
       stateManagementMixin,
@@ -37,6 +39,7 @@ export const flowRedirectUrlMixin = createSingletonMixin(
         const modal = this.createModal({ 'data-id': 'redirect-flow' });
         modal.setContent(
           createFlowTemplate({
+            locale: this.locale,
             projectId: this.projectId,
             flowId: widgetFlow,
             baseUrl: this.baseUrl,

--- a/packages/widgets/user-profile-widget/src/lib/widget/mixins/helpers.ts
+++ b/packages/widgets/user-profile-widget/src/lib/widget/mixins/helpers.ts
@@ -11,6 +11,7 @@ type FlowConfig = {
   'style-id'?: string;
   form?: Record<string, string>;
   client?: Record<string, string> | string;
+  locale?: string;
 };
 
 const stringifyValue = (value: unknown) => {
@@ -25,6 +26,7 @@ export const createFlowTemplate = (
   const template = createTemplate(`<descope-wc></descope-wc>`);
 
   Object.entries(flowConfig).forEach(([key, value]) => {
+    if (value === undefined || value === null) return;
     template.content
       .querySelector('descope-wc')
       .setAttribute(kebabCase(key), stringifyValue(value));

--- a/packages/widgets/user-profile-widget/src/lib/widget/mixins/helpers.ts
+++ b/packages/widgets/user-profile-widget/src/lib/widget/mixins/helpers.ts
@@ -26,7 +26,6 @@ export const createFlowTemplate = (
   const template = createTemplate(`<descope-wc></descope-wc>`);
 
   Object.entries(flowConfig).forEach(([key, value]) => {
-    if (value === undefined || value === null) return;
     template.content
       .querySelector('descope-wc')
       .setAttribute(kebabCase(key), stringifyValue(value));

--- a/packages/widgets/user-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initAvatarMixin.ts
+++ b/packages/widgets/user-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initAvatarMixin.ts
@@ -9,6 +9,7 @@ import {
   withMemCache,
 } from '@descope/sdk-helpers';
 import {
+  localeMixin,
   cookieConfigMixin,
   loggerMixin,
   modalMixin,
@@ -23,6 +24,7 @@ import { flowSyncThemeMixin } from '../../flowSyncThemeMixin';
 export const initAvatarMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) =>
     class AvatarMixinClass extends compose(
+      localeMixin,
       flowSyncThemeMixin,
       themeMixin,
       stateManagementMixin,
@@ -53,6 +55,7 @@ export const initAvatarMixin = createSingletonMixin(
       #initModalContent() {
         this.#modal.setContent(
           createFlowTemplate({
+            locale: this.locale,
             projectId: this.projectId,
             flowId: this.avatar.flowId,
             baseUrl: this.baseUrl,

--- a/packages/widgets/user-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initEmailUserAttrMixin.ts
+++ b/packages/widgets/user-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initEmailUserAttrMixin.ts
@@ -9,14 +9,12 @@ import {
   withMemCache,
 } from '@descope/sdk-helpers';
 import {
+  localeMixin,
   cookieConfigMixin,
   loggerMixin,
   modalMixin,
 } from '@descope/sdk-mixins';
-import {
-  getEmail,
-  getEmailBadgeLabel,
-} from '../../../state/selectors';
+import { getEmail, getEmailBadgeLabel } from '../../../state/selectors';
 import { createFlowTemplate } from '../../helpers';
 import { stateManagementMixin } from '../../stateManagementMixin';
 import { initWidgetRootMixin } from './initWidgetRootMixin';
@@ -25,6 +23,7 @@ import { flowSyncThemeMixin } from '../../flowSyncThemeMixin';
 export const initEmailUserAttrMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) =>
     class EmailUserAttrMixinClass extends compose(
+      localeMixin,
       flowSyncThemeMixin,
       stateManagementMixin,
       loggerMixin,
@@ -58,6 +57,7 @@ export const initEmailUserAttrMixin = createSingletonMixin(
       #initEditModalContent() {
         this.#editModal.setContent(
           createFlowTemplate({
+            locale: this.locale,
             projectId: this.projectId,
             flowId: this.emailUserAttr.editFlowId,
             baseUrl: this.baseUrl,
@@ -90,6 +90,7 @@ export const initEmailUserAttrMixin = createSingletonMixin(
       #initDeleteModalContent() {
         this.#deleteModal.setContent(
           createFlowTemplate({
+            locale: this.locale,
             projectId: this.projectId,
             flowId: this.emailUserAttr.deleteFlowId,
             baseUrl: this.baseUrl,

--- a/packages/widgets/user-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initGenericFlowButtonMixin.ts
+++ b/packages/widgets/user-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initGenericFlowButtonMixin.ts
@@ -4,7 +4,7 @@ import {
   ModalDriver,
 } from '@descope/sdk-component-drivers';
 import { compose, createSingletonMixin } from '@descope/sdk-helpers';
-import { loggerMixin, modalMixin } from '@descope/sdk-mixins';
+import { localeMixin, loggerMixin, modalMixin } from '@descope/sdk-mixins';
 import { flowSyncThemeMixin } from '../../flowSyncThemeMixin';
 import { initWidgetRootMixin } from './initWidgetRootMixin';
 import { stateManagementMixin } from '../../stateManagementMixin';
@@ -14,6 +14,7 @@ import { getUserId } from '../../../state/selectors';
 export const initGenericFlowButtonMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) =>
     class InitGenericFlowButtonMixinClass extends compose(
+      localeMixin,
       flowSyncThemeMixin,
       stateManagementMixin,
       modalMixin,
@@ -68,6 +69,7 @@ export const initGenericFlowButtonMixin = createSingletonMixin(
       #initModalContent(flowId: string, userId: string) {
         this.#modal.setContent(
           createFlowTemplate({
+            locale: this.locale,
             projectId: this.projectId,
             flowId,
             baseUrl: this.baseUrl,

--- a/packages/widgets/user-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initNameUserAttrMixin.ts
+++ b/packages/widgets/user-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initNameUserAttrMixin.ts
@@ -9,6 +9,7 @@ import {
   withMemCache,
 } from '@descope/sdk-helpers';
 import {
+  localeMixin,
   cookieConfigMixin,
   loggerMixin,
   modalMixin,
@@ -22,6 +23,7 @@ import { flowSyncThemeMixin } from '../../flowSyncThemeMixin';
 export const initNameUserAttrMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) =>
     class NameUserAttrMixinClass extends compose(
+      localeMixin,
       flowSyncThemeMixin,
       stateManagementMixin,
       loggerMixin,
@@ -55,6 +57,7 @@ export const initNameUserAttrMixin = createSingletonMixin(
       #initEditModalContent() {
         this.#editModal.setContent(
           createFlowTemplate({
+            locale: this.locale,
             projectId: this.projectId,
             flowId: this.nameUserAttr.editFlowId,
             baseUrl: this.baseUrl,
@@ -87,6 +90,7 @@ export const initNameUserAttrMixin = createSingletonMixin(
       #initDeleteModalContent() {
         this.#deleteModal.setContent(
           createFlowTemplate({
+            locale: this.locale,
             projectId: this.projectId,
             flowId: this.nameUserAttr.deleteFlowId,
             baseUrl: this.baseUrl,

--- a/packages/widgets/user-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initPasskeyUserAuthMethodMixin.ts
+++ b/packages/widgets/user-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initPasskeyUserAuthMethodMixin.ts
@@ -9,6 +9,7 @@ import {
   withMemCache,
 } from '@descope/sdk-helpers';
 import {
+  localeMixin,
   cookieConfigMixin,
   loggerMixin,
   modalMixin,
@@ -22,6 +23,7 @@ import { flowSyncThemeMixin } from '../../flowSyncThemeMixin';
 export const initPasskeyUserAuthMethodMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) =>
     class PasskeyUserAuthMethodMixinClass extends compose(
+      localeMixin,
       flowSyncThemeMixin,
       stateManagementMixin,
       loggerMixin,
@@ -55,6 +57,7 @@ export const initPasskeyUserAuthMethodMixin = createSingletonMixin(
       #initAddModalContent() {
         this.#addModal.setContent(
           createFlowTemplate({
+            locale: this.locale,
             projectId: this.projectId,
             flowId: this.passkeyUserAuthMethod.flowId,
             baseUrl: this.baseUrl,
@@ -87,6 +90,7 @@ export const initPasskeyUserAuthMethodMixin = createSingletonMixin(
       #initRemoveModalContent() {
         this.#removeModal.setContent(
           createFlowTemplate({
+            locale: this.locale,
             projectId: this.projectId,
             flowId: this.passkeyUserAuthMethod.fulfilledFlowId,
             baseUrl: this.baseUrl,

--- a/packages/widgets/user-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initPasswordUserAuthMethodMixin.ts
+++ b/packages/widgets/user-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initPasswordUserAuthMethodMixin.ts
@@ -5,6 +5,7 @@ import {
 } from '@descope/sdk-component-drivers';
 import { compose, createSingletonMixin } from '@descope/sdk-helpers';
 import {
+  localeMixin,
   cookieConfigMixin,
   loggerMixin,
   modalMixin,
@@ -17,6 +18,7 @@ import { flowSyncThemeMixin } from '../../flowSyncThemeMixin';
 export const initPasswordUserAuthMethodMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) =>
     class PasswordUserAuthMethodMixinClass extends compose(
+      localeMixin,
       flowSyncThemeMixin,
       stateManagementMixin,
       loggerMixin,
@@ -46,6 +48,7 @@ export const initPasswordUserAuthMethodMixin = createSingletonMixin(
       #initModalContent() {
         this.#modal.setContent(
           createFlowTemplate({
+            locale: this.locale,
             projectId: this.projectId,
             flowId: this.passwordUserAuthMethod.flowId,
             baseUrl: this.baseUrl,

--- a/packages/widgets/user-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initPhoneUserAttrMixin.ts
+++ b/packages/widgets/user-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initPhoneUserAttrMixin.ts
@@ -9,14 +9,12 @@ import {
   withMemCache,
 } from '@descope/sdk-helpers';
 import {
+  localeMixin,
   loggerMixin,
   modalMixin,
   cookieConfigMixin,
 } from '@descope/sdk-mixins';
-import {
-  getPhone,
-  getPhoneBadgeLabel,
-} from '../../../state/selectors';
+import { getPhone, getPhoneBadgeLabel } from '../../../state/selectors';
 import { createFlowTemplate } from '../../helpers';
 import { stateManagementMixin } from '../../stateManagementMixin';
 import { initWidgetRootMixin } from './initWidgetRootMixin';
@@ -25,6 +23,7 @@ import { flowSyncThemeMixin } from '../../flowSyncThemeMixin';
 export const initPhoneUserAttrMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) =>
     class PhoneUserAttrMixinClass extends compose(
+      localeMixin,
       flowSyncThemeMixin,
       stateManagementMixin,
       loggerMixin,
@@ -58,6 +57,7 @@ export const initPhoneUserAttrMixin = createSingletonMixin(
       #initEditModalContent() {
         this.#editModal.setContent(
           createFlowTemplate({
+            locale: this.locale,
             projectId: this.projectId,
             flowId: this.phoneUserAttr.editFlowId,
             baseUrl: this.baseUrl,
@@ -90,6 +90,7 @@ export const initPhoneUserAttrMixin = createSingletonMixin(
       #initDeleteModalContent() {
         this.#deleteModal.setContent(
           createFlowTemplate({
+            locale: this.locale,
             projectId: this.projectId,
             flowId: this.phoneUserAttr.deleteFlowId,
             baseUrl: this.baseUrl,

--- a/packages/widgets/user-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initTotpUserAuthMethodMixin.ts
+++ b/packages/widgets/user-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initTotpUserAuthMethodMixin.ts
@@ -9,6 +9,7 @@ import {
   withMemCache,
 } from '@descope/sdk-helpers';
 import {
+  localeMixin,
   cookieConfigMixin,
   loggerMixin,
   modalMixin,
@@ -22,6 +23,7 @@ import { flowSyncThemeMixin } from '../../flowSyncThemeMixin';
 export const initTotpUserAuthMethodMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) =>
     class TotpUserAuthMethodMixinClass extends compose(
+      localeMixin,
       flowSyncThemeMixin,
       stateManagementMixin,
       loggerMixin,
@@ -55,6 +57,7 @@ export const initTotpUserAuthMethodMixin = createSingletonMixin(
       #initAddModalContent() {
         this.#addModal.setContent(
           createFlowTemplate({
+            locale: this.locale,
             projectId: this.projectId,
             flowId: this.totpUserAuthMethod.flowId,
             baseUrl: this.baseUrl,
@@ -88,6 +91,7 @@ export const initTotpUserAuthMethodMixin = createSingletonMixin(
       #initRemoveTotpModalContent() {
         this.#removeTotpModal.setContent(
           createFlowTemplate({
+            locale: this.locale,
             projectId: this.projectId,
             flowId: this.totpUserAuthMethod.fulfilledFlowId,
             baseUrl: this.baseUrl,

--- a/packages/widgets/user-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initTrustedDevicesMixin.ts
+++ b/packages/widgets/user-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initTrustedDevicesMixin.ts
@@ -9,6 +9,7 @@ import {
   withMemCache,
 } from '@descope/sdk-helpers';
 import {
+  localeMixin,
   cookieConfigMixin,
   loggerMixin,
   modalMixin,
@@ -23,6 +24,7 @@ import { getTrustedDevices, getUserId } from '../../../state/selectors';
 export const initTrustedDevicesMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) =>
     class TrustedDevicesMixinClass extends compose(
+      localeMixin,
       flowSyncThemeMixin,
       themeMixin,
       stateManagementMixin,
@@ -52,6 +54,7 @@ export const initTrustedDevicesMixin = createSingletonMixin(
       #initModalContent(deviceId: string = '') {
         this.#modal.setContent(
           createFlowTemplate({
+            locale: this.locale,
             projectId: this.projectId,
             flowId: this.deviceList.flowId,
             baseUrl: this.baseUrl,

--- a/packages/widgets/user-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initUserBuiltinAttributesMixin.ts
+++ b/packages/widgets/user-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initUserBuiltinAttributesMixin.ts
@@ -9,6 +9,7 @@ import {
   withMemCache,
 } from '@descope/sdk-helpers';
 import {
+  localeMixin,
   cookieConfigMixin,
   loggerMixin,
   modalMixin,
@@ -22,6 +23,7 @@ import { initWidgetRootMixin } from './initWidgetRootMixin';
 export const initUserBuiltinAttributesMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) =>
     class UserBuiltinAttributesMixinClass extends compose(
+      localeMixin,
       flowSyncThemeMixin,
       stateManagementMixin,
       loggerMixin,
@@ -41,6 +43,7 @@ export const initUserBuiltinAttributesMixin = createSingletonMixin(
       #initEditModalContent(flowId: string) {
         this.#editModals[flowId]?.setContent(
           createFlowTemplate({
+            locale: this.locale,
             projectId: this.projectId,
             flowId,
             baseUrl: this.baseUrl,
@@ -61,6 +64,7 @@ export const initUserBuiltinAttributesMixin = createSingletonMixin(
       #initDeleteModalContent(flowId: string) {
         this.#deleteModals[flowId]?.setContent(
           createFlowTemplate({
+            locale: this.locale,
             projectId: this.projectId,
             flowId,
             baseUrl: this.baseUrl,

--- a/packages/widgets/user-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initUserCustomAttributesMixin.ts
+++ b/packages/widgets/user-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initUserCustomAttributesMixin.ts
@@ -9,6 +9,7 @@ import {
   withMemCache,
 } from '@descope/sdk-helpers';
 import {
+  localeMixin,
   cookieConfigMixin,
   loggerMixin,
   modalMixin,
@@ -23,6 +24,7 @@ import { flowSyncThemeMixin } from '../../flowSyncThemeMixin';
 export const initUserCustomAttributesMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) =>
     class UserCustomAttributesMixinClass extends compose(
+      localeMixin,
       flowSyncThemeMixin,
       stateManagementMixin,
       loggerMixin,
@@ -53,6 +55,7 @@ export const initUserCustomAttributesMixin = createSingletonMixin(
       #initEditModalContent(flowId: string) {
         this.#editModals[flowId]?.setContent(
           createFlowTemplate({
+            locale: this.locale,
             projectId: this.projectId,
             flowId,
             baseUrl: this.baseUrl,
@@ -73,6 +76,7 @@ export const initUserCustomAttributesMixin = createSingletonMixin(
       #initDeleteModalContent(flowId: string) {
         this.#deleteModals[flowId]?.setContent(
           createFlowTemplate({
+            locale: this.locale,
             projectId: this.projectId,
             flowId,
             baseUrl: this.baseUrl,

--- a/packages/widgets/user-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initUserPasskeysMixin.ts
+++ b/packages/widgets/user-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initUserPasskeysMixin.ts
@@ -9,6 +9,7 @@ import {
   withMemCache,
 } from '@descope/sdk-helpers';
 import {
+  localeMixin,
   cookieConfigMixin,
   loggerMixin,
   modalMixin,
@@ -22,6 +23,7 @@ import { flowSyncThemeMixin } from '../../flowSyncThemeMixin';
 export const initUserPasskeysMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) =>
     class PasskeyUserAuthMethodMixinClass extends compose(
+      localeMixin,
       flowSyncThemeMixin,
       stateManagementMixin,
       loggerMixin,
@@ -55,6 +57,7 @@ export const initUserPasskeysMixin = createSingletonMixin(
       #initAddModalContent() {
         this.#addModal.setContent(
           createFlowTemplate({
+            locale: this.locale,
             projectId: this.projectId,
             flowId: this.userPasskeys.addPasskeyFlowId,
             baseUrl: this.baseUrl,
@@ -88,6 +91,7 @@ export const initUserPasskeysMixin = createSingletonMixin(
       #initRemoveModalContent({ externalId, credentialId }) {
         this.#removeModal.setContent(
           createFlowTemplate({
+            locale: this.locale,
             projectId: this.projectId,
             flowId: this.userPasskeys.removePasskeyFlowId,
             baseUrl: this.baseUrl,

--- a/packages/widgets/user-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initWidgetRootMixin.ts
+++ b/packages/widgets/user-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initWidgetRootMixin.ts
@@ -4,13 +4,15 @@ import {
   createTemplate,
 } from '@descope/sdk-helpers';
 import {
+  createFetchWidgetPagesMixin,
   descopeUiMixin,
   initElementMixin,
   initLifecycleMixin,
   loggerMixin,
 } from '@descope/sdk-mixins';
-import { fetchWidgetPagesMixin } from '../../fetchWidgetPagesMixin';
 import { stateManagementMixin } from '../../stateManagementMixin';
+
+const WIDGET_PAGES_BASE_DIR = 'user-profile-widget';
 
 export const initWidgetRootMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) =>
@@ -19,7 +21,7 @@ export const initWidgetRootMixin = createSingletonMixin(
       initLifecycleMixin,
       descopeUiMixin,
       initElementMixin,
-      fetchWidgetPagesMixin,
+      createFetchWidgetPagesMixin(WIDGET_PAGES_BASE_DIR),
       stateManagementMixin,
     )(superclass) {
       async #initWidgetRoot() {

--- a/packages/widgets/user-profile-widget/test/fetchWidgetPagesMixin.test.ts
+++ b/packages/widgets/user-profile-widget/test/fetchWidgetPagesMixin.test.ts
@@ -6,6 +6,10 @@ const configBody = (targetLocales?: string[]) => ({
   headers: {},
 });
 
+const setNavigatorLanguage = (value: string) => {
+  Object.defineProperty(navigator, 'language', { value, configurable: true });
+};
+
 type FetchOpts = {
   targetLocales?: string[];
   localized?: string; // suffix of the localized page that resolves, e.g. '-es.html'
@@ -81,5 +85,21 @@ describe('user-profile fetchWidgetPagesMixin (locale-aware fetching)', () => {
     );
 
     await expect(m.fetchWidgetPage('page.html')).resolves.toBe('DEFAULT');
+  });
+
+  // Regression: navigator.language='en-US' against targetLocales=['en'] must use the language
+  // fallback ('en') rather than serving the default page (see resolvedLocale fallback-drop bug).
+  it('falls back to the language candidate of navigator.language (en-US -> en)', async () => {
+    setNavigatorLanguage('en-US');
+    const { m, fetchSpy } = createMixin(
+      { 'widget-id': 'w1' }, // no explicit locale attribute
+      { targetLocales: ['en'], localized: '-en.html' },
+    );
+
+    await expect(m.fetchWidgetPage('page.html')).resolves.toBe('LOCALIZED');
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'user-profile-widget/w1/page-en.html',
+      'text',
+    );
   });
 });

--- a/packages/widgets/user-profile-widget/test/fetchWidgetPagesMixin.test.ts
+++ b/packages/widgets/user-profile-widget/test/fetchWidgetPagesMixin.test.ts
@@ -1,0 +1,85 @@
+import { fetchWidgetPagesMixin } from '../src/lib/widget/mixins/fetchWidgetPagesMixin';
+
+// configMixin reads config.json and exposes it as `this.config.projectConfig`.
+const configBody = (targetLocales?: string[]) => ({
+  body: { widgets: { w1: targetLocales ? { targetLocales } : {} } },
+  headers: {},
+});
+
+type FetchOpts = {
+  targetLocales?: string[];
+  localized?: string; // suffix of the localized page that resolves, e.g. '-es.html'
+  localizedThrows?: boolean;
+};
+
+const createMixin = (
+  attrs: Record<string, string | undefined>,
+  { targetLocales, localized, localizedThrows }: FetchOpts = {},
+) => {
+  const MixinClass = fetchWidgetPagesMixin(
+    class {
+      // eslint-disable-next-line class-methods-use-this
+      getAttribute(attr: string) {
+        return attrs[attr];
+      }
+    } as any,
+  );
+  const m = new MixinClass() as any;
+  // Stub the network: config.json returns the widget config, *.html returns page text.
+  const fetchSpy = jest.fn(async (filename: string) => {
+    if (!filename.endsWith('.html')) return configBody(targetLocales);
+    if (localized && filename.endsWith(localized)) {
+      if (localizedThrows) throw new Error('not found');
+      return { body: 'LOCALIZED' };
+    }
+    return { body: 'DEFAULT' };
+  });
+  m.fetchStaticResource = fetchSpy;
+  return { m, fetchSpy };
+};
+
+describe('user-profile fetchWidgetPagesMixin (locale-aware fetching)', () => {
+  it('fetches the locale-specific page when the locale is available', async () => {
+    const { m, fetchSpy } = createMixin(
+      { 'widget-id': 'w1', locale: 'es' },
+      { targetLocales: ['es'], localized: '-es.html' },
+    );
+
+    await expect(m.fetchWidgetPage('page.html')).resolves.toBe('LOCALIZED');
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'user-profile-widget/w1/page-es.html',
+      'text',
+    );
+  });
+
+  it('matches the target locale case-insensitively', async () => {
+    const { m } = createMixin(
+      { 'widget-id': 'w1', locale: 'es' },
+      { targetLocales: ['ES'], localized: '-es.html' },
+    );
+
+    await expect(m.fetchWidgetPage('page.html')).resolves.toBe('LOCALIZED');
+  });
+
+  it('falls back to the default page when the locale is not in targetLocales', async () => {
+    const { m, fetchSpy } = createMixin(
+      { 'widget-id': 'w1', locale: 'es' },
+      { targetLocales: [] }, // es unavailable
+    );
+
+    await expect(m.fetchWidgetPage('page.html')).resolves.toBe('DEFAULT');
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'user-profile-widget/w1/page.html',
+      'text',
+    );
+  });
+
+  it('falls back to the default page when the localized fetch throws', async () => {
+    const { m } = createMixin(
+      { 'widget-id': 'w1', locale: 'es' },
+      { targetLocales: ['es'], localized: '-es.html', localizedThrows: true },
+    );
+
+    await expect(m.fetchWidgetPage('page.html')).resolves.toBe('DEFAULT');
+  });
+});


### PR DESCRIPTION
## Description

Adds widget localization to the SDK so widgets render in the user's locale, consuming the per-locale screen artifacts (`<page>-<locale>.html`) and the `config.json` `widgets[].targetLocales` published by the backend. Pairs with the backend and console-app widget-localization work.

- **sdk-mixins**: new `localeMixin` (`locale` / `resolvedLocale`, mirroring the web-component `getUserLocale` resolution so widget locale matches the flow runtime) and `widgetConfigMixin.isLocaleAvailable(locale)` backed by `config.json` `widgets[].targetLocales` (case-insensitive). `WidgetConfig` gains `version?` / `targetLocales?`.
- **all 8 widgets** (`fetchWidgetPagesMixin`): fetch `<page>-<locale>.html` when the widget publishes that locale, falling back to the default page on miss or fetch error. Unified onto `compose(staticResourcesMixin, widgetIdMixin, widgetConfigMixin, localeMixin)`.
- **flow-embedding widgets** (user-profile, tenant-profile, user-management, outbound-applications): propagate an explicit widget `locale` attribute into embedded `descope-wc` flows via `createFlowTemplate`. When no explicit `locale` is set, the embedded flow keeps its own `navigator.language` fallback.

## Tests
- `localeMixin.test.ts`, `widgetConfigMixin.test.ts` (sdk-mixins)
- `fetchWidgetPagesMixin.test.ts` (user-profile-widget): localized fetch, case-insensitive match, fallback when locale unavailable, fallback when localized fetch throws

## Must
- [x] Tests
- [ ] Documentation (if applicable)