### PR TITLE
feat(web-component): warn on multiple same-flow components on a page RELEASE

### DIFF
--- a/packages/sdks/web-component/src/lib/descope-wc/BaseDescopeWc.ts
+++ b/packages/sdks/web-component/src/lib/descope-wc/BaseDescopeWc.ts
@@ -28,7 +28,11 @@ import {
 } from '../helpers/flowInputs';
 import { setCustomStorage } from '../helpers/storage';
 import { IsChanged } from '../helpers/state';
-import { formMountMixin, componentConditionsMixin } from '../mixins';
+import {
+  formMountMixin,
+  componentConditionsMixin,
+  duplicateFlowWarningMixin,
+} from '../mixins';
 import {
   AutoFocusOptions,
   CustomStorage,
@@ -51,6 +55,7 @@ const BaseClass = compose(
   staticResourcesMixin,
   formMountMixin,
   componentConditionsMixin,
+  duplicateFlowWarningMixin,
   injectStyleMixin,
 )(HTMLElement);
 
@@ -705,6 +710,11 @@ class BaseDescopeWc extends BaseClass {
       });
 
       this.#debugState.update({ isDebug: this.debug });
+
+      // Forward to the composed mixin chain (e.g. duplicateFlowWarningMixin) so
+      // mixins can react to project-id/flow-id changes. Only reached for real
+      // post-init changes, so it does not double-fire during initial mount.
+      super.attributeChangedCallback?.(attrName, oldValue, newValue);
     }
   }
 }

--- a/packages/sdks/web-component/src/lib/descope-wc/BaseDescopeWc.ts
+++ b/packages/sdks/web-component/src/lib/descope-wc/BaseDescopeWc.ts
@@ -681,6 +681,10 @@ class BaseDescopeWc extends BaseClass {
     oldValue: string,
     newValue: string,
   ) {
+    // Forward to the composed mixin chain first so other mixins always receive
+    // the callback, regardless of the early return below.
+    super.attributeChangedCallback?.(attrName, oldValue, newValue);
+
     if (!this.shadowRoot.isConnected || !this.#init) return;
 
     if (
@@ -710,11 +714,6 @@ class BaseDescopeWc extends BaseClass {
       });
 
       this.#debugState.update({ isDebug: this.debug });
-
-      // Forward to the composed mixin chain (e.g. duplicateFlowWarningMixin) so
-      // mixins can react to project-id/flow-id changes. Only reached for real
-      // post-init changes, so it does not double-fire during initial mount.
-      super.attributeChangedCallback?.(attrName, oldValue, newValue);
     }
   }
 }

--- a/packages/sdks/web-component/src/lib/mixins/__tests__/duplicateFlowWarningMixin.test.ts
+++ b/packages/sdks/web-component/src/lib/mixins/__tests__/duplicateFlowWarningMixin.test.ts
@@ -1,0 +1,68 @@
+import {
+  getSameFlowInstances,
+  isDuplicateSameFlowInstance,
+} from '../duplicateFlowWarningMixin';
+
+const mountWc = (projectId?: string, flowId?: string): Element => {
+  const el = document.createElement('descope-wc');
+  if (projectId !== undefined) el.setAttribute('project-id', projectId);
+  if (flowId !== undefined) el.setAttribute('flow-id', flowId);
+  document.body.appendChild(el);
+  return el;
+};
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('duplicateFlowWarningMixin detection', () => {
+  it('flags the second (non-first) of two same project+flow instances, not the first', () => {
+    const a = mountWc('p1', 'sign-in');
+    const b = mountWc('p1', 'sign-in');
+
+    expect(getSameFlowInstances(a)).toHaveLength(2);
+    expect(isDuplicateSameFlowInstance(a)).toBe(false); // first → no warning
+    expect(isDuplicateSameFlowInstance(b)).toBe(true); // duplicate → warns
+  });
+
+  it('flags every duplicate after the first (one warning per extra instance)', () => {
+    const a = mountWc('p1', 'sign-in');
+    const b = mountWc('p1', 'sign-in');
+    const c = mountWc('p1', 'sign-in');
+
+    expect([a, b, c].map(isDuplicateSameFlowInstance)).toEqual([
+      false,
+      true,
+      true,
+    ]);
+  });
+
+  it('does not flag a single instance', () => {
+    const a = mountWc('p1', 'sign-in');
+    expect(isDuplicateSameFlowInstance(a)).toBe(false);
+  });
+
+  it('does not flag same project but different flow', () => {
+    const a = mountWc('p1', 'sign-in');
+    const b = mountWc('p1', 'sign-up');
+    expect(isDuplicateSameFlowInstance(a)).toBe(false);
+    expect(isDuplicateSameFlowInstance(b)).toBe(false);
+  });
+
+  it('does not flag same flow but different project', () => {
+    const a = mountWc('p1', 'sign-in');
+    const b = mountWc('p2', 'sign-in');
+    expect(isDuplicateSameFlowInstance(a)).toBe(false);
+    expect(isDuplicateSameFlowInstance(b)).toBe(false);
+  });
+
+  it('ignores instances missing project-id or flow-id', () => {
+    const noProject = mountWc(undefined, 'sign-in');
+    const noFlow = mountWc('p1', undefined);
+    mountWc('p1', 'sign-in');
+
+    expect(getSameFlowInstances(noProject)).toHaveLength(0);
+    expect(isDuplicateSameFlowInstance(noProject)).toBe(false);
+    expect(isDuplicateSameFlowInstance(noFlow)).toBe(false);
+  });
+});

