### PR TITLE
feat(core-js-sdk): also retry on transient status code 520 RELEASE

### DIFF
--- a/packages/sdks/core-js-sdk/src/httpClient/helpers/createFetchLogger.ts
+++ b/packages/sdks/core-js-sdk/src/httpClient/helpers/createFetchLogger.ts
@@ -76,11 +76,12 @@ const buildRequestLog = (args: Parameters<Fetch>) =>
 
 // we should retry on these status codes:
 // 503: Service Unavailable
+// 520: Web Server Returned an Unknown Error (Cloudflare error)
 // 521: Web Server Is Down (Cloudflare error)
 // 522: Connection Timed Out (Cloudflare error)
 // 524: A Timeout Occurred (Cloudflare error)
 // 530: Cloudflare error
-const retryStatusCodes = [503, 521, 522, 524, 530];
+const retryStatusCodes = [503, 520, 521, 522, 524, 530];
 
 // Retry delays in ms: first retry after 100ms, subsequent retries after 5000ms
 const retryDelaysMs = [100, 5000, 5000];

--- a/packages/sdks/core-js-sdk/test/httpClient.test.ts
+++ b/packages/sdks/core-js-sdk/test/httpClient.test.ts
@@ -704,6 +704,46 @@ describe('createFetchLogger', () => {
       expect(await response.text()).toBe('Success');
     });
 
+    it('should retry when receiving status code 520', async () => {
+      fetch
+        .mockResolvedValueOnce({
+          ok: false,
+          text: () => 'Cloudflare error',
+          url: 'http://descope.com/',
+          headers: new Headers({ header: 'header' }),
+          status: 520,
+          statusText: 'Web Server Returned an Unknown Error',
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          text: () => 'Success',
+          url: 'http://descope.com/',
+          headers: new Headers({ header: 'header' }),
+          status: 200,
+          statusText: 'OK',
+        });
+
+      const promise = fetchWithLogger('http://descope.com/test', {
+        method: 'GET',
+        headers: new Headers({ test: '123' }),
+      });
+
+      await jest.runAllTimersAsync();
+      const response = await promise;
+
+      expect(fetch).toHaveBeenCalledTimes(2);
+      expect(fetch).toHaveBeenNthCalledWith(1, 'http://descope.com/test', {
+        method: 'GET',
+        headers: new Headers({ test: '123' }),
+      });
+      expect(fetch).toHaveBeenNthCalledWith(2, 'http://descope.com/test', {
+        method: 'GET',
+        headers: new Headers({ test: '123' }),
+      });
+      expect(response.status).toBe(200);
+      expect(await response.text()).toBe('Success');
+    });
+
     it('should retry when receiving status code 524', async () => {
       fetch
         .mockResolvedValueOnce({


### PR DESCRIPTION
## Summary

Add Cloudflare status code `520` ("Web Server Returned an Unknown Error") to the `core-js-sdk` HTTP client's retryable status codes (`retryStatusCodes` in `createFetchLogger`), alongside the existing `503` / `521` / `522` / `524` / `530`.

Like the other Cloudflare 52x codes already retried, `520` is a transient edge error returned when the origin is briefly unreachable (e.g. during pod replacement on deploy), so the request is safe to retry. This brings `core-js-sdk` — and the `node-sdk` that depends on it — in line with the go-sdk (descope/go-sdk#775) and python-sdk (descope/python-sdk#1581).

https://github.com/descope/etc/issues/14039

## Test plan

- [x] Added `should retry when receiving status code 520` to the retry suite
- [x] Full `core-js-sdk` suite passes (`jest` → 364 passed, 19 suites; coverage thresholds met)
- [x] `eslint`, `prettier --check`, and `tsc --noEmit` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)