### PR TITLE
fix(core-js-sdk): avoid async-arrow Metro/Hermes bundling failure

### DIFF
--- a/packages/sdks/core-js-sdk/src/httpClient/helpers/createFetchLogger.ts
+++ b/packages/sdks/core-js-sdk/src/httpClient/helpers/createFetchLogger.ts
@@ -102,9 +102,10 @@ const buildResponseLog = async (resp: Response & { retries?: number }) => {
     .build();
 };
 
-const fetchWrapper =
-  (fetch: Fetch) =>
-  async (...args: Parameters<Fetch>) => {
+const fetchWrapper = (fetch: Fetch) =>
+  // Named function rather than an `async (...rest) =>` arrow: Metro/Hermes
+  // (RN 0.85+) mis-compiles that construct when bundling — facebook/metro#1725.
+  async function fetchWithRetries(...args: Parameters<Fetch>) {
     let resp: Response & { retries?: number } = await fetch(...args);
 
     let retries = 0;
@@ -147,7 +148,8 @@ const createFetchLogger = (logger: Logger, receivedFetch?: Fetch) => {
     );
 
   if (!logger) return fetchWrapper(baseFetch);
-  return async (...args: Parameters<Fetch>) => {
+  // Named function rather than an `async (...rest) =>` arrow — see fetchWrapper above.
+  return async function loggingFetch(...args: Parameters<Fetch>) {
     if (!baseFetch)
       throw Error(
         'Cannot send http request, fetch is not defined, if you are running in a test, make sure fetch is defined globally',


### PR DESCRIPTION
## Related Issues
Required for:
https://github.com/descope/etc/issues/16068

## In a Nutshell
- Convert the two rest-param `async` arrows in `createFetchLogger` to named `async function`s
- Sidesteps a Metro/Hermes bundling regression on RN 0.85+ — facebook/metro#1725
- Native `async`/`await` preserved; build, outputs, and other consumers untouched

## Description
Metro's Hermes-targeting transformer (RN 0.85+ / Metro 0.84+ / hermes-parser 0.33+) mis-compiles `async (...rest) => {}` arrows when bundling, failing with `Property id of VariableDeclarator expected node to be of a type ["LVal","VoidPattern"] but instead got "SpreadElement"`.

The only two affected spots are the rest-param async arrows in `createFetchLogger`. Converting them to named `async function` expressions means the construct is never emitted — native `async`/`await` is preserved (no downleveling), and the minified output survives terser unchanged (verified: zero rest-param async arrows in the built `cjs`/`esm`).

Validated end-to-end against a fresh Expo 56 / RN 0.85.3 app — the previously-failing Metro bundle now succeeds.

## Must
- [ ] Tests
- [ ] Documentation (if applicable)