### PR TITLE
fix(nextjs-sdk): bump @descope/node-sdk to 2.8.0 (Brotli JWKS fetch fix)

### DIFF
--- a/packages/sdks/nextjs-sdk/package.json
+++ b/packages/sdks/nextjs-sdk/package.json
@@ -72,7 +72,7 @@
 		]
 	},
 	"dependencies": {
-		"@descope/node-sdk": "2.6.0",
+		"@descope/node-sdk": "2.8.0",
 		"@descope/react-sdk": "workspace:*",
 		"@descope/core-js-sdk": "workspace:*",
 		"@descope/web-component": "workspace:*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -947,8 +947,8 @@ importers:
         specifier: workspace:*
         version: link:../core-js-sdk
       '@descope/node-sdk':
-        specifier: 2.6.0
-        version: 2.6.0(encoding@0.1.13)
+        specifier: 2.8.0
+        version: 2.8.0(encoding@0.1.13)
       '@descope/react-sdk':
         specifier: workspace:*
         version: link:../react-sdk
@@ -4638,8 +4638,8 @@ packages:
   '@descope/core-js-sdk@2.62.1':
     resolution: {integrity: sha512-Rs+CNjDyOQum0NCtXqspe04gdmXscva3kcNsYM74GOY9Rc5AU7OMHO14AZAm4U3Om7U2WusBxSyfTJPfjF49nA==}
 
-  '@descope/node-sdk@2.6.0':
-    resolution: {integrity: sha512-sHw5oq/rPEAEQoq3aozR9KC1VSlkR+VMTMw8EOgAFO/oEcs6xSJTe+eHVKumYXtKvqJ5RCgrTZXvrVzcChfB3w==}
+  '@descope/node-sdk@2.8.0':
+    resolution: {integrity: sha512-+FM75wTRU0ND6EZJJ4f+d0Fi6OiU/+N/PWiQ5bMr1UrL1xOmNxyPWGrN65Cens22dfEb3//uh7Lo4ZBSM67BnA==}
     engines: {node: '>= 16.0.0'}
 
   '@descope/web-components-ui@3.14.1':
@@ -18184,7 +18184,7 @@ snapshots:
     dependencies:
       jwt-decode: 4.0.0
 
-  '@descope/node-sdk@2.6.0(encoding@0.1.13)':
+  '@descope/node-sdk@2.8.0(encoding@0.1.13)':
     dependencies:
       '@descope/core-js-sdk': 2.62.1
       cross-fetch: 4.1.0(encoding@0.1.13)


### PR DESCRIPTION
## Summary

`@descope/nextjs-sdk` pins `@descope/node-sdk` to exactly **`2.6.0`**, which still fetches the JWKS via `cross-fetch` → **`node-fetch@2`**. `node-fetch@2` cannot decode **Brotli (`content-encoding: br`)** responses, so when the CDN in front of `api.descope.com` serves the keys endpoint with `br`, the fetch dies with `ERR_STREAM_PREMATURE_CLOSE`, `validateJwt` throws, and `authMiddleware`/`session()` reject **every valid token** → infinite `/sign-in` loop for all users.

`@descope/node-sdk@2.8.0` already fixes this (descope/node-sdk#742 — *"prefer native fetch to avoid node-fetch premature close"*): it uses the runtime's native `fetch` (undici), which decodes Brotli correctly, and only falls back to `cross-fetch` on older runtimes.

This PR bumps the pinned dependency so `nextjs-sdk` consumers actually receive that fix.

```diff
-    "@descope/node-sdk": "2.6.0",
+    "@descope/node-sdk": "2.8.0",
```

`node-sdk@2.8.0`'s declared dependencies are identical to `2.6.0` (`core-js-sdk 2.62.1`, `cross-fetch 4.1.0`, `jose 5.2.2`, `tslib 2.8.1`), so the lockfile change is minimal and `pnpm install --frozen-lockfile` passes.

## Why it's hard to diagnose

The failure is CDN-edge/POP dependent: it can appear suddenly with **no** application or SDK change (an edge simply starts serving `br`), and it rejects even cryptographically valid `DS` cookies.

## Context

Reported in #1418 with full root-cause analysis, in-pod isolation evidence, and a consumer-side bundler workaround. This PR is the upstream follow-up so the workaround is no longer necessary.

Refs #1418
Refs descope/node-sdk#742

Made with [Cursor](https://cursor.com)