--- a/packages/sdks/web-component/src/lib/mixins/duplicateFlowWarningMixin.ts
+++ b/packages/sdks/web-component/src/lib/mixins/duplicateFlowWarningMixin.ts
@@ -1,0 +1,102 @@
+/* eslint-disable import/prefer-default-export */
+import { compose, createSingletonMixin } from '@descope/sdk-helpers';
+import { loggerMixin } from '@descope/sdk-mixins';
+
+const DESCOPE_WC_TAG = 'descope-wc';
+const PROJECT_ID_ATTR = 'project-id';
+const FLOW_ID_ATTR = 'flow-id';
+
+/**
+ * All `<descope-wc>` elements in `el`'s document that run the same project-id
+ * and flow-id as `el` (including `el` itself), in document order. Empty when
+ * `el` is missing either attribute.
+ */
+export const getSameFlowInstances = (el: Element): Element[] => {
+  const projectId = el.getAttribute(PROJECT_ID_ATTR);
+  const flowId = el.getAttribute(FLOW_ID_ATTR);
+  if (!projectId || !flowId) return [];
+  return Array.from(el.ownerDocument.querySelectorAll(DESCOPE_WC_TAG)).filter(
+    (other) =>
+      other.getAttribute(PROJECT_ID_ATTR) === projectId &&
+      other.getAttribute(FLOW_ID_ATTR) === flowId,
+  );
+};
+
+/**
+ * True when `el` is a same-flow duplicate that is NOT the first such element in
+ * document order. Reporting only from the non-first element means exactly one
+ * element per same-flow group reports `true`, so a single warning is emitted
+ * regardless of how many duplicates exist. Note: light-DOM only — duplicates
+ * nested inside another component's shadow root are intentionally not detected.
+ */
+export const isDuplicateSameFlowInstance = (el: Element): boolean => {
+  const sameFlow = getSameFlowInstances(el);
+  return sameFlow.length > 1 && sameFlow[0] !== el;
+};
+
+/**
+ * Logs a one-time dev warning when more than one `<descope-wc>` on the page runs
+ * the same project-id + flow-id. Rendering the same flow more than once is not
+ * supported (it causes the post-login screen to flicker, among other issues).
+ * Warning only — no behavior change. Hooks `connectedCallback` (not `init`) and
+ * pulls in only `loggerMixin`, to avoid participating in the flow `init()` chain.
+ */
+export const duplicateFlowWarningMixin = createSingletonMixin(
+  <T extends CustomElementConstructor>(superclass: T) => {
+    const BaseClass = compose(loggerMixin)(superclass);
+
+    return class DuplicateFlowWarningMixinClass extends BaseClass {
+      // The project|flow key this element has already warned for, so we warn at
+      // most once per identity. connectedCallback can fire multiple times for
+      // the same element (e.g. formMountMixin re-parents it into a <form>), so a
+      // plain per-call warning would fire repeatedly.
+      #warnedForKey?: string;
+
+      #scheduleDuplicateFlowCheck() {
+        // Defer so sibling instances mounted in the same tick are attached to
+        // the DOM before we query it.
+        queueMicrotask(() => {
+          if (!this.isConnected) return;
+          const projectId = this.getAttribute(PROJECT_ID_ATTR);
+          const flowId = this.getAttribute(FLOW_ID_ATTR);
+          const key = `${projectId}|${flowId}`;
+          // Bail before the DOM query when we've already warned for this
+          // identity — connectedCallback can fire several times per element.
+          if (
+            this.#warnedForKey === key ||
+            !isDuplicateSameFlowInstance(this)
+          ) {
+            return;
+          }
+          this.#warnedForKey = key;
+          this.logger.warn(
+            'Multiple Descope flow components detected on the same page',
+            `More than one <descope-wc> is running the same project ("${projectId}") and flow ("${flowId}") on this page. Running the same flow in more than one component at once is not supported and may cause the flow to behave unexpectedly. Render a single Descope flow component per page.`,
+          );
+        });
+      }
+
+      connectedCallback() {
+        super.connectedCallback?.();
+        this.#scheduleDuplicateFlowCheck();
+      }
+
+      // Re-check when the flow identity changes at runtime. Relies on
+      // BaseDescopeWc forwarding `super.attributeChangedCallback?.()` (it only
+      // forwards post-init changes, so this does not double-fire on mount).
+      attributeChangedCallback(
+        attrName: string,
+        oldValue: string,
+        newValue: string,
+      ) {
+        super.attributeChangedCallback?.(attrName, oldValue, newValue);
+        if (
+          oldValue !== newValue &&
+          (attrName === PROJECT_ID_ATTR || attrName === FLOW_ID_ATTR)
+        ) {
+          this.#scheduleDuplicateFlowCheck();
+        }
+      }
+    };
+  },
+);

