### PR TITLE
fix(web-component): clear loading state after flow completes RELEASE

### DIFF
--- a/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
+++ b/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
@@ -1844,13 +1844,18 @@ class DescopeWc extends BaseDescopeWc {
       ),
     ).filter((ele) => ele !== submitter);
 
-    const restoreComponentsState = async () => {
-      this.loggerWrapper.debug('Restoring components state');
-      this.removeEventListener('popupclosed', restoreComponentsState);
+    // reset the in-flight loading/disabled state set when the next request started
+    const resetComponentsState = () => {
       submitter.removeAttribute('loading');
       enabledElements.forEach((ele) => {
         ele.removeAttribute('disabled');
       });
+    };
+
+    const restoreComponentsState = async () => {
+      this.loggerWrapper.debug('Restoring components state');
+      this.removeEventListener('popupclosed', restoreComponentsState);
+      resetComponentsState();
       // if there are client scripts, we want to reload them
       const flowConfig = await this.getFlowConfig();
       const clientScripts = [
@@ -1907,8 +1912,17 @@ class DescopeWc extends BaseDescopeWc {
           );
         } else {
           this.nextRequestStatus.unsubscribe(unsubscribeNextRequestStatus);
-          // when next request is done, we want to listen to screenId updates
-          handleScreenIdUpdates();
+          // If the flow completed successfully, no new screen will render to
+          // clear the loading state. The element can stay mounted after that
+          // (e.g. a settings page running a step-up flow), so reset the
+          // in-flight loading/disabled state here directly.
+          if (this.flowStatus === 'success') {
+            this.removeEventListener('popupclosed', restoreComponentsState);
+            resetComponentsState();
+          } else {
+            // when next request is done, we want to listen to screenId updates
+            handleScreenIdUpdates();
+          }
         }
       },
     );

--- a/packages/sdks/web-component/test/descope-wc.loadingState.test.ts
+++ b/packages/sdks/web-component/test/descope-wc.loadingState.test.ts
@@ -214,6 +214,70 @@ describe('web-component loading state', () => {
     );
   });
 
+  // Regression for issue #16353: when the flow completes while the component
+  // stays mounted, the submit button must not stay stuck in loading state.
+  it('should restore states after the flow completes successfully', async () => {
+    startMock.mockReturnValue(generateSdkResponse());
+    // last screen submit completes the flow (no new screen rendered)
+    nextMock.mockReturnValue(generateSdkResponse({ status: 'completed' }));
+
+    fixtures.pageContent = `
+      <span>Test Page</span>
+      <descope-button id="submit">Submit</descope-button>
+      <descope-button id="another">Another Button</descope-button>
+      <input id="input" placeholder="Input"/>
+      `;
+
+    const onSuccess = jest.fn();
+    document.body.innerHTML = `<descope-wc flow-id="test-flow" project-id="1"></descope-wc>`;
+    document.querySelector('descope-wc').addEventListener('success', onSuccess);
+
+    await waitFor(() => screen.getByShadowText('Test Page'), {
+      timeout: WAIT_TIMEOUT,
+    });
+
+    fireEvent.click(screen.getByShadowText('Submit'));
+
+    // loading is set while the next request is in flight
+    await waitFor(
+      () => {
+        expect(screen.getByShadowText('Submit')).toHaveAttribute(
+          'loading',
+          'true',
+        );
+      },
+      { timeout: WAIT_TIMEOUT },
+    );
+
+    // the flow completes and success fires
+    await waitFor(() => expect(onSuccess).toHaveBeenCalled(), {
+      timeout: WAIT_TIMEOUT,
+    });
+
+    // once the flow completed, the submitter and the other elements should be
+    // restored even though no new screen renders and the element stays mounted
+    await waitFor(
+      () => {
+        expect(screen.getByShadowText('Submit')).not.toHaveAttribute('loading');
+      },
+      { timeout: WAIT_TIMEOUT },
+    );
+
+    await waitFor(
+      () => {
+        expect(screen.getByShadowText('Another Button')).toBeEnabled();
+      },
+      { timeout: WAIT_TIMEOUT },
+    );
+
+    await waitFor(
+      () => {
+        expect(screen.getByShadowPlaceholderText('Input')).toBeEnabled();
+      },
+      { timeout: WAIT_TIMEOUT },
+    );
+  });
+
   it('should NOT restore states when navigating to a different screen', async () => {
     startMock.mockReturnValue(generateSdkResponse());
     nextMock.mockReturnValue(generateSdkResponse({ screenId: '1' }));


### PR DESCRIPTION
## Summary
- Fixes the submit button staying stuck in a loading/spinner state after a flow completes successfully while the `<descope-wc>` element stays mounted (e.g. a settings page running a step-up flow).
- The `success` event and all API calls already worked — only the button UI never reset, because the loading state was restored solely on a screen re-render, `pageshow`, or `popupclosed`, none of which fire on completion.
- On completion (`flowStatus === 'success'`) the in-flight loading/disabled state is now reset directly. Recoverable errors (e.g. wrong OTP) are unaffected — they re-render the same screen and restore via the existing path.

## Linked
- Ticket: descope/etc#16353
- Related PRs: none (single-repo change)

## Changes
- `DescopeWc.ts` — in `#handleComponentsLoadingState`, the request-finished branch now resets loading/disabled directly when `flowStatus === 'success'`; otherwise it keeps the existing screen-update path. Extracted a shared `resetComponentsState()` reused by `restoreComponentsState` and the new branch.
- `descope-wc.loadingState.test.ts` — added a regression test: start flow → submit → `next` returns `status: 'completed'` → assert the submitter and the other elements restore after `success` fires.

## Manual test plan
- Run a flow (ideally a step-up flow) where the host keeps the `<descope-wc>` element mounted on `success` (does not unmount/redirect).
- Click submit on the final screen; confirm the button returns to its normal (non-loading) state after completion and the component is usable again.
- Sanity-check unchanged paths: a multi-screen flow still shows loading between screens; a wrong-OTP error still re-renders the screen and clears loading.

## Risk / review focus
- The fix hinges on `flowStatus === 'success'` being set before the loading state's request-finished handler runs — verified: `success` is dispatched synchronously inside `#handleSdkResponse` before `next()` resolves.
- Scope is intentionally success-only. A fatal transport error (network/5xx) on submit can still leave the button stuck — a rarer, separate edge not addressed here. (The common recoverable-error case already restores correctly.)
- Review focus: `#handleComponentsLoadingState` in `DescopeWc.ts`.