### PR TITLE
fix(sdk-mixins): avoid CSP style-src violation in debugger overlay RELEASE

### DIFF
--- a/packages/libs/sdk-mixins/src/mixins/debuggerMixin/debugger-wc.ts
+++ b/packages/libs/sdk-mixins/src/mixins/debuggerMixin/debugger-wc.ts
@@ -15,9 +15,7 @@ const MIN_SIZE = 200;
 
 const template = document.createElement('template');
 template.innerHTML = `
-<div style="top:${INITIAL_POS_THRESHOLD}px; left:${
-  window.innerWidth - INITIAL_WIDTH - INITIAL_POS_THRESHOLD
-}px;" class="debugger">
+<div class="debugger">
   <div class="header">
     <span>Debugger messages</span>
   </div>
@@ -166,6 +164,14 @@ class Debugger extends BaseClass {
 
     this.#rootEle =
       this.shadowRoot!.querySelector<HTMLDivElement>('.debugger')!;
+
+    // Set initial position via CSSOM instead of an inline style attribute,
+    // which a strict CSP style-src (without 'unsafe-inline') would block.
+    this.#rootEle.style.top = `${INITIAL_POS_THRESHOLD}px`;
+    this.#rootEle.style.left = `${
+      window.innerWidth - INITIAL_WIDTH - INITIAL_POS_THRESHOLD
+    }px`;
+
     this.#contentEle = this.#rootEle.querySelector<HTMLDivElement>('.content')!;
     this.#headerEle = this.#rootEle.querySelector<HTMLDivElement>('.header')!;
   }


### PR DESCRIPTION
## What
The debugger overlay (`descope-debugger`) positioned itself with an inline
`style="top:..;left:.."` attribute in its template. Under a strict CSP
`style-src` without `'unsafe-inline'`, browsers block inline style
attributes, so the overlay raised a CSP violation the moment it mounted.

## Fix
Removed the inline style attribute; set `top`/`left` via CSSOM
(`element.style.top/left`) in the constructor after the root element is
queried. CSSOM writes are not covered by `style-src`, so they pass under a
strict CSP. The injected `<style>` block was already CSP-safe
(adoptedStyleSheets + nonce fallback).

## Related issue
https://github.com/descope/etc/issues/16555

## Test plan
- Ran the tenant-profile-widget demo with `debug=true` under a strict
  `style-src 'self'` CSP — debugger overlay renders, no CSP violation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)