### PR TITLE
feat(access-key-management-widget): add Rotate action RELEASE

### DIFF
--- a/packages/widgets/access-key-management-widget/e2e/access-key-management-widget.spec.ts
+++ b/packages/widgets/access-key-management-widget/e2e/access-key-management-widget.spec.ts
@@ -44,14 +44,15 @@ const readShadowDomElementValue = (
       if (!root) return null;
       const direct = root.querySelector?.(s);
       if (direct) return direct;
-      const all = root.querySelectorAll?.('*') || [];
-      for (const el of all) {
+      const all = Array.from(root.querySelectorAll?.('*') || []);
+      let found: any = null;
+      all.some((el: any) => {
         if (el.shadowRoot) {
-          const found = findInShadow(el.shadowRoot, s);
-          if (found) return found;
+          found = findInShadow(el.shadowRoot, s);
         }
-      }
-      return null;
+        return !!found;
+      });
+      return found;
     }
     return findInShadow(document, sel)?.value;
   }, selector);

--- a/packages/widgets/access-key-management-widget/e2e/access-key-management-widget.spec.ts
+++ b/packages/widgets/access-key-management-widget/e2e/access-key-management-widget.spec.ts
@@ -15,6 +15,8 @@ import createdAccessKeyModalMock from '../test/mocks/createdAccessKeyModalMock';
 import deleteAccessKeyModalMock from '../test/mocks/deleteAccessKeyModalMock';
 import activateAccessKeyModalMock from '../test/mocks/activateAccessKeyModalMock';
 import deactivateAccessKeyModalMock from '../test/mocks/deactivateAccessKeyModalMock';
