### PR TITLE
fix(web-component): bump @descope/flow-scripts to 1.0.17 RELEASE

### DIFF
--- a/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
+++ b/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
@@ -314,7 +314,7 @@ class DescopeWc extends BaseDescopeWc {
         if (!globalThis.descope?.[script.id]) {
           await this.injectNpmLib(
             '@descope/flow-scripts',
-            '1.0.16', // currently using a fixed version when loading scripts
+            '1.0.17', // currently using a fixed version when loading scripts
             `dist/${script.id}.js`,
           );
         }


### PR DESCRIPTION
## What

Bump the fixed `@descope/flow-scripts` version loaded at runtime by the web-component from `1.0.16` to `1.0.17`.

## Why

Pick up the latest flow-scripts release.

## Details

- Single change in [`DescopeWc.ts`](packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts) — the version string passed to `injectNpmLib('@descope/flow-scripts', ...)`.
- `RELEASE` in the title triggers the release workflow on merge; `@descope/web-component` will be auto-bumped (patch: `3.69.0` → `3.69.1`) via the conventional-commit versioning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)