### PR TITLE
fix(user-profile-widget): init builtin attribute modals + listeners once

### DIFF
--- a/packages/widgets/user-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initUserBuiltinAttributesMixin.ts
+++ b/packages/widgets/user-profile-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initUserBuiltinAttributesMixin.ts
@@ -31,6 +31,9 @@ export const initUserBuiltinAttributesMixin = createSingletonMixin(
       cookieConfigMixin,
       modalMixin,
     )(superclass) {
+      // field name (e.g. `givenName`) -> driver wrapping the matching descope-user-attribute
+      #drivers: Record<string, UserAttributeDriver> = {};
+
       // flow Id is key in all maps
       #editModals: Record<string, ModalDriver> = {};
 
@@ -81,98 +84,98 @@ export const initUserBuiltinAttributesMixin = createSingletonMixin(
         });
       }
 
-      #updateBuiltinValueUserAttrs = withMemCache(
-        (userBuiltinAttributes: ReturnType<typeof getUserBuiltinAttrs>) => {
-          const allBuiltinAttributesComponents =
-            this.shadowRoot?.querySelectorAll(
-              'descope-user-attribute[data-id^="builtin."]',
-            );
-
-          Array.from(allBuiltinAttributesComponents).forEach((nodeEle) => {
-            const field = nodeEle
-              .getAttribute('data-id')
-              .replace('builtin.', '');
-            const val = userBuiltinAttributes[field];
-
-            const compInstance = new UserAttributeDriver(nodeEle, {
-              logger: this.logger,
-            });
-
-            compInstance.value = (val || '').toString();
-
-            this.#initEditFlow(nodeEle, field, compInstance);
-            this.#initDeleteFlow(nodeEle, field, compInstance);
-          });
-        },
-      );
-
       #initEditFlow(
         nodeEle: Element,
         field: string,
-        compInstance: UserAttributeDriver,
+        driver: UserAttributeDriver,
       ) {
         const editFlowId = nodeEle.getAttribute('edit-flow-id');
-        if (editFlowId) {
-          this.#editModals[editFlowId] = this.createModal({
-            'data-id': `edit-${field}`,
-          });
+        if (!editFlowId) return;
 
-          this.#editFlows[editFlowId] = new FlowDriver(
-            () =>
-              this.#editModals[editFlowId]?.ele?.querySelector('descope-wc'),
-            { logger: this.logger },
-          );
-          this.#editModals[editFlowId].afterClose =
-            this.#initEditModalContent.bind(this, editFlowId);
+        this.#editModals[editFlowId] = this.createModal({
+          'data-id': `edit-${field}`,
+        });
 
-          compInstance.onEditClick(() => {
-            this.#editModals?.[editFlowId]?.open();
-          });
+        this.#editFlows[editFlowId] = new FlowDriver(
+          () => this.#editModals[editFlowId]?.ele?.querySelector('descope-wc'),
+          { logger: this.logger },
+        );
+        this.#editModals[editFlowId].afterClose =
+          this.#initEditModalContent.bind(this, editFlowId);
 
-          this.#initEditModalContent(editFlowId);
-          this.syncFlowTheme(this.#editFlows[editFlowId]);
-        }
+        driver.onEditClick(() => {
+          this.#editModals?.[editFlowId]?.open();
+        });
+
+        this.#initEditModalContent(editFlowId);
+        this.syncFlowTheme(this.#editFlows[editFlowId]);
       }
 
       #initDeleteFlow(
         nodeEle: Element,
         field: string,
-        compInstance: UserAttributeDriver,
+        driver: UserAttributeDriver,
       ) {
         const deleteFlowId = nodeEle.getAttribute('delete-flow-id');
-        if (deleteFlowId) {
-          this.#deleteModals[deleteFlowId] = this.createModal({
-            'data-id': `delete-${field}`,
-          });
+        if (!deleteFlowId) return;
 
-          this.#deleteFlows[deleteFlowId] = new FlowDriver(
-            () =>
-              this.#deleteModals[deleteFlowId]?.ele?.querySelector(
-                'descope-wc',
-              ),
-            { logger: this.logger },
-          );
-          this.#deleteModals[deleteFlowId].afterClose =
-            this.#initDeleteModalContent.bind(this, deleteFlowId);
+        this.#deleteModals[deleteFlowId] = this.createModal({
+          'data-id': `delete-${field}`,
+        });
 