+import rotateAccessKeyModalMock from '../test/mocks/rotateAccessKeyModalMock';
+import rotatedAccessKeyModalMock from '../test/mocks/rotatedAccessKeyModalMock';
 
 const configContent = {
   flows: {
@@ -29,6 +31,30 @@ const apiPath = (prop: 'accesskey' | 'tenant', path: string) =>
 const MODAL_TIMEOUT = 500;
 const STATE_TIMEOUT = 2000;
 const cleartext = 'aaaaaaaaaaaaaa';
+
+// Reads `.value` from a custom element matching `selector` anywhere in the
+// page, walking shadow roots. Needed because descope-text-field isn't a native
+// <input>, so playwright's locator.inputValue() doesn't work on it.
+const readShadowDomElementValue = (
+  page: import('@playwright/test').Page,
+  selector: string,
+): Promise<string | undefined> =>
+  page.evaluate((sel: string) => {
+    function findInShadow(root: any, s: string): any {
+      if (!root) return null;
+      const direct = root.querySelector?.(s);
+      if (direct) return direct;
+      const all = root.querySelectorAll?.('*') || [];
+      for (const el of all) {
+        if (el.shadowRoot) {
+          const found = findInShadow(el.shadowRoot, s);
+          if (found) return found;
+        }
+      }
+      return null;
+    }
+    return findInShadow(document, sel)?.value;
+  }, selector);
 
 test.describe('widget', () => {
   test.beforeEach(async ({ page }) => {
@@ -71,6 +97,14 @@ test.describe('widget', () => {
       route.fulfill({ body: deactivateAccessKeyModalMock }),
     );
 
+    await page.route('*/**/rotate-access-key-modal.html', async (route) =>
+      route.fulfill({ body: rotateAccessKeyModalMock }),
+    );
+
+    await page.route('*/**/rotated-access-key-modal.html', async (route) =>
+      route.fulfill({ body: rotatedAccessKeyModalMock }),
+    );
+
     await page.route(apiPath('accesskey', 'create'), async (route) =>
       route.fulfill({ json: { key: mockNewAccessKey, cleartext } }),
     );
@@ -97,6 +131,12 @@ test.describe('widget', () => {
 
     await page.route(apiPath('accesskey', 'deactivate'), async (route) =>
       route.fulfill({ json: { tenant: 'mockTenant' } }),
+    );
+
+    await page.route(apiPath('accesskey', 'rotate'), async (route) =>
+      route.fulfill({
+        json: { key: mockAccessKeys.keys[0], cleartext },
+      }),
     );
 
     await page.route('**/auth/me', async (route) =>
@@ -179,10 +219,11 @@ test.describe('widget', () => {
       page.locator('text=Access Key created successfully'),
     ).toBeVisible();
 
-    const generatedAccessKeyNameInput = page
-      .getByPlaceholder('Generated Key')
-      .last();
-    expect(await generatedAccessKeyNameInput.inputValue()).toEqual(cleartext);
+    const createdAccessKeyValue = await readShadowDomElementValue(
+      page,
+      '[data-testid="created-access-key-input"]',
+    );
+    expect(createdAccessKeyValue).toEqual(cleartext);
 
     // click modal create button
     const closeCreatedAccessKeyButton = page
@@ -587,6 +628,223 @@ test.describe('widget', () => {
 
     // deactivate button remains disabled for expired keys
     await expect(deactivateAccessKeyTrigger).toBeDisabled();
+  });
+
+  test('rotate access key', async ({ page, browserName }) => {
+    const rotatedCleartext = 'rotated-cleartext-value';
+    await page.route(apiPath('accesskey', 'rotate'), async (route) =>
+      route.fulfill({
+        json: {
+          key: mockAccessKeys.keys[0],
+          cleartext: rotatedCleartext,
+        },
+      }),
+    );
+
+    await page.waitForTimeout(STATE_TIMEOUT);
+
+    const rotateAccessKeyTrigger = page
+      .getByTestId('rotate-access-keys-trigger')
+      .first();
+    const rotateModalSubmitButton = page
+      .getByTestId('rotate-access-key-modal-submit')
+      .first();
+
+    await rotateAccessKeyTrigger.waitFor({ state: 'visible' });
+
+    // rotate button initial state is disabled
+    await expect(rotateAccessKeyTrigger).toBeDisabled();
+
+    // select a single row (.first() is the select-all header checkbox; .nth(1)
+    // is the first row's checkbox)
+    await page.locator('descope-checkbox').nth(1).click();
+
+    await page.waitForTimeout(MODAL_TIMEOUT);
+
+    // rotate button is enabled when exactly one active key is selected
+    await expect(rotateAccessKeyTrigger).toBeEnabled();
+
+    // click rotate — opens the confirm modal first
+    await rotateAccessKeyTrigger.click();
+
+    // confirm modal renders with the rotate title + selected key name in the
+    // dynamic body
+    const rotateConfirmTitle = page.locator('text=Rotate access key').first();
+    await expect(rotateConfirmTitle).toBeVisible();
+    await expect(
+      page.locator(`text=Rotate ${mockAccessKeys.keys[0].name}?`),
+    ).toBeVisible();
+
+    // confirm — fires the rotate API and opens the reveal modal
+    await rotateModalSubmitButton.click();
+
+    // success notification
+    await expect(
+      page.locator('text=Access key rotated successfully'),
+    ).toBeVisible();
+
+    // reveal modal now has the rotate-specific title
+    await expect(page.locator('text=Access key secret rotated')).toBeVisible();
+
+    const rotatedAccessKeyValue = await readShadowDomElementValue(
+      page,
+      '[data-testid="rotated-access-key-input"]',
+    );
+    expect(rotatedAccessKeyValue).toEqual(rotatedCleartext);
+
+    // close the reveal modal — exercises the clipboard copy
+    const closeRevealButton = page
+      .getByTestId('rotated-access-key-modal-close')
+      .first();
+    await closeRevealButton.click();
+
+    if (browserName === 'chromium') {
+      const clipboardContent = await page.evaluate(
+        'navigator.clipboard.readText()',
+      );
+      expect(clipboardContent).toEqual(rotatedCleartext);
+    }
+  });
+
+  test('rotate keeps the reveal modal closed when the API rejects', async ({
+    page,
+  }) => {
+    // Override the default rotate route to return a server error
+    await page.route(apiPath('accesskey', 'rotate'), async (route) =>
+      route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          errorCode: 'E000000',
+          errorDescription: 'simulated server error',
+        }),
+      }),
+    );
+
+    await page.waitForTimeout(STATE_TIMEOUT);
+
+    const rotateAccessKeyTrigger = page
+      .getByTestId('rotate-access-keys-trigger')
+      .first();
+    const rotateModalSubmitButton = page
+      .getByTestId('rotate-access-key-modal-submit')
+      .first();
+
+    await rotateAccessKeyTrigger.waitFor({ state: 'visible' });
+
+    // pick a row + open the confirm modal
+    await page.locator('descope-checkbox').nth(1).click();
+    await page.waitForTimeout(MODAL_TIMEOUT);
+    await rotateAccessKeyTrigger.click();
+
+    await expect(page.locator('text=Rotate access key').first()).toBeVisible();
+
+    // submit → API rejects → no reveal modal, error notification surfaces
+    await rotateModalSubmitButton.click();
+    await page.waitForTimeout(MODAL_TIMEOUT);
+
+    // The "secret isn't lost" invariant: reveal modal must NOT open on failure,
+    // otherwise the user would see an empty/stale cleartext input.
+    await expect(page.locator('text=Access key secret rotated')).toBeHidden();
+
+    // Error notification surfaced via the withNotifications helper.
+    await expect(
+      page.locator('text=Failed to rotate access key').first(),
+    ).toBeVisible();
+  });
+
+  test('rotate confirm modal can be cancelled without firing the API', async ({
+    page,
+  }) => {
+    let rotateCalls = 0;
+    await page.route(apiPath('accesskey', 'rotate'), async (route) => {
+      rotateCalls += 1;
+      return route.fulfill({
+        json: {
+          key: mockAccessKeys.keys[0],
+          cleartext: 'should-not-be-shown',
+        },
+      });
+    });
+
+    await page.waitForTimeout(STATE_TIMEOUT);
+
+    const rotateAccessKeyTrigger = page
+      .getByTestId('rotate-access-keys-trigger')
+      .first();
+    const rotateModalCancelButton = page
+      .getByTestId('rotate-access-key-modal-cancel')
+      .first();
+
+    await rotateAccessKeyTrigger.waitFor({ state: 'visible' });
+
+    // pick a row + open the confirm modal
+    await page.locator('descope-checkbox').nth(1).click();
+    await page.waitForTimeout(MODAL_TIMEOUT);
+    await rotateAccessKeyTrigger.click();
+
+    await expect(page.locator('text=Rotate access key').first()).toBeVisible();
+
+    // cancel → modal closes, no API call, no reveal
+    await rotateModalCancelButton.click();
+    await page.waitForTimeout(MODAL_TIMEOUT);
+
+    expect(rotateCalls).toBe(0);
+    await expect(page.locator('text=Access key secret rotated')).toBeHidden();
+  });
+
+  test('rotate button is disabled when multiple keys are selected', async ({
+    page,
+  }) => {
+    await page.waitForTimeout(STATE_TIMEOUT);
+
+    const rotateAccessKeyTrigger = page
+      .getByTestId('rotate-access-keys-trigger')
+      .first();
+
+    await rotateAccessKeyTrigger.waitFor({ state: 'visible' });
+
+    // rotate button initial state is disabled
+    await expect(rotateAccessKeyTrigger).toBeDisabled();
+
+    // select-all checkbox (selects all 3 keys)
+    await page.locator('descope-checkbox').first().click();
+
+    await page.waitForTimeout(STATE_TIMEOUT);
+
+    // rotate requires a single selection — stays disabled with multi-select
+    await expect(rotateAccessKeyTrigger).toBeDisabled();
+  });
+
+  test('rotate button is disabled for expired keys', async ({ page }) => {
+    await page.waitForLoadState('networkidle');
+    await page.route(apiPath('accesskey', 'search'), async (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ keys: mockAccessKeysWithExpired.keys }),
+      }),
+    );
+    page.reload();
+    await page.waitForLoadState('networkidle');
+
+    await page.waitForTimeout(STATE_TIMEOUT);
+
+    const rotateAccessKeyTrigger = page
+      .getByTestId('rotate-access-keys-trigger')
+      .first();
+
+    await rotateAccessKeyTrigger.waitFor({ state: 'visible' });
+
+    await expect(rotateAccessKeyTrigger).toBeDisabled();
+
+    // select first row's checkbox
+    await page.locator('descope-checkbox').nth(1).click();
+
+    await page.waitForTimeout(STATE_TIMEOUT);
+
+    // rotate stays disabled for expired keys
+    await expect(rotateAccessKeyTrigger).toBeDisabled();
   });
 
   test('delete button is still enabled for expired keys', async ({ page }) => {

--- a/packages/widgets/access-key-management-widget/src/lib/widget/api/apiPaths.ts
+++ b/packages/widgets/access-key-management-widget/src/lib/widget/api/apiPaths.ts
@@ -5,6 +5,7 @@ export const apiPaths = {
     create: '/v1/mgmt/accesskey/create',
     deactivate: '/v1/mgmt/accesskey/deactivate/batch',
     activate: '/v1/mgmt/accesskey/activate/batch',
+    rotate: '/v1/mgmt/accesskey/rotate',
   },
   tenant: {
     roles: '/v1/mgmt/role/all',

--- a/packages/widgets/access-key-management-widget/src/lib/widget/api/sdk/createAccessKeySdk.ts
+++ b/packages/widgets/access-key-management-widget/src/lib/widget/api/sdk/createAccessKeySdk.ts
@@ -3,6 +3,7 @@ import {
   CreateAccessKeyConfig,
   SearchAccessKeyConfig,
   AccessKey,
+  RotateAccessKeyConfig,
 } from '../types';
 import { apiPaths } from '../apiPaths';
 import { withErrorHandler } from './helpers';
@@ -147,11 +148,34 @@ export const createAccessKeySdk = ({
     return json;
   };
 
+  const rotate: (
+    config: RotateAccessKeyConfig,
+  ) => Promise<{ cleartext: string; key: AccessKey }> = async ({ id }) => {
+    if (mock) {
+      return accessKey.rotate({ id });
+    }
+
+    const res = await httpClient.post(
+      apiPaths.accesskey.rotate,
+      { id },
+      {
+        queryParams: { tenant },
+      },
+    );
+
+    await withErrorHandler(res);
+
+    const json = await res.json();
+
+    return json;
+  };
+
   return {
     search,
     deleteBatch,
     create,
     activate,
     deactivate,
+    rotate,
   };
 };

--- a/packages/widgets/access-key-management-widget/src/lib/widget/api/sdk/mocks.ts
+++ b/packages/widgets/access-key-management-widget/src/lib/widget/api/sdk/mocks.ts
@@ -2,6 +2,7 @@ import {
   AccessKey,
   CreateAccessKeyConfig,
   Role,
+  RotateAccessKeyConfig,
   SearchAccessKeyConfig,
 } from '../types';
 
@@ -80,6 +81,28 @@ const deactivate = async () => {};
 
 const deleteBatch = async () => {};
 
+const rotate: (
+  config: RotateAccessKeyConfig,
+) => Promise<{ cleartext: string; key: AccessKey }> = async ({ id }) =>
+  new Promise((resolve) => {
+    resolve({
+      cleartext: Math.random().toString(20).substring(2),
+      key: {
+        id,
+        name: `Access Key ${id}`,
+        createdBy: 'User',
+        editable: true,
+        expireTime: new Date().getTime() / 1000 + 60 * 60 * 24 * 30,
+        createdTime: new Date().getTime() / 1000,
+        roleNames: [],
+        permittedIps: [],
+        status: 'active',
+        clientId: `Client ID ${id}`,
+        boundUserId: 'User',
+      },
+    });
+  });
+
 const getTenantRoles = (
   tenant: string,
 ): Promise<{
@@ -105,6 +128,7 @@ const accessKey = {
   activate,
   deactivate,
   deleteBatch,
+  rotate,
 };
 const tenants = {
   getTenantRoles,

--- a/packages/widgets/access-key-management-widget/src/lib/widget/api/types.ts
+++ b/packages/widgets/access-key-management-widget/src/lib/widget/api/types.ts
@@ -45,6 +45,10 @@ export type DeactivateAccessKeyConfig = {
   id: string;
 };
 
+export type RotateAccessKeyConfig = {
+  id: string;
+};
+
 export type Role = {
   name: string;
   description: string;

--- a/packages/widgets/access-key-management-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initRotateAccessKeyButtonMixin.ts
+++ b/packages/widgets/access-key-management-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initRotateAccessKeyButtonMixin.ts
@@ -1,0 +1,55 @@
+import { ButtonDriver } from '@descope/sdk-component-drivers';
+import {
+  compose,
+  createSingletonMixin,
+  withMemCache,
+} from '@descope/sdk-helpers';
+import { loggerMixin } from '@descope/sdk-mixins';
+import { getCanRotateAccessKey } from '../../../state/selectors';
+import { stateManagementMixin } from '../../stateManagementMixin';
+import { initRotateAccessKeyModalMixin } from './initRotateAccessKeyModalMixin';
+import { initWidgetRootMixin } from './initWidgetRootMixin';
+
+export const initRotateAccessKeyButtonMixin = createSingletonMixin(
+  <T extends CustomElementConstructor>(superclass: T) =>
+    class InitRotateAccessKeyButtonMixinClass extends compose(
+      loggerMixin,
+      initWidgetRootMixin,
+      stateManagementMixin,
+      initRotateAccessKeyModalMixin,
+    )(superclass) {
+      rotateButton: ButtonDriver;
+
+      #initRotateButton() {
+        this.rotateButton = new ButtonDriver(
+          this.shadowRoot?.querySelector('[data-id="rotate-access-keys"]'),
+          { logger: this.logger },
+        );
+        this.rotateButton.disable();
+        this.rotateButton.onClick(() => {
+          this.rotateAccessKeyModal.open();
+        });
+      }
+
+      #onCanRotateUpdate = withMemCache(
+        (canRotate: ReturnType<typeof getCanRotateAccessKey>) => {
+          if (canRotate) {
+            this.rotateButton.enable();
+          } else {
+            this.rotateButton.disable();
+          }
+        },
+      );
+
+      async onWidgetRootReady() {
+        await super.onWidgetRootReady?.();
+
+        this.#initRotateButton();
+
+        this.subscribe(
+          this.#onCanRotateUpdate.bind(this),
+          getCanRotateAccessKey,
+        );
+      }
+    },
+);

--- a/packages/widgets/access-key-management-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initRotateAccessKeyModalMixin.ts
+++ b/packages/widgets/access-key-management-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initRotateAccessKeyModalMixin.ts
@@ -17,9 +17,6 @@ import { stateManagementMixin } from '../../stateManagementMixin';
 import { initRotatedAccessKeyModalMixin } from './initRotatedAccessKeyModalMixin';
 import { initWidgetRootMixin } from './initWidgetRootMixin';
 
-// Confirm dialog for the Rotate flow — mirrors initDeactivateAccessKeysModalMixin.
-// Submit calls actions.rotateAccessKey({ id }) and, on success, opens the
-// dedicated rotated-access-key reveal modal with the new cleartext.
 export const initRotateAccessKeyModalMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) =>
     class InitRotateAccessKeyModalMixinClass extends compose(

--- a/packages/widgets/access-key-management-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initRotateAccessKeyModalMixin.ts
+++ b/packages/widgets/access-key-management-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initRotateAccessKeyModalMixin.ts
@@ -1,0 +1,97 @@
+import {
+  ButtonDriver,
+  ModalDriver,
+  TextDriver,
+} from '@descope/sdk-component-drivers';
+import {
+  compose,
+  createSingletonMixin,
+  createTemplate,
+} from '@descope/sdk-helpers';
+import { formMixin, loggerMixin, modalMixin } from '@descope/sdk-mixins';
+import {
+  getSelectedAccessKeys,
+  getSelectedAccessKeysDetailsForDisplay,
+} from '../../../state/selectors';
+import { stateManagementMixin } from '../../stateManagementMixin';
+import { initRotatedAccessKeyModalMixin } from './initRotatedAccessKeyModalMixin';
+import { initWidgetRootMixin } from './initWidgetRootMixin';
+
+// Confirm dialog for the Rotate flow — mirrors initDeactivateAccessKeysModalMixin.
+// Submit calls actions.rotateAccessKey({ id }) and, on success, opens the
+// dedicated rotated-access-key reveal modal with the new cleartext.
+export const initRotateAccessKeyModalMixin = createSingletonMixin(
+  <T extends CustomElementConstructor>(superclass: T) =>
+    class InitRotateAccessKeyModalMixinClass extends compose(
+      stateManagementMixin,
+      modalMixin,
+      formMixin,
+      loggerMixin,
+      initWidgetRootMixin,
+      initRotatedAccessKeyModalMixin,
+    )(superclass) {
+      rotateAccessKeyModal: ModalDriver;
+
+      async #initRotateAccessKeyModal() {
+        this.rotateAccessKeyModal = this.createModal();
+        this.rotateAccessKeyModal.setContent(
+          createTemplate(
+            await this.fetchWidgetPage('rotate-access-key-modal.html'),
+          ),
+        );
+
+        const cancelButton = new ButtonDriver(
+          () =>
+            this.rotateAccessKeyModal.ele?.querySelector(
+              '[data-id="modal-cancel"]',
+            ),
+          { logger: this.logger },
+        );
+        cancelButton.onClick(() => this.rotateAccessKeyModal.close());
+
+        const submitButton = new ButtonDriver(
+          () =>
+            this.rotateAccessKeyModal.ele?.querySelector(
+              '[data-id="modal-submit"]',
+            ),
+          { logger: this.logger },
+        );
+        submitButton.onClick(async () => {
+          const selected = getSelectedAccessKeys(this.state)?.[0];
+          if (!selected) {
+            this.rotateAccessKeyModal.close();
+            return;
+          }
+          const res: Record<string, any> = await this.actions.rotateAccessKey({
+            id: selected.id,
+          });
+          this.rotateAccessKeyModal.close();
+
+          if (res?.payload?.cleartext) {
+            this.setFormData(this.rotatedAccessKeyModal.ele, {
+              'generated-key': res.payload.cleartext,
+            });
+            this.rotatedAccessKeyModal.open();
+          }
+        });
+
+        const description = new TextDriver(
+          this.rotateAccessKeyModal.ele?.querySelector('[data-id="body-text"]'),
+          { logger: this.logger },
+        );
+
+        this.rotateAccessKeyModal.beforeOpen = () => {
+          const accessKeyDetails = getSelectedAccessKeysDetailsForDisplay(
+            this.state,
+          );
+          description.text = `Rotate ${accessKeyDetails}?`;
+        };
+      }
+
+      async onWidgetRootReady() {
+        await super.onWidgetRootReady?.();
+
+        await this.#initRotateAccessKeyModal();
+      }
+    },
+);

--- a/packages/widgets/access-key-management-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initRotatedAccessKeyModalMixin.ts
+++ b/packages/widgets/access-key-management-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initRotatedAccessKeyModalMixin.ts
@@ -1,0 +1,52 @@
+import { ButtonDriver, ModalDriver } from '@descope/sdk-component-drivers';
+import {
+  compose,
+  createSingletonMixin,
+  createTemplate,
+} from '@descope/sdk-helpers';
+import { formMixin, loggerMixin, modalMixin } from '@descope/sdk-mixins';
+import { stateManagementMixin } from '../../stateManagementMixin';
+import { initWidgetRootMixin } from './initWidgetRootMixin';
+
+export const initRotatedAccessKeyModalMixin = createSingletonMixin(
+  <T extends CustomElementConstructor>(superclass: T) =>
+    class InitRotatedAccessKeyModalMixinClass extends compose(
+      stateManagementMixin,
+      modalMixin,
+      formMixin,
+      loggerMixin,
+      initWidgetRootMixin,
+    )(superclass) {
+      rotatedAccessKeyModal: ModalDriver;
+
+      async #initRotatedAccessKeyModal() {
+        this.rotatedAccessKeyModal = this.createModal();
+        this.rotatedAccessKeyModal.setContent(
+          createTemplate(
+            await this.fetchWidgetPage('rotated-access-key-modal.html'),
+          ),
+        );
+
+        const closeButton = new ButtonDriver(
+          () =>
+            this.rotatedAccessKeyModal.ele?.querySelector(
+              '[data-id="modal-close"]',
+            ),
+          { logger: this.logger },
+        );
+        closeButton.onClick(() => {
+          navigator.clipboard.writeText(
+            this.getFormData(this.rotatedAccessKeyModal.ele)['generated-key'],
+          );
+          this.resetFormData(this.rotatedAccessKeyModal.ele);
+          this.rotatedAccessKeyModal.close();
+        });
+      }
+
+      async onWidgetRootReady() {
+        await super.onWidgetRootReady?.();
+
+        this.#initRotatedAccessKeyModal();
+      }
+    },
+);

--- a/packages/widgets/access-key-management-widget/src/lib/widget/mixins/initMixin/initMixin.ts
+++ b/packages/widgets/access-key-management-widget/src/lib/widget/mixins/initMixin/initMixin.ts
@@ -7,6 +7,7 @@ import { initDeactivateAccessKeysButtonMixin } from './initComponentsMixins/init
 import { initDeleteAccessKeysButtonMixin } from './initComponentsMixins/initDeleteAccessKeysButtonMixin';
 import { initFilterAccessKeysInputMixin } from './initComponentsMixins/initFilterAccessKeysInputMixin';
 import { initNotificationsMixin } from './initComponentsMixins/initNotificationsMixin';
+import { initRotateAccessKeyButtonMixin } from './initComponentsMixins/initRotateAccessKeyButtonMixin';
 
 export const initMixin = createSingletonMixin(
   <T extends CustomElementConstructor>(superclass: T) =>
@@ -20,6 +21,7 @@ export const initMixin = createSingletonMixin(
       initFilterAccessKeysInputMixin,
       initActivateAccessKeysButtonMixin,
       initDeactivateAccessKeysButtonMixin,
+      initRotateAccessKeyButtonMixin,
       initNotificationsMixin,
     )(superclass) {
       async init() {

--- a/packages/widgets/access-key-management-widget/src/lib/widget/mixins/stateManagementMixin.ts
+++ b/packages/widgets/access-key-management-widget/src/lib/widget/mixins/stateManagementMixin.ts
@@ -11,6 +11,7 @@ import {
   deactivateAccessKeys,
   deleteAccessKeys,
   getTenantRoles,
+  rotateAccessKey,
   searchAccessKeys,
 } from '../state/asyncActions';
 import { initialState } from '../state/initialState';
@@ -36,6 +37,7 @@ export const stateManagementMixin = createSingletonMixin(
           searchAccessKeys.reducer(builder);
           activateAccessKeys.reducer(builder);
           deactivateAccessKeys.reducer(builder);
+          rotateAccessKey.reducer(builder);
           getTenantRoles.reducer(builder);
         },
         asyncActions: {
@@ -44,6 +46,7 @@ export const stateManagementMixin = createSingletonMixin(
           activateAccessKeys: activateAccessKeys.action,
           deactivateAccessKeys: deactivateAccessKeys.action,
           deleteAccessKeys: deleteAccessKeys.action,
+          rotateAccessKey: rotateAccessKey.action,
           getTenantRoles: getTenantRoles.action,
         },
       }),

--- a/packages/widgets/access-key-management-widget/src/lib/widget/state/asyncActions/index.ts
+++ b/packages/widgets/access-key-management-widget/src/lib/widget/state/asyncActions/index.ts
@@ -3,4 +3,5 @@ export * from './deleteAccessKey';
 export * from './searchAccessKeys';
 export * from './activateAccessKey';
 export * from './deactivateAccessKey';
+export * from './rotateAccessKey';
 export * from './getTenantRoles';

--- a/packages/widgets/access-key-management-widget/src/lib/widget/state/asyncActions/rotateAccessKey.ts
+++ b/packages/widgets/access-key-management-widget/src/lib/widget/state/asyncActions/rotateAccessKey.ts
@@ -1,0 +1,41 @@
+/* eslint-disable no-param-reassign */
+/* eslint-disable @typescript-eslint/no-shadow */
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import { Sdk } from '../../api/sdk';
+import { FirstParameter, State, ThunkConfigExtraApi } from '../types';
+import {
+  buildAsyncReducer,
+  withNotifications,
+  withRequestStatus,
+} from './helpers';
+
+const action = createAsyncThunk<
+  any,
+  FirstParameter<Sdk['accesskey']['rotate']>,
+  ThunkConfigExtraApi
+>('accessKeys/rotate', (arg, { extra: { api } }) => api.accesskey.rotate(arg));
+
+const reducer = buildAsyncReducer(action)(
+  {
+    onFulfilled: (state, action) => {
+      const idx = state.accessKeysList.data.findIndex(
+        (k) => k.id === action.payload.key.id,
+      );
+      if (idx >= 0) state.accessKeysList.data[idx] = action.payload.key;
+    },
+  },
+  withRequestStatus((state: State) => state.rotateAccessKey),
+  withNotifications({
+    getSuccessMsg: () => 'Access key rotated successfully',
+    getErrorMsg: (action) => {
+      const errorMsg = action.error?.message;
+      return `
+      <div>
+        <div>Failed to rotate access key</div>
+        ${errorMsg}
+      </div>`;
+    },
+  }),
+);
+
+export const rotateAccessKey = { action, reducer };

--- a/packages/widgets/access-key-management-widget/src/lib/widget/state/initialState.ts
+++ b/packages/widgets/access-key-management-widget/src/lib/widget/state/initialState.ts
@@ -22,6 +22,10 @@ export const initialState: State = {
     loading: false,
     error: null,
   },
+  rotateAccessKey: {
+    loading: false,
+    error: null,
+  },
   tenantRoles: {
     loading: false,
     error: null,

--- a/packages/widgets/access-key-management-widget/src/lib/widget/state/selectors.ts
+++ b/packages/widgets/access-key-management-widget/src/lib/widget/state/selectors.ts
@@ -77,3 +77,13 @@ export const getSelectedAccessKeysDetailsForDisplay = createSelector(
     return `${selectedAccessKeys.length} access keys`;
   },
 );
+
+// canChangeStatus is shared with Activate (which needs inactive), so it does
+// NOT gate on active — we add that here for Rotate.
+export const getCanRotateAccessKey = createSelector(
+  getCanChangeAccessKeysStatus,
+  getIsSingleAccessKeysSelected,
+  getSelectedAccessKeys,
+  (canChangeStatus, isSingle, selected) =>
+    canChangeStatus && isSingle && selected[0]?.status === 'active',
+);

--- a/packages/widgets/access-key-management-widget/src/lib/widget/state/types.ts
+++ b/packages/widgets/access-key-management-widget/src/lib/widget/state/types.ts
@@ -24,6 +24,10 @@ export type State = {
     loading: boolean;
     error: unknown;
   };
+  rotateAccessKey: {
+    loading: boolean;
+    error: unknown;
+  };
   tenantRoles: {
     loading: boolean;
     error: unknown;

--- a/packages/widgets/access-key-management-widget/test/access-key-management-widget.test.ts
+++ b/packages/widgets/access-key-management-widget/test/access-key-management-widget.test.ts
@@ -7,6 +7,7 @@ import { createSdk } from '../src/lib/widget/api/sdk';
 import {
   getCanModifyAccessKeys,
   getCanChangeAccessKeysStatus,
+  getCanRotateAccessKey,
   getHasSelectedExpiredAccessKeys,
 } from '../src/lib/widget/state/selectors';
 import { State } from '../src/lib/widget/state/types';
@@ -17,6 +18,8 @@ import createdAccessKeyModalMock from './mocks/createdAccessKeyModalMock';
 import deleteAccessKeyModalMock from './mocks/deleteAccessKeyModalMock';
 import activateAccessKeyModalMock from './mocks/activateAccessKeyModalMock';
 import deactivateAccessKeyModalMock from './mocks/deactivateAccessKeyModalMock';
+import rotateAccessKeyModalMock from './mocks/rotateAccessKeyModalMock';
+import rotatedAccessKeyModalMock from './mocks/rotatedAccessKeyModalMock';
 
 const origAppend = document.body.append;
 
@@ -102,6 +105,12 @@ describe('access-key-management-widget', () => {
         }
         case url.endsWith('delete-access-keys-modal.html'): {
           return { ...res, text: () => deleteAccessKeyModalMock };
+        }
+        case url.endsWith('rotate-access-key-modal.html'): {
+          return { ...res, text: () => rotateAccessKeyModalMock };
+        }
+        case url.endsWith('rotated-access-key-modal.html'): {
+          return { ...res, text: () => rotatedAccessKeyModalMock };
         }
         default: {
           return { ok: false };
@@ -241,6 +250,36 @@ describe('access-key-management-widget', () => {
         ),
       );
     });
+
+    it('rotate', async () => {
+      const sdk = createSdk({ projectId: mockProjectId }, mockTenant, false);
+      const id = mockAccessKeys.keys[0]['id'];
+      const rotateResponse = { cleartext: 'rotated-secret', key: { id } };
+      mockHttpClient.post.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(rotateResponse),
+        text: () => Promise.resolve(JSON.stringify(rotateResponse)),
+      });
+
+      await sdk.accesskey.rotate({ id });
+
+      await waitFor(
+        () => expect(mockHttpClient.post).toHaveBeenCalledTimes(1),
+        { timeout: 5000 },
+      );
+      await waitFor(() =>
+        expect(mockHttpClient.post).toHaveBeenCalledWith(
+          apiPaths.accesskey.rotate,
+          { id },
+          {
+            queryParams: {
+              tenant: mockTenant,
+            },
+          },
+        ),
+      );
+    });
   });
 
   describe('utils', () => {
@@ -267,6 +306,7 @@ describe('access-key-management-widget', () => {
       activateAccessKey: { loading: false, error: null },
       deactivateAccessKey: { loading: false, error: null },
       deleteAccessKey: { loading: false, error: null },
+      rotateAccessKey: { loading: false, error: null },
       tenantRoles: { loading: false, error: null, data: [] },
       searchParams: { text: '', sort: [] },
       selectedAccessKeysIds: [],
@@ -376,6 +416,210 @@ describe('access-key-management-widget', () => {
       };
 
       expect(getCanChangeAccessKeysStatus(state)).toBe(false);
+    });
+
+    it('getCanRotateAccessKey should return true for single active non-expired editable selected', () => {
+      const state: State = {
+        ...baseState,
+        accessKeysList: {
+          ...baseState.accessKeysList,
+          data: [makeKey({ id: '1' })],
+        },
+        selectedAccessKeysIds: ['1'],
+      };
+
+      expect(getCanRotateAccessKey(state)).toBe(true);
+    });
+
+    it('getCanRotateAccessKey should return false when no keys selected', () => {
+      const state: State = {
+        ...baseState,
+        accessKeysList: {
+          ...baseState.accessKeysList,
+          data: [makeKey({ id: '1' })],
+        },
+        selectedAccessKeysIds: [],
+      };
+
+      expect(getCanRotateAccessKey(state)).toBe(false);
+    });
+
+    it('getCanRotateAccessKey should return false when multiple keys are selected', () => {
+      const state: State = {
+        ...baseState,
+        accessKeysList: {
+          ...baseState.accessKeysList,
+          data: [makeKey({ id: '1' }), makeKey({ id: '2' })],
+        },
+        selectedAccessKeysIds: ['1', '2'],
+      };
+
+      expect(getCanRotateAccessKey(state)).toBe(false);
+    });
+
+    it('getCanRotateAccessKey should return false for a single expired key', () => {
+      const state: State = {
+        ...baseState,
+        accessKeysList: {
+          ...baseState.accessKeysList,
+          data: [makeKey({ id: '1', expireTime: pastTime })],
+        },
+        selectedAccessKeysIds: ['1'],
+      };
+
+      expect(getCanRotateAccessKey(state)).toBe(false);
+    });
+
+    it('getCanRotateAccessKey should return false for a single inactive (status !== "active") key', () => {
+      const state: State = {
+        ...baseState,
+        accessKeysList: {
+          ...baseState.accessKeysList,
+          data: [makeKey({ id: '1', status: 'inactive' })],
+        },
+        selectedAccessKeysIds: ['1'],
+      };
+
+      expect(getCanRotateAccessKey(state)).toBe(false);
+    });
+
+    it('getCanRotateAccessKey should return false for a single non-editable key', () => {
+      const state: State = {
+        ...baseState,
+        accessKeysList: {
+          ...baseState.accessKeysList,
+          data: [makeKey({ id: '1', editable: false })],
+        },
+        selectedAccessKeysIds: ['1'],
+      };
+
+      expect(getCanRotateAccessKey(state)).toBe(false);
+    });
+  });
+
+  describe('rotateAccessKey reducer', () => {
+    const pastTime = Math.floor(Date.now() / 1000) - 3600;
+    const futureTime = Math.floor(Date.now() / 1000) + 3600;
+
+    const makeKey = (overrides: Partial<(typeof mockAccessKeys.keys)[0]>) => ({
+      id: '1',
+      name: 'Key 1',
+      clientId: 'c1',
+      createdBy: 'user',
+      roleNames: [],
+      permittedIps: [],
+      createdTime: pastTime,
+      expireTime: futureTime,
+      status: 'active',
+      editable: true,
+      boundUserId: 'u1',
+      ...overrides,
+    });
+
+    const baseState: State = {
+      accessKeysList: { data: [], loading: false, error: null },
+      createAccessKey: { loading: false, error: null },
+      activateAccessKey: { loading: false, error: null },
+      deactivateAccessKey: { loading: false, error: null },
+      deleteAccessKey: { loading: false, error: null },
+      rotateAccessKey: { loading: false, error: null },
+      tenantRoles: { loading: false, error: null, data: [] },
+      searchParams: { text: '', sort: [] },
+      selectedAccessKeysIds: [],
+      notifications: [],
+    };
+
+    // The action and reducer are wired via Redux Toolkit + the buildAsyncReducer
+    // helper. Importing them dynamically here mirrors how the widget runtime composes
+    // them, so the test catches breakage in the wiring (not just the action shape).
+    // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
+    const {
+      rotateAccessKey,
+      // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
+    } = require('../src/lib/widget/state/asyncActions/rotateAccessKey');
+
+    const applyAction = (initial: State, action: any): State => {
+      // Each reducer registers cases on a builder; we re-run those on a fresh
+      // builder that captures into a map keyed by action type.
+      const cases: Record<string, any> = {};
+      rotateAccessKey.reducer({
+        addCase: (matcher: any, fn: any) => {
+          cases[matcher.type] = fn;
+          return { addCase: cases.addCase };
+        },
+      });
+      const fn = cases[action.type];
+      // Mutate-in-place via Redux Toolkit's pattern — for the test we deep-clone
+      // the state to avoid leaking between assertions.
+      const next: State = JSON.parse(JSON.stringify(initial));
+      if (fn) fn(next, action);
+      return next;
+    };
+
+    it('onFulfilled replaces the matching key in accessKeysList.data with the response key', () => {
+      const oldKey = makeKey({ id: '1', name: 'old-name', clientId: 'c-old' });
+      const newKey = { ...oldKey, name: 'new-name', clientId: 'c-new' };
+      const initial: State = {
+        ...baseState,
+        accessKeysList: { ...baseState.accessKeysList, data: [oldKey] },
+      };
+
+      const next = applyAction(initial, {
+        type: rotateAccessKey.action.fulfilled.type,
+        payload: { key: newKey, cleartext: 'rotated-secret' },
+        meta: { arg: { id: '1' }, requestId: 'r1' },
+      });
+
+      expect(next.accessKeysList.data).toHaveLength(1);
+      expect(next.accessKeysList.data[0].name).toBe('new-name');
+      expect(next.accessKeysList.data[0].clientId).toBe('c-new');
+      const successNotifications = next.notifications.filter(
+        (n) => n.type === 'success',
+      );
+      expect(successNotifications).toHaveLength(1);
+      expect(successNotifications[0].msg).toBe(
+        'Access key rotated successfully',
+      );
+    });
+
+    it('onFulfilled is a no-op for the list when the response id is not in the list', () => {
+      const someKey = makeKey({ id: '2', name: 'untouched' });
+      const initial: State = {
+        ...baseState,
+        accessKeysList: { ...baseState.accessKeysList, data: [someKey] },
+      };
+
+      const next = applyAction(initial, {
+        type: rotateAccessKey.action.fulfilled.type,
+        payload: { key: { ...someKey, id: '999' }, cleartext: 's' },
+        meta: { arg: { id: '999' }, requestId: 'r1' },
+      });
+
+      expect(next.accessKeysList.data).toEqual([someKey]);
+    });
+
+    it('onRejected pushes an error notification and does NOT mutate accessKeysList', () => {
+      const key = makeKey({ id: '1', name: 'kept-as-is' });
+      const initial: State = {
+        ...baseState,
+        accessKeysList: { ...baseState.accessKeysList, data: [key] },
+      };
+
+      const next = applyAction(initial, {
+        type: rotateAccessKey.action.rejected.type,
+        payload: undefined,
+        error: { message: 'boom' },
+        meta: { arg: { id: '1' }, requestId: 'r1' },
+      });
+
+      expect(next.accessKeysList.data).toEqual([key]);
+      const errorNotifications = next.notifications.filter(
+        (n) => n.type === 'error',
+      );
+      expect(errorNotifications).toHaveLength(1);
+      expect(errorNotifications[0].msg).toContain(
+        'Failed to rotate access key',
+      );
     });
   });
 });

--- a/packages/widgets/access-key-management-widget/test/access-key-management-widget.test.ts
+++ b/packages/widgets/access-key-management-widget/test/access-key-management-widget.test.ts
@@ -253,7 +253,7 @@ describe('access-key-management-widget', () => {
 
     it('rotate', async () => {
       const sdk = createSdk({ projectId: mockProjectId }, mockTenant, false);
-      const id = mockAccessKeys.keys[0]['id'];
+      const { id } = mockAccessKeys.keys[0];
       const rotateResponse = { cleartext: 'rotated-secret', key: { id } };
       mockHttpClient.post.mockResolvedValueOnce({
         ok: true,

--- a/packages/widgets/access-key-management-widget/test/mocks/rootMock.ts
+++ b/packages/widgets/access-key-management-widget/test/mocks/rootMock.ts
@@ -6,6 +6,7 @@ export default `
         <descope-button data-id="delete-access-keys" data-testid="delete-access-keys-trigger" data-type="button" formNoValidate="false" full-width="false" id="deleteAccessKeys" shape="" size="sm" variant="outline" mode="primary" square="false">Delete</descope-button>
         <descope-button data-id="activate-access-keys" data-testid="activate-access-keys-trigger" data-type="button" formNoValidate="false" full-width="false" id="activateAccessKeys" shape="" size="sm" variant="outline" mode="primary" square="false">Activate</descope-button>
         <descope-button data-id="deactivate-access-keys" data-testid="deactivate-access-keys-trigger" data-type="button" formNoValidate="false" full-width="false" id="deactivateAccessKeys" shape="" size="sm" variant="outline" mode="primary" square="false">Deactivate</descope-button>
+        <descope-button data-id="rotate-access-keys" data-testid="rotate-access-keys-trigger" data-type="button" formNoValidate="false" full-width="false" id="rotateAccessKeys" shape="" size="sm" variant="outline" mode="primary" square="false">Rotate</descope-button>
         <descope-button data-id="create-access-key" data-testid="create-access-key-trigger" data-type="button" formNoValidate="false" full-width="false" id="createAccessKey" shape="" size="sm" variant="contained" mode="primary" square="false">+ Access Key</descope-button>
     </descope-container>
   </descope-container>

--- a/packages/widgets/access-key-management-widget/test/mocks/rotateAccessKeyModalMock.ts
+++ b/packages/widgets/access-key-management-widget/test/mocks/rotateAccessKeyModalMock.ts
@@ -1,0 +1,10 @@
+export default `
+<descope-container border-radius="sm" data-editor-type="container" direction="column" id="ROOT" space-between="md" st-horizontal-padding="0rem" st-vertical-padding="0rem" st-align-items="start" st-justify-content="safe center" st-background-color="#80808000" st-host-width="100%" st-gap="0.5rem">
+  <descope-text full-width="false" id="titleText" italic="false" mode="primary" text-align="center" variant="subtitle2">Rotate access key</descope-text>
+  <descope-text data-id="body-text" full-width="false" id="bodyText" italic="false" mode="primary" text-align="center" variant="body1"></descope-text>
+  <descope-container data-editor-type="container" direction="row" id="buttonsContainer" st-horizontal-padding="0rem" st-vertical-padding="0rem" st-align-items="start" st-justify-content="flex-end" st-background-color="#ffffff00" st-host-width="100%" st-gap="0rem">
+    <descope-button data-id="modal-cancel" data-testid="rotate-access-key-modal-cancel" data-type="button" formNoValidate="false" full-width="false" id="rotateAccessKeyCancelButton" shape="" size="xs" variant="link" mode="primary" square="false">Cancel</descope-button>
+    <descope-button data-id="modal-submit" data-testid="rotate-access-key-modal-submit" data-type="button" formNoValidate="false" full-width="false" id="rotateAccessKeySubmitButton" shape="" size="xs" variant="contained" mode="primary" square="false">Rotate</descope-button>
+  </descope-container>
+</descope-container>
+`;

--- a/packages/widgets/access-key-management-widget/test/mocks/rotatedAccessKeyModalMock.ts
+++ b/packages/widgets/access-key-management-widget/test/mocks/rotatedAccessKeyModalMock.ts
@@ -1,0 +1,11 @@
+export default `
+<descope-container data-editor-type="container" direction="column" id="ROOT" space-between="md" st-horizontal-padding="0rem" st-vertical-padding="0rem" st-align-items="start" st-justify-content="safe center" st-background-color="#80808000" st-host-width="100%" st-gap="0.5rem">
+  <descope-text full-width="false" id="titleText" italic="false" mode="primary" text-align="center" variant="subtitle2">Access key secret rotated</descope-text>
+  <descope-text full-width="false" id="subtitleText" italic="false" mode="primary" text-align="center" variant="body1">Make sure to copy it now, since it won't be available again in the future.</descope-text>
+  <descope-text full-width="false" id="bodyText" italic="false" mode="primary" text-align="center" variant="body1">Your new access key is:</descope-text>
+  <descope-text-field bordered="true" full-width="true" id="generated-key" label="" max="100" name="generated-key" placeholder="Generated Key" required="true" size="sm" readonly data-testid="rotated-access-key-input"></descope-text-field>
+  <descope-container data-editor-type="container" direction="row" id="buttonsContainer" st-horizontal-padding="0rem" st-vertical-padding="0rem" st-align-items="start" st-justify-content="flex-end" st-background-color="#ffffff00" st-host-width="100%" st-gap="0rem">
+    <descope-button data-id="modal-close" data-testid="rotated-access-key-modal-close" data-type="button" formNoValidate="false" full-width="false" id="rotatedAccessKeyCloseButton" shape="" size="xs" variant="contained" mode="primary" square="false">Copy to clipboard & close</descope-button>
+  </descope-container>
+</descope-container>
+`;


### PR DESCRIPTION
## Summary

- New `rotate({id})` SDK call hitting `POST /v1/mgmt/accesskey/rotate`.
- New confirm dialog and dedicated cleartext reveal modal — both are new screen IDs (`rotate-access-key-modal`, `rotated-access-key-modal`) seeded onto the widget by the console-app screen-injection on save.
- Single-active-key gating: `getCanRotateAccessKey` selector composes the existing `canChangeStatus + isSingleSelected` and adds `status === 'active'` (which the shared selector intentionally doesn't gate on because it's used by Activate too).

## Linked

- Ticket: descope/etc#15738
- Related PRs:
  - descope/backend — https://github.com/descope/backend/pull/1331
  - descope/console-app — https://github.com/descope/console-app/pull/5410

## Changes

- `apiPaths.ts`: `rotate: '/v1/mgmt/accesskey/rotate'`.
- `createAccessKeySdk.ts`, `mocks.ts`, `types.ts`: SDK function + mock + `RotateAccessKeyConfig` type.
- `state/asyncActions/rotateAccessKey.ts`: new async thunk. `onFulfilled` replaces the matching key in the list with the BE response (defensive against any BE-side metadata updates on rotate).
- `state/selectors.ts`: `getCanRotateAccessKey`.
- `state/initialState.ts`, `state/types.ts`, `stateManagementMixin.ts`: state slice + wiring.
- `initMixin/initComponentsMixins/initRotateAccessKeyButtonMixin.ts`: new button mixin — click opens the confirm modal.
- `initMixin/initComponentsMixins/initRotateAccessKeyModalMixin.ts`: new confirm dialog. Submit fires the rotate action; on success opens the reveal modal.
- `initMixin/initComponentsMixins/initRotatedAccessKeyModalMixin.ts`: new dedicated cleartext reveal — title "Access key secret rotated" (vs the create flow's "Access key was created").
- `test/access-key-management-widget.test.ts`: SDK + selector + reducer tests.
- `e2e/access-key-management-widget.spec.ts`: 5 new Playwright tests (happy path, API failure, cancel, multi-select disabled, expired disabled).

## Manual test plan

- Local: build + run widget against a local BE with the matching permission entry from the companion `descope/backend` PR.
- Save an access-key widget in console-app (so the new modal screens land on S3).
- In the widget runtime: select an active key → click Rotate → confirm modal opens with "Rotate `<name>`?" → click Rotate → API fires → reveal modal opens with "Access key secret rotated" + new cleartext → "Copy & close" puts the secret in the clipboard.
- Verify the existing Create flow still uses its own reveal modal ("Access key was created").

## Risk / review focus

- The two new mixins (`initRotateAccessKeyModalMixin`, `initRotatedAccessKeyModalMixin`) mirror existing deactivate/created mixins closely — same modal-driver patterns, same form-data plumbing.
- Reveal-modal duplication: the create and rotate reveal modals share structure but are deliberately separate so each title fits its flow.
- Cross-repo coupling: this PR is inert (rotate button no-ops) until both the console-app PR and the backend PR are merged. Merge order: backend → either FE in either order.