### PR TITLE
feat(web-component): support new doesnt-contains realtime operator RELEASE

### DIFF
--- a/packages/sdks/web-component/src/lib/helpers/realtime-conditions/__tests__/evaluator.test.ts
+++ b/packages/sdks/web-component/src/lib/helpers/realtime-conditions/__tests__/evaluator.test.ts
@@ -153,6 +153,41 @@ describe('evaluateAtomic via evaluateCondition — operators', () => {
     );
   });
 
+  it('doesnt-contains is the inverse of contains for string and array targets', () => {
+    const rStr = conditionWithSingleAtom(
+      'doesnt-contains',
+      { kind: 'form', form: 'form.greeting' },
+      { kind: 'value', value: 'world' },
+    );
+    expect(evaluateCondition(rStr, { 'form.greeting': 'hello there' })).toBe(
+      true,
+    );
+    expect(evaluateCondition(rStr, { 'form.greeting': 'hello world' })).toBe(
+      false,
+    );
+
+    const rArr = conditionWithSingleAtom(
+      'doesnt-contains',
+      { kind: 'form', form: 'form.tags' },
+      { kind: 'value', value: 'admin' },
+    );
+    expect(evaluateCondition(rArr, { 'form.tags': ['user', 'guest'] })).toBe(
+      true,
+    );
+    expect(evaluateCondition(rArr, { 'form.tags': ['user', 'admin'] })).toBe(
+      false,
+    );
+  });
+
+  it('doesnt-contains returns false on non-string non-array target (mirrors contains)', () => {
+    const r = conditionWithSingleAtom(
+      'doesnt-contains',
+      { kind: 'form', form: 'form.x' },
+      { kind: 'value', value: 'y' },
+    );
+    expect(evaluateCondition(r, { 'form.x': 42 })).toBe(false);
+  });
+
   it('in / not-in', () => {
     const rIn = conditionWithSingleAtom(
       'in',

--- a/packages/sdks/web-component/src/lib/helpers/realtime-conditions/evaluator.ts
+++ b/packages/sdks/web-component/src/lib/helpers/realtime-conditions/evaluator.ts
@@ -99,6 +99,13 @@ const operators: Record<RealtimeOperator, OperatorFn> = {
     if (typeof target === 'string') return target.includes(toString(predicate));
     return false;
   },
+  // Mirrors `contains`: bad input → false, not true.
+  'doesnt-contains': (target, predicate) => {
+    if (Array.isArray(target)) return !target.includes(predicate);
+    if (typeof target === 'string')
+      return !target.includes(toString(predicate));
+    return false;
+  },
   'greater-than': (target, predicate) => {
     const targetNum = toFloat(target);
     const predicateNum = toFloat(predicate);

--- a/packages/sdks/web-component/src/lib/types.ts
+++ b/packages/sdks/web-component/src/lib/types.ts
@@ -60,6 +60,7 @@ export type RealtimeOperator =
   | 'equal'
   | 'not-equal'
   | 'contains'
+  | 'doesnt-contains'
   | 'greater-than'
   | 'greater-than-or-equal'
   | 'less-than'


### PR DESCRIPTION
## Summary
- The backend added a new realtime operator `doesnt-contains` (descope/backend#1348) and put it on the client-eligible allow-list, so realtime CCs using it now ship to the client.
- Adds the matching SDK implementation: type union entry + evaluator fn + unit tests.
- Inverse of `contains`, mirroring the BE `fn` exactly — false on non-string non-array targets (same "bad input → false" policy as `not-in`).

## Linked
- Ticket: descope/etc#16322
- Related PRs:
  - descope/backend#1348 — "Doesnt contain operator" (merged) — the BE side this is paired with

## Changes
- `types.ts` — add `'doesnt-contains'` to the `RealtimeOperator` union
- `evaluator.ts` — implement the operator in the `operators` Record
- `evaluator.test.ts` — three new tests: string positive/negative, array positive/negative, non-string-non-array → false (parity check with `contains`)

## Manual test plan
- ✅ Verified end-to-end against local BE (built from `origin/main` including #1348):
  - PUT a flow with a CC `doesnt-contains(form.text, "admin") → hide Text`
  - At flow start (form.text=""): BE residualizes the CC to `realtimeComponentsConditions`, SDK evaluates client-side, Text hidden ✅
  - Type "admin" into the input → CC stops firing → Text shown ✅
  - Type "guest" → CC fires again → Text hidden ✅
  - Zero error/warn messages related to the new operator
- ✅ `npx tsc --noEmit` clean
- ✅ `npx nx test web-component --testPathPattern=evaluator.test` — 29 passed, 29 total

## Risk / review focus
- Tiny additive change. The only behavioral risk is the `doesnt-contains` fn's edge cases — confirmed to mirror BE semantics including the "false on non-string non-array target" policy (test 3 covers this explicitly).
- No public-API change beyond a new string in a union type that the SDK already treats as a fully-listed allow-list.
- Without this change the SDK silently no-ops the operator (unknown operator → `evaluateAtomic` returns false), so the regression mode is "feature doesn't work" rather than "crash" — but for customers configuring the new operator the CC would just stop responding to typing.