-          compInstance.onDeleteClick(() => {
-            this.#deleteModals?.[deleteFlowId]?.open();
-          });
+        this.#deleteFlows[deleteFlowId] = new FlowDriver(
+          () =>
+            this.#deleteModals[deleteFlowId]?.ele?.querySelector('descope-wc'),
+          { logger: this.logger },
+        );
+        this.#deleteModals[deleteFlowId].afterClose =
+          this.#initDeleteModalContent.bind(this, deleteFlowId);
 
-          this.#initDeleteModalContent(deleteFlowId);
-          this.syncFlowTheme(this.#deleteFlows[deleteFlowId]);
-        }
+        driver.onDeleteClick(() => {
+          this.#deleteModals?.[deleteFlowId]?.open();
+        });
+
+        this.#initDeleteModalContent(deleteFlowId);
+        this.syncFlowTheme(this.#deleteFlows[deleteFlowId]);
       }
+
+      #initBuiltinUserAttrs() {
+        const allBuiltinAttributesComponents =
+          this.shadowRoot?.querySelectorAll(
+            'descope-user-attribute[data-id^="builtin."]',
+          );
+
+        Array.from(allBuiltinAttributesComponents || []).forEach((nodeEle) => {
+          const field = nodeEle.getAttribute('data-id').replace('builtin.', '');
+
+          const driver = new UserAttributeDriver(nodeEle, {
+            logger: this.logger,
+          });
+          this.#drivers[field] = driver;
+
+          this.#initEditFlow(nodeEle, field, driver);
+          this.#initDeleteFlow(nodeEle, field, driver);
+        });
+      }
+
+      #onValueUpdate = withMemCache(
+        (userBuiltinAttributes: ReturnType<typeof getUserBuiltinAttrs>) => {
+          Object.keys(this.#drivers).forEach((field) => {
+            this.#drivers[field].value = (
+              userBuiltinAttributes[field] || ''
+            ).toString();
+          });
+        },
+      );
 
       async onWidgetRootReady() {
         await super.onWidgetRootReady?.();
 
-        this.#updateBuiltinValueUserAttrs(getUserBuiltinAttrs(this.state));
+        this.#initBuiltinUserAttrs();
 
-        this.subscribe(
-          this.#updateBuiltinValueUserAttrs.bind(this),
-          getUserBuiltinAttrs,
-        );
+        this.#onValueUpdate(getUserBuiltinAttrs(this.state));
+
+        this.subscribe(this.#onValueUpdate.bind(this), getUserBuiltinAttrs);
       }
     },
 );


### PR DESCRIPTION
## Summary
- Builtin attributes (given / middle / family name) used to re-create their edit + delete modals and re-add `edit-clicked` / `delete-clicked` listeners on every redux state change. After a few interactions the widget shadow DOM was holding dozens of modal elements.
- Split setup from updates to match the sibling email / name / phone mixins: one `#initBuiltinUserAttrs` call in `onWidgetRootReady`, and a redux subscriber that only sets `driver.value`.

## Linked
- Ticket: descope/etc#16306

## Changes
- `initUserBuiltinAttributesMixin.ts`:
  - New `#drivers: Record<string, UserAttributeDriver>` keyed by field name.
  - New `#initBuiltinUserAttrs()` — walks `descope-user-attribute[data-id^="builtin."]`, creates one driver + edit modal + delete modal per node, wires the click handlers. Runs once in `onWidgetRootReady`.
  - `#onValueUpdate` is now the only subscriber to `getUserBuiltinAttrs`, and just sets each cached driver's value.
  - `#initEditFlow` / `#initDeleteFlow` now early-return on missing flow id and take `driver` (was `compInstance`) for naming consistency with `#initBuiltinUserAttrs`.

## Manual test plan
- Load the user-profile-widget against a project that has `builtin.givenName` / `builtin.middleName` / `builtin.familyName` configured.
- In the shadow DOM, count `descope-user-profile-widget >>> descope-modal` — should stay at the per-field max (2 modals × number of builtin fields configured) regardless of how many `getMe` cycles fire.
- Click Edit on Given Name → modal opens, edit screen renders, Save submits, modal closes after success, value re-fetches via `getMe`.
- Same flow for Family Name and Middle Name.
- Click Delete on any of them → delete modal opens, delete flow runs, modal closes after success.

## Risk / review focus
- The mixin is now order-sensitive: drivers are populated in `#initBuiltinUserAttrs`, and `#onValueUpdate` reads from `#drivers`. `onWidgetRootReady` calls them in the right order — but if a future change moves `#onValueUpdate` to before `#initBuiltinUserAttrs`, it would silently no-op.
- This PR fixes the modal leak only. The customer-visible bug (descope/etc#16292 — given/family name edits don't persist) is a separate issue on the flow/backend side; this PR does not address it.