### PR TITLE
feat(core-js-sdk): add mfa option to OTP update phone/email

### DIFF
--- a/packages/sdks/core-js-sdk/src/sdk/types.ts
+++ b/packages/sdks/core-js-sdk/src/sdk/types.ts
@@ -427,4 +427,11 @@ export type UpdateOptions<T extends boolean> = {
   templateOptions?: TemplateOptions;
   templateId?: string;
   providerId?: string;
+  /**
+   * When true, preserves the auth methods already on the refresh token and adds the
+   * updated factor to them (so the resulting `amr` keeps the previously-passed factors)
+   * instead of replacing it with a single factor. Requires a valid refresh token.
+   * Currently applies to the OTP update phone / email flows.
+   */
+  mfa?: boolean;
 };

--- a/packages/sdks/core-js-sdk/test/sdk/otp.test.ts
+++ b/packages/sdks/core-js-sdk/test/sdk/otp.test.ts
@@ -378,6 +378,31 @@ describe('otp', () => {
         );
       });
 
+      it('should send the correct request with mfa', () => {
+        const httpRespJson = { response: 'response' };
+        const httpResponse = {
+          ok: true,
+          json: () => httpRespJson,
+          clone: () => ({
+            json: () => Promise.resolve(httpRespJson),
+          }),
+          status: 200,
+        };
+        mockHttpClient.post.mockResolvedValue(httpResponse);
+        sdk.otp.update.email('loginId', 'new@email.com', 'token', {
+          mfa: true,
+        });
+        expect(mockHttpClient.post).toHaveBeenCalledWith(
+          apiPaths.otp.update.email,
+          {
+            email: 'new@email.com',
+            loginId: 'loginId',
+            mfa: true,
+          },
+          { token: 'token' },
+        );
+      });
+
       it('should return the correct response', async () => {
         const httpRespJson = { response: 'response' };
         const httpResponse = {
@@ -451,6 +476,31 @@ describe('otp', () => {
             phone: '+9720000000',
             loginId: 'loginId',
             providerId: 'some-provider',
+          },
+          { token: 'token' },
+        );
+      });
+
+      it('should send the correct request with mfa', async () => {
+        const httpRespJson = { response: 'response', maskedPhone: '**99' };
+        const httpResponse = {
+          ok: true,
+          json: () => httpRespJson,
+          clone: () => ({
+            json: () => Promise.resolve(httpRespJson),
+          }),
+          status: 200,
+        };
+        mockHttpClient.post.mockResolvedValue(httpResponse);
+        await sdk.otp.update.phone.sms('loginId', '+9720000000', 'token', {
+          mfa: true,
+        });
+        expect(mockHttpClient.post).toHaveBeenCalledWith(
+          apiPaths.otp.update.phone + '/sms',
+          {
+            phone: '+9720000000',
+            loginId: 'loginId',
+            mfa: true,
           },
           { token: 'token' },
         );


### PR DESCRIPTION
## What

Adds an `mfa` flag to `UpdateOptions`, consumed by the OTP **update phone / email** flows (`otp.update.phone.*` / `otp.update.email`). This powers `@descope/node-sdk` (and the web/React SDKs that depend on core-js-sdk).

```ts
await sdk.otp.update.phone.sms(loginId, phone, refreshToken, { mfa: true });
await sdk.otp.update.email(loginId, email, refreshToken, { mfa: true });
```

## Why

When an already-authenticated user enrolls or updates a phone/email via the OTP update flow, verification mints a fresh **single-factor** session token, dropping the auth methods already on the refresh token (e.g. `pwd`). This forced a double-confirmation UX (one round to enroll the factor, a second `mfa` sign-in just to re-grab a token with a correct merged `amr`).

With `{ mfa: true }` (and a valid refresh token), the resulting session token preserves the prior factors and adds the updated one, e.g. `['pwd', 'phone', 'mfa']`.

Reported by PerciHealth (descope/etc#16372). Pairs with the backend change adding `mfa` to `UpdateUserPhoneOTPRequest` / `UpdateUserEmailOTPRequest`.

## Notes

- `mfa` is optional and defaults to `undefined`, so existing callers are unaffected.
- It rides the existing `...updateOptions` spread into the request body — no transport changes.
- Applies to the OTP update flows only (matching backend support).

## Test

Added `update.email` / `update.phone.sms` "should send the correct request with mfa" cases asserting the request body carries `mfa: true`. `otp.test.ts` update suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)