### PR TITLE
fix(react-sdk): clear loading state when AuthProvider refresh/me reject

### DIFF
--- a/packages/sdks/react-sdk/src/components/AuthProvider/AuthProvider.tsx
+++ b/packages/sdks/react-sdk/src/components/AuthProvider/AuthProvider.tsx
@@ -149,7 +149,7 @@ const AuthProvider: FC<IAuthProviderProps> = ({
     isSessionFetched.current = true;
 
     setIsSessionLoading(true);
-    withValidation(sdk?.refresh)(undefined, true).then(() => {
+    const stopSessionLoading = () => {
       // Defer to a separate render pass so React doesn't batch this with
       // the setIsSessionLoading(true) above when refresh() short-circuits
       // synchronously - downstream consumers (e.g. useSession) need to
@@ -159,7 +159,16 @@ const AuthProvider: FC<IAuthProviderProps> = ({
           setIsSessionLoading(false);
         }, 0);
       });
-    });
+    };
+    // Clear the loading state on both fulfilment and rejection. A rejected
+    // refresh (e.g. a transient network failure on the proactive refresh) must
+    // still clear `isSessionLoading` - `isSessionFetched` is already set so
+    // `fetchSession` never re-runs, and consumers (e.g. useSession) would
+    // otherwise hang on "loading" forever despite a valid session.
+    withValidation(sdk?.refresh)(undefined, true).then(
+      stopSessionLoading,
+      stopSessionLoading,
+    );
   }, [sdk]);
 
   const fetchUser = useCallback(() => {
@@ -168,9 +177,10 @@ const AuthProvider: FC<IAuthProviderProps> = ({
     isUserFetched.current = true;
 
     setIsUserLoading(true);
-    withValidation(sdk.me)().then(() => {
-      setIsUserLoading(false);
-    });
+    // Clear the loading state on both fulfilment and rejection so a failed
+    // `me()` doesn't leave `isUserLoading` stuck `true` (see fetchSession).
+    const stopUserLoading = () => setIsUserLoading(false);
+    withValidation(sdk.me)().then(stopUserLoading, stopUserLoading);
   }, [sdk]);
 
   const value = useMemo<IContext>(

--- a/packages/sdks/react-sdk/test/components/AuthProviderSessionLoading.test.tsx
+++ b/packages/sdks/react-sdk/test/components/AuthProviderSessionLoading.test.tsx
@@ -1,0 +1,73 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { createSdk } from '@descope/web-js-sdk';
+import { render, waitFor } from '@testing-library/react';
+import React from 'react';
+import { AuthProvider, useSession, useUser } from '../../src';
+
+jest.mock('@descope/web-js-sdk', () => {
+  const sdk = {
+    onSessionTokenChange: jest.fn(() => () => {}),
+    onIsAuthenticatedChange: jest.fn(() => () => {}),
+    onUserChange: jest.fn(() => () => {}),
+    onClaimsChange: jest.fn(() => () => {}),
+    refresh: jest.fn(() => Promise.resolve()),
+    me: jest.fn(() => Promise.resolve()),
+  };
+  return { createSdk: () => sdk };
+});
+
+const { onIsAuthenticatedChange, refresh, me } = createSdk({ projectId: '' });
+
+const SessionProbe = () => {
+  const { isSessionLoading } = useSession();
+  return <div data-testid="session-loading">{String(isSessionLoading)}</div>;
+};
+
+const UserProbe = () => {
+  const { isUserLoading } = useUser();
+  return <div data-testid="user-loading">{String(isUserLoading)}</div>;
+};
+
+describe('AuthProvider loading state on a rejected refresh / me', () => {
+  beforeEach(() => {
+    (onIsAuthenticatedChange as jest.Mock).mockImplementation(() => () => {});
+    (refresh as jest.Mock).mockImplementation(() => Promise.resolve());
+    (me as jest.Mock).mockImplementation(() => Promise.resolve());
+  });
+
+  // Without a rejection handler the loading state stays `true` forever, since
+  // isSessionFetched/isUserFetched are set before the call so the fetch never re-runs.
+  it('clears isSessionLoading when the initial refresh rejects', async () => {
+    (refresh as jest.Mock).mockRejectedValueOnce(new Error('network error'));
+
+    const { getByTestId } = render(
+      <AuthProvider projectId="p1">
+        <SessionProbe />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => expect(refresh).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(getByTestId('session-loading').textContent).toBe('false'),
+    );
+  });
+
+  it('clears isUserLoading when me rejects', async () => {
+    (onIsAuthenticatedChange as jest.Mock).mockImplementation((cb) => {
+      cb(true);
+      return () => {};
+    });
+    (me as jest.Mock).mockRejectedValueOnce(new Error('network error'));
+
+    const { getByTestId } = render(
+      <AuthProvider projectId="p1">
+        <UserProbe />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => expect(me).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(getByTestId('user-loading').textContent).toBe('false'),
+    );
+  });
+});


### PR DESCRIPTION
## Problem
`AuthProvider`'s `fetchSession` and `fetchUser` attach only an `onFulfilled`
handler to `sdk.refresh()` / `sdk.me()`:

```ts
withValidation(sdk?.refresh)(undefined, true).then(() => {
  /* ... setIsSessionLoading(false) ... */
});
```

`withValidation` only invokes the underlying SDK function — it does not catch.
So when `refresh()` (or `me()`) **rejects** (e.g. a transient network failure
during the proactive refresh on mount), the `.then` callback never runs and
`setIsSessionLoading(false)` / `setIsUserLoading(false)` is never called.

Since `isSessionFetched` / `isUserFetched` are set `true` *before* the call,
`fetchSession` / `fetchUser` never re-run — so `useSession().isSessionLoading`
(and `useUser().isUserLoading`) stay `true` **forever**, pinning the app on its
loading state until a full remount, even when a valid session cookie/token is
still present (the rejected call was only a background refresh).

## Reproduction
1. Render an app with `AuthProvider` and a valid session.
2. Make the initial `POST /v1/auth/try-refresh` fail at mount (offline, or a
   proxy that drops the cross-origin request).
3. `useSession().isSessionLoading` stays `true` indefinitely.

## Fix
Run the loading-state cleanup on **both** fulfilment and rejection
(`.then(onDone, onDone)`). Providing the rejection handler also means the
rejection is handled (no unhandled promise rejection).

- Minimal; preserves the existing `#1393` deferred-`setIsSessionLoading(false)`.
- Does not change the "fetch once" semantics — a failed proactive refresh falls
  back to the existing session state and `autoRefresh` retries on schedule.

Happy to add a unit test if you point me at the preferred place / mocking setup.