--- a/packages/sdks/web-component/src/lib/mixins/duplicateFlowWarningMixin.ts
+++ b/packages/sdks/web-component/src/lib/mixins/duplicateFlowWarningMixin.ts
@@ -71,7 +71,7 @@ export const duplicateFlowWarningMixin = createSingletonMixin(
           this.#warnedForKey = key;
           this.logger.warn(
             'Multiple Descope flow components detected on the same page',
-            `More than one <descope-wc> is running the same project ("${projectId}") and flow ("${flowId}") on this page. Running the same flow in more than one component at once is not supported and may cause the flow to behave unexpectedly. Render a single Descope flow component per page.`,
+            `The same flow ("${flowId}") and project ("${projectId}") are running more than once on this page. This is not supported and may cause the flow to behave unexpectedly.`,
           );
         });
       }
@@ -81,9 +81,9 @@ export const duplicateFlowWarningMixin = createSingletonMixin(
         this.#scheduleDuplicateFlowCheck();
       }
 
-      // Re-check when the flow identity changes at runtime. Relies on
-      // BaseDescopeWc forwarding `super.attributeChangedCallback?.()` (it only
-      // forwards post-init changes, so this does not double-fire on mount).
+      // Re-check when the flow identity changes at runtime. BaseDescopeWc
+      // forwards `super.attributeChangedCallback?.()`; the `#warnedForKey`
+      // de-dupe keeps this to one warning even if it also fires on mount.
       attributeChangedCallback(
         attrName: string,
         oldValue: string,

--- a/packages/sdks/web-component/src/lib/mixins/index.ts
+++ b/packages/sdks/web-component/src/lib/mixins/index.ts
@@ -1,2 +1,3 @@
 export * from './formMountMixin';
 export * from './componentConditionsMixin';
+export * from './duplicateFlowWarningMixin';

--- a/packages/sdks/web-component/test/descope-wc.duplicateFlowWarning.test.ts
+++ b/packages/sdks/web-component/test/descope-wc.duplicateFlowWarning.test.ts
@@ -65,6 +65,7 @@ const startResponse = {
 const installLoggerSpy = () => {
   const warn = jest.fn();
   document.querySelectorAll('descope-wc').forEach((el) => {
+    // eslint-disable-next-line no-param-reassign
     (el as any).logger = {
       error: jest.fn(),
       warn,

--- a/packages/sdks/web-component/test/descope-wc.duplicateFlowWarning.test.ts
+++ b/packages/sdks/web-component/test/descope-wc.duplicateFlowWarning.test.ts
@@ -1,0 +1,154 @@
+import { createSdk } from '@descope/web-js-sdk';
+import { waitFor } from '@testing-library/dom';
+import '@testing-library/jest-dom';
+import '../src/lib/descope-wc';
+import { invokeScriptOnload } from './testUtils';
+
+jest.mock('@descope/web-js-sdk', () => {
+  const sdk = {
+    flow: {
+      start: jest.fn().mockName('flow.start'),
+      next: jest.fn().mockName('flow.next'),
+    },
+    webauthn: { helpers: { isSupported: jest.fn() } },
+    getLastUserLoginId: jest.fn().mockName('getLastUserLoginId'),
+    getLastUserDisplayName: jest.fn().mockName('getLastUserDisplayName'),
+  };
+  return {
+    __esModule: true,
+    createSdk: () => sdk,
+    clearFingerprintData: jest.fn(),
+  };
+});
+
+const sdk = createSdk({ projectId: '' });
+const startMock = sdk.flow.start as jest.Mock;
+
+const fetchMock: jest.Mock = jest.fn();
+global.fetch = fetchMock;
+
+Object.defineProperty(window, 'location', {
+  value: new URL(window.location.origin),
+});
+window.location.assign = jest.fn();
+Object.defineProperty(window.history, 'pushState', {
+  value: (x: any, y: any, url: string) => {
+    window.location.href = url;
+  },
+});
+Object.defineProperty(window.history, 'replaceState', {
+  value: (x: any, y: any, url: string) => {
+    window.location.href = url;
+  },
+});
+
+const startResponse = {
+  ok: true,
+  headers: new Headers({ h: '1' }),
+  data: {
+    stepId: '0',
+    action: 'screen',
+    screen: { id: '0', state: {} },
+    redirect: { url: '' },
+    executionId: '0',
+    status: 'running',
+    authInfo: 'auth info',
+    webauthn: { options: '', transactionId: '' },
+    error: null,
+  },
+  error: { errorMessage: '', errorDescription: '' },
+};
+
+// Inject a spy logger onto every <descope-wc> on the page. The duplicate check
+// reads `this.logger` lazily (in a deferred microtask), so a logger set
+// synchronously right after mount is the one it uses.
+const installLoggerSpy = () => {
+  const warn = jest.fn();
+  document.querySelectorAll('descope-wc').forEach((el) => {
+    (el as any).logger = {
+      error: jest.fn(),
+      warn,
+      info: jest.fn(),
+      debug: jest.fn(),
+    };
+  });
+  return warn;
+};
+
+const duplicateWarnCount = (warn: jest.Mock) =>
+  warn.mock.calls.filter((args) =>
+    String(args[0]).includes('Multiple Descope flow components'),
+  ).length;
+
+describe('duplicate flow warning', () => {
+  beforeEach(() => {
+    fetchMock.mockImplementation((url: string) => {
+      const res = { ok: true, headers: new Headers({ h: '1' }) };
+      if (url.endsWith('theme.json')) return { ...res, json: () => null };
+      if (url.endsWith('.html'))
+        return { ...res, text: () => '<span>ok</span>' };
+      if (url.endsWith('config.json')) return { ...res, json: () => ({}) };
+      return { ok: false };
+    });
+    startMock.mockReturnValue(startResponse);
+    invokeScriptOnload();
+  });
+
+  afterEach(() => {
+    document.getElementsByTagName('html')[0].innerHTML = '';
+    jest.resetAllMocks();
+  });
+
+  it('warns once when two components share the same project-id and flow-id', async () => {
+    document.body.innerHTML = `
+      <descope-wc flow-id="sign-in" project-id="p1"></descope-wc>
+      <descope-wc flow-id="sign-in" project-id="p1"></descope-wc>`;
+    const warn = installLoggerSpy();
+
+    await waitFor(() => expect(duplicateWarnCount(warn)).toBe(1));
+    // stays at one even though formMountMixin re-parents (connectedCallback fires twice)
+    await new Promise((r) => {
+      setTimeout(r, 50);
+    });
+    expect(duplicateWarnCount(warn)).toBe(1);
+  });
+
+  it('does not warn for a single component', async () => {
+    document.body.innerHTML = `<descope-wc flow-id="sign-in" project-id="p1"></descope-wc>`;
+    const warn = installLoggerSpy();
+
+    await new Promise((r) => {
+      setTimeout(r, 50);
+    });
+    expect(duplicateWarnCount(warn)).toBe(0);
+  });
+
+  it('does not warn for two components running different flows', async () => {
+    document.body.innerHTML = `
+      <descope-wc flow-id="sign-in" project-id="p1"></descope-wc>
+      <descope-wc flow-id="sign-up" project-id="p1"></descope-wc>`;
+    const warn = installLoggerSpy();
+
+    await new Promise((r) => {
+      setTimeout(r, 50);
+    });
+    expect(duplicateWarnCount(warn)).toBe(0);
+  });
+
+  it('warns when a flow-id change makes a component collide with another', async () => {
+    document.body.innerHTML = `
+      <descope-wc flow-id="sign-in" project-id="p1"></descope-wc>
+      <descope-wc id="second" flow-id="sign-up" project-id="p1"></descope-wc>`;
+    const warn = installLoggerSpy();
+
+    // no collision yet
+    await new Promise((r) => {
+      setTimeout(r, 50);
+    });
+    expect(duplicateWarnCount(warn)).toBe(0);
+
+    // change makes it a duplicate of the first
+    document.getElementById('second')!.setAttribute('flow-id', 'sign-in');
+    await waitFor(() => expect(duplicateWarnCount(warn)).toBe(1));
+  });
+});


### PR DESCRIPTION
## Summary
- Rendering more than one `<descope-wc>` with the same `project-id` + `flow-id` on a page is unsupported and can make the flow misbehave (e.g. the sign-in screen flickering after a successful login — the customer report in #14040).
- Adds a **dev warning** (via the SDK logger) that detects this on mount and on runtime `project-id`/`flow-id` changes, and points the developer at the fix.
- **Warning only — no behavior change.** Single instances and instances running *different* flows are unaffected.

## Linked
- Ticket: descope/etc#14040
- Related PRs: none (single-repo change)

## Changes
- New `duplicateFlowWarningMixin` (`src/lib/mixins/`): queries the DOM for `<descope-wc>` siblings sharing the same project-id + flow-id and warns **once per identity**, from the non-first instance. Hooks `connectedCallback` (kept out of the flow `init()` chain on purpose) and `attributeChangedCallback`.
- `BaseDescopeWc`: composes the mixin and forwards `super.attributeChangedCallback?.()` (mirrors the existing `super.disconnectedCallback?.()` forward) so mixins can react to attribute changes.
- Tests: pure-detection unit tests + a component-mount test covering the dedup (incl. `formMountMixin` re-parent double-fire) and the on-change path.

## Manual test plan
- Render two `<descope-wc>` with the same project-id + flow-id → exactly **one** console warning.
- Render a single component → **no** warning.
- Render two with **different** flow-ids → **no** warning.
- Change a live component's `flow-id` to collide with another → warns.

## Risk / review focus
- `BaseDescopeWc.attributeChangedCallback` now calls `super.attributeChangedCallback?.()`. Verified only this mixin defines one in the web-component chain today, so no other behavior changes; it's placed inside the post-init observed-change block so it doesn't double-fire on mount.
- Light-DOM only: a `<descope-wc>` nested in another component's shadow root is intentionally not detected (acceptable for a dev warning).