### PR TITLE
feat(web-js-sdk): support well-known issuer URLs and resource-scoped tokens for OIDC

### DIFF
--- a/packages/sdks/nextjs-sdk/CHANGELOG.md
+++ b/packages/sdks/nextjs-sdk/CHANGELOG.md
@@ -101,358 +101,407 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.50.4`
-* `react-sdk` updated to version `2.29.0`
-* `web-component` updated to version `3.68.0`
+- `web-js-sdk` updated to version `1.50.4`
+- `react-sdk` updated to version `2.29.0`
+- `web-component` updated to version `3.68.0`
+
 ## [0.15.42](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.41...nextjs-sdk-0.15.42) (2026-06-09)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.50.3`
-* `react-sdk` updated to version `2.28.11`
-* `core-js-sdk` updated to version `2.62.2`
-* `web-component` updated to version `3.67.1`
+- `web-js-sdk` updated to version `1.50.3`
+- `react-sdk` updated to version `2.28.11`
+- `core-js-sdk` updated to version `2.62.2`
+- `web-component` updated to version `3.67.1`
+
 ## [0.15.41](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.40...nextjs-sdk-0.15.41) (2026-06-09)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.28.10`
-* `web-component` updated to version `3.67.0`
+- `react-sdk` updated to version `2.28.10`
+- `web-component` updated to version `3.67.0`
+
 ## [0.15.40](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.39...nextjs-sdk-0.15.40) (2026-06-07)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.50.2`
-* `react-sdk` updated to version `2.28.9`
-* `core-js-sdk` updated to version `2.62.1`
-* `web-component` updated to version `3.66.1`
+- `web-js-sdk` updated to version `1.50.2`
+- `react-sdk` updated to version `2.28.9`
+- `core-js-sdk` updated to version `2.62.1`
+- `web-component` updated to version `3.66.1`
+
 ## [0.15.39](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.38...nextjs-sdk-0.15.39) (2026-06-04)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.28.8`
-* `web-component` updated to version `3.66.0`
+- `react-sdk` updated to version `2.28.8`
+- `web-component` updated to version `3.66.0`
+
 ## [0.15.39](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.38...nextjs-sdk-0.15.39) (2026-06-04)
 
 ## [0.15.38](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.37...nextjs-sdk-0.15.38) (2026-06-01)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.28.7`
+- `react-sdk` updated to version `2.28.7`
+
 ## [0.15.37](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.36...nextjs-sdk-0.15.37) (2026-05-28)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.28.6`
-* `web-component` updated to version `3.65.0`
+- `react-sdk` updated to version `2.28.6`
+- `web-component` updated to version `3.65.0`
+
 ## [0.15.36](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.35...nextjs-sdk-0.15.36) (2026-05-28)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.28.5`
-* `web-component` updated to version `3.64.3`
+- `react-sdk` updated to version `2.28.5`
+- `web-component` updated to version `3.64.3`
+
 ## [0.15.35](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.34...nextjs-sdk-0.15.35) (2026-05-26)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.50.1`
-* `react-sdk` updated to version `2.28.4`
-* `web-component` updated to version `3.64.2`
+- `web-js-sdk` updated to version `1.50.1`
+- `react-sdk` updated to version `2.28.4`
+- `web-component` updated to version `3.64.2`
+
 ## [0.15.34](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.33...nextjs-sdk-0.15.34) (2026-05-25)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.50.0`
-* `react-sdk` updated to version `2.28.3`
-* `web-component` updated to version `3.64.1`
+- `web-js-sdk` updated to version `1.50.0`
+- `react-sdk` updated to version `2.28.3`
+- `web-component` updated to version `3.64.1`
+
 ## [0.15.33](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.32...nextjs-sdk-0.15.33) (2026-05-25)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.28.2`
+- `react-sdk` updated to version `2.28.2`
+
 ## [0.15.32](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.31...nextjs-sdk-0.15.32) (2026-05-25)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.49.1`
-* `react-sdk` updated to version `2.28.1`
-* `core-js-sdk` updated to version `2.62.0`
-* `web-component` updated to version `3.64.0`
+- `web-js-sdk` updated to version `1.49.1`
+- `react-sdk` updated to version `2.28.1`
+- `core-js-sdk` updated to version `2.62.0`
+- `web-component` updated to version `3.64.0`
+
 ## [0.15.31](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.30...nextjs-sdk-0.15.31) (2026-05-24)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.49.0`
-* `react-sdk` updated to version `2.28.0`
-* `web-component` updated to version `3.63.0`
+- `web-js-sdk` updated to version `1.49.0`
+- `react-sdk` updated to version `2.28.0`
+- `web-component` updated to version `3.63.0`
+
 ## [0.15.30](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.29...nextjs-sdk-0.15.30) (2026-05-14)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.48.4`
-* `react-sdk` updated to version `2.27.12`
-* `web-component` updated to version `3.62.0`
+- `web-js-sdk` updated to version `1.48.4`
+- `react-sdk` updated to version `2.27.12`
+- `web-component` updated to version `3.62.0`
+
 ## [0.15.29](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.28...nextjs-sdk-0.15.29) (2026-05-11)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.48.3`
-* `react-sdk` updated to version `2.27.11`
-* `core-js-sdk` updated to version `2.61.0`
-* `web-component` updated to version `3.61.0`
+- `web-js-sdk` updated to version `1.48.3`
+- `react-sdk` updated to version `2.27.11`
+- `core-js-sdk` updated to version `2.61.0`
+- `web-component` updated to version `3.61.0`
+
 ## [0.15.28](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.27...nextjs-sdk-0.15.28) (2026-05-06)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.27.10`
+- `react-sdk` updated to version `2.27.10`
+
 ## [0.15.27](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.26...nextjs-sdk-0.15.27) (2026-04-29)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.48.2`
-* `react-sdk` updated to version `2.27.9`
-* `core-js-sdk` updated to version `2.60.0`
-* `web-component` updated to version `3.60.0`
+- `web-js-sdk` updated to version `1.48.2`
+- `react-sdk` updated to version `2.27.9`
+- `core-js-sdk` updated to version `2.60.0`
+- `web-component` updated to version `3.60.0`
+
 ## [0.15.26](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.25...nextjs-sdk-0.15.26) (2026-04-21)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.48.1`
-* `react-sdk` updated to version `2.27.8`
-* `core-js-sdk` updated to version `2.59.1`
-* `web-component` updated to version `3.59.2`
+- `web-js-sdk` updated to version `1.48.1`
+- `react-sdk` updated to version `2.27.8`
+- `core-js-sdk` updated to version `2.59.1`
+- `web-component` updated to version `3.59.2`
+
 ## [0.15.25](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.24...nextjs-sdk-0.15.25) (2026-04-20)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.27.7`
-* `web-component` updated to version `3.59.1`
+- `react-sdk` updated to version `2.27.7`
+- `web-component` updated to version `3.59.1`
+
 ## [0.15.24](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.23...nextjs-sdk-0.15.24) (2026-04-20)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.48.0`
-* `react-sdk` updated to version `2.27.6`
-* `core-js-sdk` updated to version `2.59.0`
-* `web-component` updated to version `3.59.0`
+- `web-js-sdk` updated to version `1.48.0`
+- `react-sdk` updated to version `2.27.6`
+- `core-js-sdk` updated to version `2.59.0`
+- `web-component` updated to version `3.59.0`
+
 ## [0.15.23](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.22...nextjs-sdk-0.15.23) (2026-04-20)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.47.2`
-* `react-sdk` updated to version `2.27.5`
-* `core-js-sdk` updated to version `2.58.2`
-* `web-component` updated to version `3.58.4`
+- `web-js-sdk` updated to version `1.47.2`
+- `react-sdk` updated to version `2.27.5`
+- `core-js-sdk` updated to version `2.58.2`
+- `web-component` updated to version `3.58.4`
+
 ## [0.15.22](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.21...nextjs-sdk-0.15.22) (2026-04-13)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.47.1`
-* `react-sdk` updated to version `2.27.4`
-* `core-js-sdk` updated to version `2.58.1`
-* `web-component` updated to version `3.58.3`
+- `web-js-sdk` updated to version `1.47.1`
+- `react-sdk` updated to version `2.27.4`
+- `core-js-sdk` updated to version `2.58.1`
+- `web-component` updated to version `3.58.3`
+
 ## [0.15.21](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.20...nextjs-sdk-0.15.21) (2026-04-12)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.27.3`
-* `web-component` updated to version `3.58.2`
+- `react-sdk` updated to version `2.27.3`
+- `web-component` updated to version `3.58.2`
+
 ## [0.15.20](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.19...nextjs-sdk-0.15.20) (2026-04-06)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.27.2`
-* `web-component` updated to version `3.58.1`
+- `react-sdk` updated to version `2.27.2`
+- `web-component` updated to version `3.58.1`
+
 ## [0.15.19](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.18...nextjs-sdk-0.15.19) (2026-03-31)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.27.1`
-* `web-component` updated to version `3.58.0`
+- `react-sdk` updated to version `2.27.1`
+- `web-component` updated to version `3.58.0`
+
 ## [0.15.18](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.17...nextjs-sdk-0.15.18) (2026-03-26)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.47.0`
-* `react-sdk` updated to version `2.27.0`
-* `web-component` updated to version `3.57.1`
+- `web-js-sdk` updated to version `1.47.0`
+- `react-sdk` updated to version `2.27.0`
+- `web-component` updated to version `3.57.1`
+
 ## [0.15.17](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.16...nextjs-sdk-0.15.17) (2026-03-23)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.46.0`
-* `react-sdk` updated to version `2.26.8`
-* `core-js-sdk` updated to version `2.58.0`
-* `web-component` updated to version `3.57.0`
+- `web-js-sdk` updated to version `1.46.0`
+- `react-sdk` updated to version `2.26.8`
+- `core-js-sdk` updated to version `2.58.0`
+- `web-component` updated to version `3.57.0`
+
 ## [0.15.16](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.15...nextjs-sdk-0.15.16) (2026-02-26)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.26.7`
-* `web-component` updated to version `3.56.0`
+- `react-sdk` updated to version `2.26.7`
+- `web-component` updated to version `3.56.0`
+
 ## [0.15.15](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.14...nextjs-sdk-0.15.15) (2026-02-26)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.26.6`
-* `web-component` updated to version `3.55.4`
+- `react-sdk` updated to version `2.26.6`
+- `web-component` updated to version `3.55.4`
+
 ## [0.15.14](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.13...nextjs-sdk-0.15.14) (2026-02-19)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.26.5`
+- `react-sdk` updated to version `2.26.5`
+
 ## [0.15.13](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.12...nextjs-sdk-0.15.13) (2026-02-17)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.26.4`
-* `web-component` updated to version `3.55.3`
+- `react-sdk` updated to version `2.26.4`
+- `web-component` updated to version `3.55.3`
+
 ## [0.15.12](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.11...nextjs-sdk-0.15.12) (2026-02-11)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.26.3`
-* `web-component` updated to version `3.55.2`
+- `react-sdk` updated to version `2.26.3`
+- `web-component` updated to version `3.55.2`
+
 ## [0.15.11](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.10...nextjs-sdk-0.15.11) (2026-02-01)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.26.2`
-* `web-component` updated to version `3.55.1`
+- `react-sdk` updated to version `2.26.2`
+- `web-component` updated to version `3.55.1`
+
 ## [0.15.10](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.9...nextjs-sdk-0.15.10) (2026-02-01)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.26.1`
+- `react-sdk` updated to version `2.26.1`
+
 ## [0.15.9](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.8...nextjs-sdk-0.15.9) (2026-01-29)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.45.0`
-* `react-sdk` updated to version `2.26.0`
-* `core-js-sdk` updated to version `2.57.0`
-* `web-component` updated to version `3.55.0`
+- `web-js-sdk` updated to version `1.45.0`
+- `react-sdk` updated to version `2.26.0`
+- `core-js-sdk` updated to version `2.57.0`
+- `web-component` updated to version `3.55.0`
+
 ## [0.15.8](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.7...nextjs-sdk-0.15.8) (2026-01-21)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.44.0`
-* `react-sdk` updated to version `2.25.8`
-* `core-js-sdk` updated to version `2.56.2`
-* `web-component` updated to version `3.54.0`
+- `web-js-sdk` updated to version `1.44.0`
+- `react-sdk` updated to version `2.25.8`
+- `core-js-sdk` updated to version `2.56.2`
+- `web-component` updated to version `3.54.0`
+
 ## [0.15.7](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.6...nextjs-sdk-0.15.7) (2026-01-04)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.43.1`
-* `react-sdk` updated to version `2.25.7`
-* `core-js-sdk` updated to version `2.56.1`
-* `web-component` updated to version `3.53.4`
+- `web-js-sdk` updated to version `1.43.1`
+- `react-sdk` updated to version `2.25.7`
+- `core-js-sdk` updated to version `2.56.1`
+- `web-component` updated to version `3.53.4`
+
 ## [0.15.6](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.5...nextjs-sdk-0.15.6) (2026-01-01)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.43.0`
-* `react-sdk` updated to version `2.25.6`
-* `core-js-sdk` updated to version `2.56.0`
-* `web-component` updated to version `3.53.3`
+- `web-js-sdk` updated to version `1.43.0`
+- `react-sdk` updated to version `2.25.6`
+- `core-js-sdk` updated to version `2.56.0`
+- `web-component` updated to version `3.53.3`
+
 ## [0.15.5](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.4...nextjs-sdk-0.15.5) (2025-12-30)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.25.5`
-* `web-component` updated to version `3.53.2`
+- `react-sdk` updated to version `2.25.5`
+- `web-component` updated to version `3.53.2`
+
 ## [0.15.4](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.3...nextjs-sdk-0.15.4) (2025-12-30)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.42.1`
-* `react-sdk` updated to version `2.25.4`
-* `core-js-sdk` updated to version `2.55.0`
-* `web-component` updated to version `3.53.1`
+- `web-js-sdk` updated to version `1.42.1`
+- `react-sdk` updated to version `2.25.4`
+- `core-js-sdk` updated to version `2.55.0`
+- `web-component` updated to version `3.53.1`
+
 ## [0.15.3](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.2...nextjs-sdk-0.15.3) (2025-12-25)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.25.3`
+- `react-sdk` updated to version `2.25.3`
+
 ## [0.15.2](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.1...nextjs-sdk-0.15.2) (2025-12-24)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.25.2`
-* `web-component` updated to version `3.53.0`
+- `react-sdk` updated to version `2.25.2`
+- `web-component` updated to version `3.53.0`
+
 ## [0.15.1](https://github.com/descope/descope-js/compare/nextjs-sdk-0.15.0...nextjs-sdk-0.15.1) (2025-12-24)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.42.0`
-* `react-sdk` updated to version `2.25.1`
-* `core-js-sdk` updated to version `2.54.0`
-* `web-component` updated to version `3.52.4`
+- `web-js-sdk` updated to version `1.42.0`
+- `react-sdk` updated to version `2.25.1`
+- `core-js-sdk` updated to version `2.54.0`
+- `web-component` updated to version `3.52.4`
+
 ## [0.15.0](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.50...nextjs-sdk-0.15.0) (2025-12-16)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.41.0`
-* `react-sdk` updated to version `2.25.0`
-* `web-component` updated to version `3.52.3`
+- `web-js-sdk` updated to version `1.41.0`
+- `react-sdk` updated to version `2.25.0`
+- `web-component` updated to version `3.52.3`
 
 ### Features
 
-* pass refresh to the middleware in next ([#1286](https://github.com/descope/descope-js/issues/1286)) RELEASE ([e0b89bc](https://github.com/descope/descope-js/commit/e0b89bc27407a5c25b5186f185893eb7779bc2b9))
+- pass refresh to the middleware in next ([#1286](https://github.com/descope/descope-js/issues/1286)) RELEASE ([e0b89bc](https://github.com/descope/descope-js/commit/e0b89bc27407a5c25b5186f185893eb7779bc2b9))
 
 ## [0.14.50](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.49...nextjs-sdk-0.14.50) (2025-12-04)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.40.2`
-* `react-sdk` updated to version `2.24.3`
-* `web-component` updated to version `3.52.2`
+- `web-js-sdk` updated to version `1.40.2`
+- `react-sdk` updated to version `2.24.3`
+- `web-component` updated to version `3.52.2`
+
 ## [0.14.49](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.48...nextjs-sdk-0.14.49) (2025-12-03)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.40.1`
-* `react-sdk` updated to version `2.24.2`
-* `core-js-sdk` updated to version `2.53.1`
-* `web-component` updated to version `3.52.1`
+- `web-js-sdk` updated to version `1.40.1`
+- `react-sdk` updated to version `2.24.2`
+- `core-js-sdk` updated to version `2.53.1`
+- `web-component` updated to version `3.52.1`
+
 ## [0.14.48](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.47...nextjs-sdk-0.14.48) (2025-12-02)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.24.1`
+- `react-sdk` updated to version `2.24.1`
+
 ## [0.14.47](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.46...nextjs-sdk-0.14.47) (2025-12-02)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.40.0`
-* `react-sdk` updated to version `2.24.0`
-* `web-component` updated to version `3.52.0`
+- `web-js-sdk` updated to version `1.40.0`
+- `react-sdk` updated to version `2.24.0`
+- `web-component` updated to version `3.52.0`
+
 ## [0.14.46](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.45...nextjs-sdk-0.14.46) (2025-12-01)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.39.1`
-* `react-sdk` updated to version `2.23.12`
-* `core-js-sdk` updated to version `2.53.0`
-* `web-component` updated to version `3.51.0`
+- `web-js-sdk` updated to version `1.39.1`
+- `react-sdk` updated to version `2.23.12`
+- `core-js-sdk` updated to version `2.53.0`
+- `web-component` updated to version `3.51.0`
+
 ## [0.14.45](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.44...nextjs-sdk-0.14.45) (2025-11-30)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.23.11`
-* `web-component` updated to version `3.50.0`
+- `react-sdk` updated to version `2.23.11`
+- `web-component` updated to version `3.50.0`
+
 ## [0.14.44](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.43...nextjs-sdk-0.14.44) (2025-11-24)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.23.10`
-## [0.14.43](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.42...nextjs-sdk-0.14.43) (2025-11-23)
+- `react-sdk` updated to version `2.23.10`
 
+## [0.14.43](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.42...nextjs-sdk-0.14.43) (2025-11-23)
 
 ### Bug Fixes
 
-* issue 12932 RELEASE ([#1271](https://github.com/descope/descope-js/issues/1271)) ([b2ed233](https://github.com/descope/descope-js/commit/b2ed23394afeb1774dde729e00c613fcee7bfc0f))
+- issue 12932 RELEASE ([#1271](https://github.com/descope/descope-js/issues/1271)) ([b2ed233](https://github.com/descope/descope-js/commit/b2ed23394afeb1774dde729e00c613fcee7bfc0f))
 
 ## [0.14.42](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.41...nextjs-sdk-0.14.42) (2025-11-20)
 
@@ -460,337 +509,381 @@ This file was generated using [@jscutlery/semver](https://github.com/jscutlery/s
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.39.0`
-* `react-sdk` updated to version `2.23.9`
-* `web-component` updated to version `3.49.3`
+- `web-js-sdk` updated to version `1.39.0`
+- `react-sdk` updated to version `2.23.9`
+- `web-component` updated to version `3.49.3`
+
 ## [0.14.40](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.39...nextjs-sdk-0.14.40) (2025-11-18)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.38.3`
-* `react-sdk` updated to version `2.23.8`
-* `web-component` updated to version `3.49.2`
+- `web-js-sdk` updated to version `1.38.3`
+- `react-sdk` updated to version `2.23.8`
+- `web-component` updated to version `3.49.2`
+
 ## [0.14.39](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.38...nextjs-sdk-0.14.39) (2025-11-16)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.23.7`
+- `react-sdk` updated to version `2.23.7`
+
 ## [0.14.38](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.37...nextjs-sdk-0.14.38) (2025-11-13)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.23.6`
-* `web-component` updated to version `3.49.1`
+- `react-sdk` updated to version `2.23.6`
+- `web-component` updated to version `3.49.1`
+
 ## [0.14.37](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.36...nextjs-sdk-0.14.37) (2025-11-11)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.23.5`
-* `web-component` updated to version `3.49.0`
+- `react-sdk` updated to version `2.23.5`
+- `web-component` updated to version `3.49.0`
+
 ## [0.14.36](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.35...nextjs-sdk-0.14.36) (2025-11-09)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.38.2`
-* `react-sdk` updated to version `2.23.4`
-* `core-js-sdk` updated to version `2.52.2`
-* `web-component` updated to version `3.48.3`
+- `web-js-sdk` updated to version `1.38.2`
+- `react-sdk` updated to version `2.23.4`
+- `core-js-sdk` updated to version `2.52.2`
+- `web-component` updated to version `3.48.3`
+
 ## [0.14.35](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.34...nextjs-sdk-0.14.35) (2025-11-06)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.23.3`
+- `react-sdk` updated to version `2.23.3`
+
 ## [0.14.34](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.33...nextjs-sdk-0.14.34) (2025-11-06)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.38.1`
-* `react-sdk` updated to version `2.23.2`
-* `core-js-sdk` updated to version `2.52.1`
-* `web-component` updated to version `3.48.2`
+- `web-js-sdk` updated to version `1.38.1`
+- `react-sdk` updated to version `2.23.2`
+- `core-js-sdk` updated to version `2.52.1`
+- `web-component` updated to version `3.48.2`
+
 ## [0.14.33](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.32...nextjs-sdk-0.14.33) (2025-11-05)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.23.1`
-* `web-component` updated to version `3.48.1`
+- `react-sdk` updated to version `2.23.1`
+- `web-component` updated to version `3.48.1`
+
 ## [0.14.32](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.31...nextjs-sdk-0.14.32) (2025-11-03)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.23.0`
+- `react-sdk` updated to version `2.23.0`
+
 ## [0.14.31](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.30...nextjs-sdk-0.14.31) (2025-10-23)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.38.0`
-* `react-sdk` updated to version `2.22.0`
-* `core-js-sdk` updated to version `2.52.0`
-* `web-component` updated to version `3.48.0`
+- `web-js-sdk` updated to version `1.38.0`
+- `react-sdk` updated to version `2.22.0`
+- `core-js-sdk` updated to version `2.52.0`
+- `web-component` updated to version `3.48.0`
+
 ## [0.14.30](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.29...nextjs-sdk-0.14.30) (2025-10-22)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.37.2`
-* `react-sdk` updated to version `2.21.4`
-* `core-js-sdk` updated to version `2.51.0`
-* `web-component` updated to version `3.47.12`
+- `web-js-sdk` updated to version `1.37.2`
+- `react-sdk` updated to version `2.21.4`
+- `core-js-sdk` updated to version `2.51.0`
+- `web-component` updated to version `3.47.12`
+
 ## [0.14.29](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.28...nextjs-sdk-0.14.29) (2025-10-21)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.21.3`
-* `web-component` updated to version `3.47.11`
+- `react-sdk` updated to version `2.21.3`
+- `web-component` updated to version `3.47.11`
 
 ### Bug Fixes
 
-* issue 12311 - nextjs type definitions ([#1230](https://github.com/descope/descope-js/issues/1230)) ([3cde977](https://github.com/descope/descope-js/commit/3cde97751d52b43e6f65c5d21204d815aa2aa75f))
+- issue 12311 - nextjs type definitions ([#1230](https://github.com/descope/descope-js/issues/1230)) ([3cde977](https://github.com/descope/descope-js/commit/3cde97751d52b43e6f65c5d21204d815aa2aa75f))
 
 ## [0.14.28](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.27...nextjs-sdk-0.14.28) (2025-10-16)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.37.1`
-* `react-sdk` updated to version `2.21.2`
-* `web-component` updated to version `3.47.10`
+- `web-js-sdk` updated to version `1.37.1`
+- `react-sdk` updated to version `2.21.2`
+- `web-component` updated to version `3.47.10`
+
 ## [0.14.27](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.26...nextjs-sdk-0.14.27) (2025-10-13)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.21.1`
+- `react-sdk` updated to version `2.21.1`
+
 ## [0.14.26](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.25...nextjs-sdk-0.14.26) (2025-10-09)
 
 ## [0.14.25](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.24...nextjs-sdk-0.14.25) (2025-09-29)
 
-
 ### Bug Fixes
 
-* add custom cookie name for next functions ([#1228](https://github.com/descope/descope-js/issues/1228)) RELEASE ([160f9e9](https://github.com/descope/descope-js/commit/160f9e91e30fc68f698bb22cfa2e8684cb402801))
+- add custom cookie name for next functions ([#1228](https://github.com/descope/descope-js/issues/1228)) RELEASE ([160f9e9](https://github.com/descope/descope-js/commit/160f9e91e30fc68f698bb22cfa2e8684cb402801))
 
 ## [0.14.24](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.23...nextjs-sdk-0.14.24) (2025-09-29)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.37.0`
-* `react-sdk` updated to version `2.21.0`
-* `web-component` updated to version `3.47.9`
+- `web-js-sdk` updated to version `1.37.0`
+- `react-sdk` updated to version `2.21.0`
+- `web-component` updated to version `3.47.9`
+
 ## [0.14.23](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.22...nextjs-sdk-0.14.23) (2025-09-28)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.36.2`
-* `react-sdk` updated to version `2.20.5`
-* `core-js-sdk` updated to version `2.50.1`
-* `web-component` updated to version `3.47.8`
+- `web-js-sdk` updated to version `1.36.2`
+- `react-sdk` updated to version `2.20.5`
+- `core-js-sdk` updated to version `2.50.1`
+- `web-component` updated to version `3.47.8`
+
 ## [0.14.22](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.21...nextjs-sdk-0.14.22) (2025-09-14)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.36.1`
-* `react-sdk` updated to version `2.20.4`
-* `web-component` updated to version `3.47.7`
+- `web-js-sdk` updated to version `1.36.1`
+- `react-sdk` updated to version `2.20.4`
+- `web-component` updated to version `3.47.7`
+
 ## [0.14.21](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.20...nextjs-sdk-0.14.21) (2025-09-13)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.20.3`
-* `web-component` updated to version `3.47.6`
+- `react-sdk` updated to version `2.20.3`
+- `web-component` updated to version `3.47.6`
+
 ## [0.14.20](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.19...nextjs-sdk-0.14.20) (2025-09-10)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.20.2`
-* `web-component` updated to version `3.47.5`
+- `react-sdk` updated to version `2.20.2`
+- `web-component` updated to version `3.47.5`
+
 ## [0.14.19](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.18...nextjs-sdk-0.14.19) (2025-09-10)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.20.1`
-* `web-component` updated to version `3.47.4`
+- `react-sdk` updated to version `2.20.1`
+- `web-component` updated to version `3.47.4`
+
 ## [0.14.18](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.17...nextjs-sdk-0.14.18) (2025-09-10)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.36.0`
-* `react-sdk` updated to version `2.20.0`
-* `core-js-sdk` updated to version `2.50.0`
-* `web-component` updated to version `3.47.3`
+- `web-js-sdk` updated to version `1.36.0`
+- `react-sdk` updated to version `2.20.0`
+- `core-js-sdk` updated to version `2.50.0`
+- `web-component` updated to version `3.47.3`
+
 ## [0.14.17](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.16...nextjs-sdk-0.14.17) (2025-09-09)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.19.3`
-* `web-component` updated to version `3.47.2`
+- `react-sdk` updated to version `2.19.3`
+- `web-component` updated to version `3.47.2`
+
 ## [0.14.16](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.15...nextjs-sdk-0.14.16) (2025-09-07)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.19.2`
-* `web-component` updated to version `3.47.1`
+- `react-sdk` updated to version `2.19.2`
+- `web-component` updated to version `3.47.1`
+
 ## [0.14.15](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.14...nextjs-sdk-0.14.15) (2025-08-28)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.35.1`
-* `react-sdk` updated to version `2.19.1`
-* `core-js-sdk` updated to version `2.49.0`
-* `web-component` updated to version `3.47.0`
+- `web-js-sdk` updated to version `1.35.1`
+- `react-sdk` updated to version `2.19.1`
+- `core-js-sdk` updated to version `2.49.0`
+- `web-component` updated to version `3.47.0`
+
 ## [0.14.14](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.13...nextjs-sdk-0.14.14) (2025-08-26)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.35.0`
-* `react-sdk` updated to version `2.19.0`
-* `core-js-sdk` updated to version `2.48.0`
-* `web-component` updated to version `3.46.4`
+- `web-js-sdk` updated to version `1.35.0`
+- `react-sdk` updated to version `2.19.0`
+- `core-js-sdk` updated to version `2.48.0`
+- `web-component` updated to version `3.46.4`
+
 ## [0.14.13](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.12...nextjs-sdk-0.14.13) (2025-08-25)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.34.3`
-* `react-sdk` updated to version `2.18.3`
-* `core-js-sdk` updated to version `2.47.0`
-* `web-component` updated to version `3.46.3`
+- `web-js-sdk` updated to version `1.34.3`
+- `react-sdk` updated to version `2.18.3`
+- `core-js-sdk` updated to version `2.47.0`
+- `web-component` updated to version `3.46.3`
+
 ## [0.14.12](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.11...nextjs-sdk-0.14.12) (2025-08-19)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.34.2`
-* `react-sdk` updated to version `2.18.2`
-* `core-js-sdk` updated to version `2.46.2`
-* `web-component` updated to version `3.46.2`
+- `web-js-sdk` updated to version `1.34.2`
+- `react-sdk` updated to version `2.18.2`
+- `core-js-sdk` updated to version `2.46.2`
+- `web-component` updated to version `3.46.2`
+
 ## [0.14.11](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.10...nextjs-sdk-0.14.11) (2025-08-17)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.34.1`
-* `react-sdk` updated to version `2.18.1`
-* `core-js-sdk` updated to version `2.46.1`
-* `web-component` updated to version `3.46.1`
+- `web-js-sdk` updated to version `1.34.1`
+- `react-sdk` updated to version `2.18.1`
+- `core-js-sdk` updated to version `2.46.1`
+- `web-component` updated to version `3.46.1`
+
 ## [0.14.10](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.9...nextjs-sdk-0.14.10) (2025-08-14)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.34.0`
-* `react-sdk` updated to version `2.18.0`
-* `core-js-sdk` updated to version `2.46.0`
-* `web-component` updated to version `3.46.0`
+- `web-js-sdk` updated to version `1.34.0`
+- `react-sdk` updated to version `2.18.0`
+- `core-js-sdk` updated to version `2.46.0`
+- `web-component` updated to version `3.46.0`
+
 ## [0.14.9](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.8...nextjs-sdk-0.14.9) (2025-08-10)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.17.1`
-* `web-component` updated to version `3.45.1`
+- `react-sdk` updated to version `2.17.1`
+- `web-component` updated to version `3.45.1`
+
 ## [0.14.8](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.7...nextjs-sdk-0.14.8) (2025-08-07)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.33.7`
-* `react-sdk` updated to version `2.17.0`
-* `core-js-sdk` updated to version `2.45.0`
-* `web-component` updated to version `3.45.0`
+- `web-js-sdk` updated to version `1.33.7`
+- `react-sdk` updated to version `2.17.0`
+- `core-js-sdk` updated to version `2.45.0`
+- `web-component` updated to version `3.45.0`
+
 ## [0.14.7](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.6...nextjs-sdk-0.14.7) (2025-08-05)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.33.6`
-* `react-sdk` updated to version `2.16.5`
-* `core-js-sdk` updated to version `2.44.5`
-* `web-component` updated to version `3.44.4`
+- `web-js-sdk` updated to version `1.33.6`
+- `react-sdk` updated to version `2.16.5`
+- `core-js-sdk` updated to version `2.44.5`
+- `web-component` updated to version `3.44.4`
+
 ## [0.14.6](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.5...nextjs-sdk-0.14.6) (2025-07-31)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.16.4`
-* `web-component` updated to version `3.44.3`
+- `react-sdk` updated to version `2.16.4`
+- `web-component` updated to version `3.44.3`
+
 ## [0.14.5](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.4...nextjs-sdk-0.14.5) (2025-07-31)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.16.3`
-* `web-component` updated to version `3.44.2`
+- `react-sdk` updated to version `2.16.3`
+- `web-component` updated to version `3.44.2`
+
 ## [0.14.4](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.3...nextjs-sdk-0.14.4) (2025-07-29)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.16.2`
+- `react-sdk` updated to version `2.16.2`
+
 ## [0.14.3](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.2...nextjs-sdk-0.14.3) (2025-07-27)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.16.1`
-* `web-component` updated to version `3.44.1`
+- `react-sdk` updated to version `2.16.1`
+- `web-component` updated to version `3.44.1`
+
 ## [0.14.2](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.1...nextjs-sdk-0.14.2) (2025-07-22)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.16.0`
-* `web-component` updated to version `3.44.0`
+- `react-sdk` updated to version `2.16.0`
+- `web-component` updated to version `3.44.0`
+
 ## [0.14.1](https://github.com/descope/descope-js/compare/nextjs-sdk-0.14.0...nextjs-sdk-0.14.1) (2025-07-21)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.15.0`
-* `web-component` updated to version `3.43.20`
+- `react-sdk` updated to version `2.15.0`
+- `web-component` updated to version `3.43.20`
+
 ## [0.14.0](https://github.com/descope/descope-js/compare/nextjs-sdk-0.13.20...nextjs-sdk-0.14.0) (2025-07-10)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.33.5`
-* `react-sdk` updated to version `2.14.26`
-* `core-js-sdk` updated to version `2.44.4`
-* `web-component` updated to version `3.43.19`
+- `web-js-sdk` updated to version `1.33.5`
+- `react-sdk` updated to version `2.14.26`
+- `core-js-sdk` updated to version `2.44.4`
+- `web-component` updated to version `3.43.19`
 
 ### Features
 
-* Support multiple global sdks in next sdk ([#1154](https://github.com/descope/descope-js/issues/1154)) RELEASE ([b91186d](https://github.com/descope/descope-js/commit/b91186de2d4122018dfb892bb8b31c5aa4a9ffc8))
+- Support multiple global sdks in next sdk ([#1154](https://github.com/descope/descope-js/issues/1154)) RELEASE ([b91186d](https://github.com/descope/descope-js/commit/b91186de2d4122018dfb892bb8b31c5aa4a9ffc8))
 
 ## [0.13.20](https://github.com/descope/descope-js/compare/nextjs-sdk-0.13.19...nextjs-sdk-0.13.20) (2025-07-02)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.14.25`
-* `web-component` updated to version `3.43.18`
+- `react-sdk` updated to version `2.14.25`
+- `web-component` updated to version `3.43.18`
+
 ## [0.13.19](https://github.com/descope/descope-js/compare/nextjs-sdk-0.13.18...nextjs-sdk-0.13.19) (2025-06-24)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.14.24`
+- `react-sdk` updated to version `2.14.24`
+
 ## [0.13.18](https://github.com/descope/descope-js/compare/nextjs-sdk-0.13.17...nextjs-sdk-0.13.18) (2025-06-13)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.14.23`
-* `web-component` updated to version `3.43.17`
+- `react-sdk` updated to version `2.14.23`
+- `web-component` updated to version `3.43.17`
+
 ## [0.13.17](https://github.com/descope/descope-js/compare/nextjs-sdk-0.13.16...nextjs-sdk-0.13.17) (2025-06-11)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.33.4`
-* `react-sdk` updated to version `2.14.22`
-* `core-js-sdk` updated to version `2.44.3`
-* `web-component` updated to version `3.43.16`
+- `web-js-sdk` updated to version `1.33.4`
+- `react-sdk` updated to version `2.14.22`
+- `core-js-sdk` updated to version `2.44.3`
+- `web-component` updated to version `3.43.16`
+
 ## [0.13.16](https://github.com/descope/descope-js/compare/nextjs-sdk-0.13.15...nextjs-sdk-0.13.16) (2025-06-11)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.33.3`
-* `react-sdk` updated to version `2.14.21`
-* `core-js-sdk` updated to version `2.44.2`
-* `web-component` updated to version `3.43.15`
+- `web-js-sdk` updated to version `1.33.3`
+- `react-sdk` updated to version `2.14.21`
+- `core-js-sdk` updated to version `2.44.2`
+- `web-component` updated to version `3.43.15`
+
 ## [0.13.15](https://github.com/descope/descope-js/compare/nextjs-sdk-0.13.14...nextjs-sdk-0.13.15) (2025-05-22)
 
 ### Dependency Updates
 
-* `web-js-sdk` updated to version `1.33.2`
-* `react-sdk` updated to version `2.14.20`
-* `web-component` updated to version `3.43.14`
+- `web-js-sdk` updated to version `1.33.2`
+- `react-sdk` updated to version `2.14.20`
+- `web-component` updated to version `3.43.14`
+
 ## [0.13.14](https://github.com/descope/descope-js/compare/nextjs-sdk-0.13.13...nextjs-sdk-0.13.14) (2025-05-20)
 
 ### Dependency Updates
 
-* `react-sdk` updated to version `2.14.19`
-* `web-component` updated to version `3.43.13`
+- `react-sdk` updated to version `2.14.19`
+- `web-component` updated to version `3.43.13`
+
 ## [0.13.13](https://github.com/descope/descope-js/compare/nextjs-sdk-0.13.12...nextjs-sdk-0.13.13) (2025-05-18)
 
 ### Dependency Updates

--- a/packages/sdks/nextjs-sdk/README.md
+++ b/packages/sdks/nextjs-sdk/README.md
@@ -332,6 +332,8 @@ session({
 
 This allows developers to use `session()` even if the project ID is not set in the environment.
 
+Both `authMiddleware` and `session()` also accept a `resource` option (RFC 8707) to validate the token's audience against a resource-scoped access token. If you request a resource-scoped token client-side via `oidcConfig.resource` (see the [react-sdk](../react-sdk/README.md#requesting-a-resource-scoped-token-resource) / [web-js-sdk](../web-js-sdk/README.md#requesting-a-resource-scoped-token-resource) docs), the `resource` value passed here must match it, so the server validates against the same audience the client requested at sign-in.
+
 #### Access Descope SDK in server side
 
 Use `createSdk` function to create Descope SDK in server side.

--- a/packages/sdks/nextjs-sdk/README.md
+++ b/packages/sdks/nextjs-sdk/README.md
@@ -136,9 +136,12 @@ By default, the SDK fires a periodic heartbeat (refresh call) whenever the tab i
 ```tsx
 import { AuthProvider } from '@descope/nextjs-sdk';
 
-<AuthProvider projectId="my-project-id" autoRefresh={{ customActivityTracking: true }}>
-  <App />
-</AuthProvider>
+<AuthProvider
+	projectId="my-project-id"
+	autoRefresh={{ customActivityTracking: true }}
+>
+	<App />
+</AuthProvider>;
 ```
 
 **Step 2:** Call `markUserActive()` on user interactions using the `useDescope` hook from `@descope/nextjs-sdk/client`:
@@ -149,27 +152,27 @@ import { useEffect } from 'react';
 import { useDescope } from '@descope/nextjs-sdk/client';
 
 function useActivityTracking() {
-  const sdk = useDescope();
+	const sdk = useDescope();
 
-  useEffect(() => {
-    const { markUserActive } = sdk;
+	useEffect(() => {
+		const { markUserActive } = sdk;
 
-    document.addEventListener('click', markUserActive);
-    document.addEventListener('keydown', markUserActive);
-    document.addEventListener('touchstart', markUserActive);
+		document.addEventListener('click', markUserActive);
+		document.addEventListener('keydown', markUserActive);
+		document.addEventListener('touchstart', markUserActive);
 
-    const onVisibility = () => {
-      if (document.visibilityState === 'visible') markUserActive();
-    };
-    document.addEventListener('visibilitychange', onVisibility);
+		const onVisibility = () => {
+			if (document.visibilityState === 'visible') markUserActive();
+		};
+		document.addEventListener('visibilitychange', onVisibility);
 
-    return () => {
-      document.removeEventListener('click', markUserActive);
-      document.removeEventListener('keydown', markUserActive);
-      document.removeEventListener('touchstart', markUserActive);
-      document.removeEventListener('visibilitychange', onVisibility);
-    };
-  }, [sdk]);
+		return () => {
+			document.removeEventListener('click', markUserActive);
+			document.removeEventListener('keydown', markUserActive);
+			document.removeEventListener('touchstart', markUserActive);
+			document.removeEventListener('visibilitychange', onVisibility);
+		};
+	}, [sdk]);
 }
 ```
 
@@ -184,7 +187,7 @@ import { useEffect } from 'react';
 
 const { refresh } = useDescope();
 useEffect(() => {
-  refresh().catch(console.error);
+	refresh().catch(console.error);
 }, [refresh]);
 ```
 

--- a/packages/sdks/nextjs-sdk/examples/app-router/README.md
+++ b/packages/sdks/nextjs-sdk/examples/app-router/README.md
@@ -25,6 +25,7 @@ DESCOPE_MANAGEMENT_KEY=<Your Descope Management Key> # Default is sign-up-or-in
 # This is an example of a custom route for the sign-in page
 # the /login route is the one that this example uses
 SIGN_IN_ROUTE="/login"
+DESCOPE_RESOURCE=<Optional: Resource identifier (RFC 8707) to validate the JWT audience against - must match a Resource associated with your Inbound App>
 ```
 
 ## Run the example

--- a/packages/sdks/nextjs-sdk/examples/app-router/middleware.ts
+++ b/packages/sdks/nextjs-sdk/examples/app-router/middleware.ts
@@ -4,7 +4,7 @@ export default authMiddleware({
 	projectId: process.env.NEXT_PUBLIC_DESCOPE_PROJECT_ID,
 	baseUrl: process.env.NEXT_PUBLIC_DESCOPE_BASE_URL,
 	logLevel: process.env.DESCOPE_LOG_LEVEL as any,
-	resource: 'https://mcp.myapp.com/abc'
+	resource: process.env.DESCOPE_RESOURCE as any
 });
 
 export const config = {

--- a/packages/sdks/nextjs-sdk/examples/app-router/middleware.ts
+++ b/packages/sdks/nextjs-sdk/examples/app-router/middleware.ts
@@ -3,7 +3,8 @@ import { authMiddleware } from '@descope/nextjs-sdk/server';
 export default authMiddleware({
 	projectId: process.env.NEXT_PUBLIC_DESCOPE_PROJECT_ID,
 	baseUrl: process.env.NEXT_PUBLIC_DESCOPE_BASE_URL,
-	logLevel: process.env.DESCOPE_LOG_LEVEL as any
+	logLevel: process.env.DESCOPE_LOG_LEVEL as any,
+	resource: 'https://mcp.myapp.com/abc'
 });
 
 export const config = {

--- a/packages/sdks/nextjs-sdk/src/server/authMiddleware.ts
+++ b/packages/sdks/nextjs-sdk/src/server/authMiddleware.ts
@@ -43,6 +43,12 @@ type MiddlewareOptions = {
 	// Defaults to 'DSR'
 	// Used to refresh the session when the JWT expires
 	refreshTokenCookieName?: string;
+
+	// The Resource identifier (OAuth Resource Server) to validate the JWT audience against.
+	// Required when using Inbound Apps scoped to a specific Resource.
+	// Should match the resource identifier configured in the Descope console.
+	// Accepts a single resource identifier or an array for multi-audience scenarios.
+	resource?: string | string[];
 };
 
 const getSessionJwt = (
@@ -67,9 +73,8 @@ const getRefreshJwt = (
 	req: NextRequest,
 	options: MiddlewareOptions
 ): string | undefined => {
-	const refreshJwt = req.cookies?.get(
-		options?.refreshTokenCookieName || 'DSR'
-	)?.value;
+	const refreshJwt = req.cookies?.get(options?.refreshTokenCookieName || 'DSR')
+		?.value;
 	return refreshJwt;
 };
 
@@ -137,7 +142,7 @@ const createAuthMiddleware =
 			await getGlobalSdk({
 				projectId: options.projectId,
 				baseUrl: options.baseUrl
-			}).validateJwt(sessionJwt);
+			}).validateJwt(sessionJwt, { audience: options.resource });
 			validToken = true;
 			logger.debug('[Auth middleware] Session JWT is valid');
 		} catch (err) {

--- a/packages/sdks/nextjs-sdk/src/server/authMiddleware.ts
+++ b/packages/sdks/nextjs-sdk/src/server/authMiddleware.ts
@@ -148,24 +148,33 @@ const createAuthMiddleware =
 		} catch (err) {
 			logger.debug('[Auth middleware] Failed to validate session JWT', err);
 
-			// Try to validate the refresh token instead
-			const refreshJwt = getRefreshJwt(req, options);
-			if (refreshJwt) {
-				logger.debug('[Auth middleware] Attempting to validate refresh token');
-				try {
-					await getGlobalSdk({
-						projectId: options.projectId,
-						baseUrl: options.baseUrl
-					}).validateJwt(refreshJwt);
+			const isAudienceMismatch =
+				options.resource &&
+				(err as any)?.code === 'ERR_JWT_CLAIM_VALIDATION_FAILED' &&
+				(err as any)?.claim === 'aud';
 
-					logger.debug('[Auth middleware] Refresh token is valid');
-					validToken = true;
-				} catch (refreshErr) {
+			if (!isAudienceMismatch) {
+				// Try to validate the refresh token instead
+				const refreshJwt = getRefreshJwt(req, options);
+				if (refreshJwt) {
 					logger.debug(
-						'[Auth middleware] Refresh token validation failed',
-						refreshErr
+						'[Auth middleware] Attempting to validate refresh token'
 					);
-					// Refresh token validation failed, continue to redirect logic below
+					try {
+						await getGlobalSdk({
+							projectId: options.projectId,
+							baseUrl: options.baseUrl
+						}).validateJwt(refreshJwt);
+
+						logger.debug('[Auth middleware] Refresh token is valid');
+						validToken = true;
+					} catch (refreshErr) {
+						logger.debug(
+							'[Auth middleware] Refresh token validation failed',
+							refreshErr
+						);
+						// Refresh token validation failed, continue to redirect logic below
+					}
 				}
 			}
 

--- a/packages/sdks/nextjs-sdk/src/server/session.ts
+++ b/packages/sdks/nextjs-sdk/src/server/session.ts
@@ -18,6 +18,12 @@ type SessionConfig = CreateSdkParams & {
 	// The name of the refresh token cookie
 	// Defaults to 'DSR'
 	refreshTokenCookieName?: string;
+
+	// The Resource identifier (OAuth Resource Server) to validate the JWT audience against.
+	// Required when using Inbound Apps scoped to a specific Resource.
+	// Should match the resource identifier configured in the Descope console.
+	// Accepts a single resource identifier or an array for multi-audience scenarios.
+	resource?: string | string[];
 };
 
 const getSessionCookieName = (config?: SessionConfig) =>
@@ -34,7 +40,7 @@ const getSessionFromAuthorizationOrCookie = async (
 	if (sessionJwt) {
 		try {
 			const sdk = getGlobalSdk(config);
-			return await sdk.validateJwt(sessionJwt);
+			return await sdk.validateJwt(sessionJwt, { audience: config?.resource });
 		} catch (err) {
 			logger.debug('Error validating session from Authorization header', err);
 		}
@@ -47,7 +53,7 @@ const getSessionFromAuthorizationOrCookie = async (
 	}
 	try {
 		const sdk = getGlobalSdk(config);
-		return await sdk.validateJwt(cookieJwt);
+		return await sdk.validateJwt(cookieJwt, { audience: config?.resource });
 	} catch (err) {
 		logger.debug('Error getting session from cookie', err);
 		return undefined;

--- a/packages/sdks/nextjs-sdk/test/server/authMiddleware.test.ts
+++ b/packages/sdks/nextjs-sdk/test/server/authMiddleware.test.ts
@@ -341,6 +341,30 @@ describe('authMiddleware', () => {
 			expect(mockValidateJwt).toHaveBeenNthCalledWith(2, 'validRefreshJwt');
 		});
 
+		it('redirects and skips refresh fallback when session JWT fails with audience mismatch', async () => {
+			const audienceMismatchErr = Object.assign(
+				new Error('JWT audience mismatch'),
+				{ code: 'ERR_JWT_CLAIM_VALIDATION_FAILED', claim: 'aud' }
+			);
+			mockValidateJwt.mockRejectedValueOnce(audienceMismatchErr);
+
+			const middleware = authMiddleware({ resource: 'https://mcp.myapp.com' });
+			const mockReq = createMockNextRequest({
+				pathname: '/private',
+				cookies: { DS: 'wrongAudienceJwt', DSR: 'validRefreshJwt' }
+			});
+
+			const response = await middleware(mockReq);
+
+			// Only the session JWT validation is attempted; refresh token is NOT tried
+			expect(mockValidateJwt).toHaveBeenCalledTimes(1);
+			expect(mockValidateJwt).toHaveBeenCalledWith('wrongAudienceJwt', {
+				audience: 'https://mcp.myapp.com'
+			});
+			expect(NextResponse.redirect).toHaveBeenCalledWith(expect.anything());
+			expect(response).toEqual({ pathname: DEFAULT_PUBLIC_ROUTES.signIn });
+		});
+
 		it('calls validateJwt without audience when resource is not provided', async () => {
 			const authInfo = {
 				jwt: 'sessionJwt',

--- a/packages/sdks/nextjs-sdk/test/server/authMiddleware.test.ts
+++ b/packages/sdks/nextjs-sdk/test/server/authMiddleware.test.ts
@@ -297,6 +297,71 @@ describe('authMiddleware', () => {
 		expect(headersArg.get('x-descope-session')).toBeNull();
 	});
 
+	describe('resource / audience forwarding', () => {
+		it('passes resource as audience to validateJwt when provided', async () => {
+			const authInfo = {
+				jwt: 'sessionJwt',
+				token: { iss: 'project-1', sub: 'user-123' }
+			};
+			mockValidateJwt.mockResolvedValue(authInfo);
+
+			const middleware = authMiddleware({ resource: 'https://mcp.myapp.com' });
+			const mockReq = createMockNextRequest({
+				pathname: '/private',
+				cookies: { DS: 'sessionJwt' }
+			});
+
+			await middleware(mockReq);
+
+			expect(mockValidateJwt).toHaveBeenCalledWith('sessionJwt', {
+				audience: 'https://mcp.myapp.com'
+			});
+		});
+
+		it('does NOT pass resource audience when validating refresh token', async () => {
+			mockValidateJwt
+				.mockRejectedValueOnce(new Error('Session JWT expired'))
+				.mockResolvedValueOnce({
+					jwt: 'validRefreshJwt',
+					token: { iss: 'project-1', sub: 'user-123' }
+				});
+
+			const middleware = authMiddleware({ resource: 'https://mcp.myapp.com' });
+			const mockReq = createMockNextRequest({
+				pathname: '/private',
+				cookies: { DS: 'expiredSessionJwt', DSR: 'validRefreshJwt' }
+			});
+
+			await middleware(mockReq);
+
+			// Session JWT gets the audience check; refresh token does not
+			expect(mockValidateJwt).toHaveBeenNthCalledWith(1, 'expiredSessionJwt', {
+				audience: 'https://mcp.myapp.com'
+			});
+			expect(mockValidateJwt).toHaveBeenNthCalledWith(2, 'validRefreshJwt');
+		});
+
+		it('calls validateJwt without audience when resource is not provided', async () => {
+			const authInfo = {
+				jwt: 'sessionJwt',
+				token: { iss: 'project-1', sub: 'user-123' }
+			};
+			mockValidateJwt.mockResolvedValue(authInfo);
+
+			const middleware = authMiddleware();
+			const mockReq = createMockNextRequest({
+				pathname: '/private',
+				cookies: { DS: 'sessionJwt' }
+			});
+
+			await middleware(mockReq);
+
+			expect(mockValidateJwt).toHaveBeenCalledWith('sessionJwt', {
+				audience: undefined
+			});
+		});
+	});
+
 	describe('Refresh token validation', () => {
 		it('validates refresh token when session JWT fails', async () => {
 			// First call fails (session JWT), second call succeeds (refresh token)
@@ -318,7 +383,9 @@ describe('authMiddleware', () => {
 
 			// Expect validateJwt to be called twice
 			expect(mockValidateJwt).toHaveBeenCalledTimes(2);
-			expect(mockValidateJwt).toHaveBeenNthCalledWith(1, 'expiredSessionJwt');
+			expect(mockValidateJwt).toHaveBeenNthCalledWith(1, 'expiredSessionJwt', {
+				audience: undefined
+			});
 			expect(mockValidateJwt).toHaveBeenNthCalledWith(2, 'validRefreshJwt');
 
 			// Expect no redirect since refresh token is valid

--- a/packages/sdks/nextjs-sdk/test/server/session.test.ts
+++ b/packages/sdks/nextjs-sdk/test/server/session.test.ts
@@ -87,7 +87,9 @@ describe('session utilities', () => {
 			);
 			(cookies as jest.Mock).mockImplementation(() => new Map());
 			const result = await session({ projectId: 'test' });
-			expect(mockValidateJwt).toHaveBeenCalledWith('authorizationJwt');
+			expect(mockValidateJwt).toHaveBeenCalledWith('authorizationJwt', {
+				audience: undefined
+			});
 			expect(result).toEqual(authInfo);
 		});
 
@@ -130,9 +132,12 @@ describe('session utilities', () => {
 
 			expect(mockValidateJwt).toHaveBeenNthCalledWith(
 				1,
-				'invalidAuthorizationJwt'
+				'invalidAuthorizationJwt',
+				{ audience: undefined }
 			);
-			expect(mockValidateJwt).toHaveBeenNthCalledWith(2, 'cookieJwt');
+			expect(mockValidateJwt).toHaveBeenNthCalledWith(2, 'cookieJwt', {
+				audience: undefined
+			});
 			expect(result).toEqual(authInfo);
 		});
 
@@ -141,6 +146,42 @@ describe('session utilities', () => {
 			(cookies as jest.Mock).mockImplementation(() => new Map());
 			const result = await session();
 			expect(result).toBeUndefined();
+		});
+
+		it('passes resource as audience to validateJwt when provided in config', async () => {
+			const authInfo = {
+				jwt: 'validJwt',
+				token: { iss: 'project-1', sub: 'user-123' }
+			};
+			mockValidateJwt.mockResolvedValue(authInfo);
+			(cookies as jest.Mock).mockImplementation(
+				() => new Map([['DS', { value: 'validJwt' }]])
+			);
+			(headers as jest.Mock).mockImplementation(() => new Map());
+
+			await session({ projectId: 'test', resource: 'https://mcp.myapp.com' });
+
+			expect(mockValidateJwt).toHaveBeenCalledWith('validJwt', {
+				audience: 'https://mcp.myapp.com'
+			});
+		});
+
+		it('calls validateJwt without audience when resource is not provided', async () => {
+			const authInfo = {
+				jwt: 'validJwt',
+				token: { iss: 'project-1', sub: 'user-123' }
+			};
+			mockValidateJwt.mockResolvedValue(authInfo);
+			(cookies as jest.Mock).mockImplementation(
+				() => new Map([['DS', { value: 'validJwt' }]])
+			);
+			(headers as jest.Mock).mockImplementation(() => new Map());
+
+			await session({ projectId: 'test' });
+
+			expect(mockValidateJwt).toHaveBeenCalledWith('validJwt', {
+				audience: undefined
+			});
 		});
 	});
 
@@ -158,7 +199,9 @@ describe('session utilities', () => {
 				projectId: 'test',
 				baseUrl: 'http://example.com'
 			});
-			expect(mockValidateJwt).toHaveBeenCalledWith('validJwt');
+			expect(mockValidateJwt).toHaveBeenCalledWith('validJwt', {
+				audience: undefined
+			});
 			expect(result).toEqual(authInfo);
 		});
 
@@ -173,7 +216,9 @@ describe('session utilities', () => {
 			});
 			const mockReq = { headers: {}, cookies: { DS: 'cookieJwt' } };
 			const result = await getSession(mockReq as any, { projectId: 'test' });
-			expect(mockValidateJwt).toHaveBeenCalledWith('cookieJwt');
+			expect(mockValidateJwt).toHaveBeenCalledWith('cookieJwt', {
+				audience: undefined
+			});
 			expect(result).toEqual(authInfo);
 		});
 
@@ -188,7 +233,9 @@ describe('session utilities', () => {
 				projectId: 'test',
 				sessionCookieName: 'my-session'
 			});
-			expect(mockValidateJwt).toHaveBeenCalledWith('customJwt');
+			expect(mockValidateJwt).toHaveBeenCalledWith('customJwt', {
+				audience: undefined
+			});
 			expect(result).toEqual(authInfo);
 		});
 
@@ -215,7 +262,9 @@ describe('session utilities', () => {
 				}
 			};
 			const result = await getSession(mockReq as any, { projectId: 'test' });
-			expect(mockValidateJwt).toHaveBeenCalledWith('authorizationJwt');
+			expect(mockValidateJwt).toHaveBeenCalledWith('authorizationJwt', {
+				audience: undefined
+			});
 			expect(result).toEqual(authInfo);
 		});
 

--- a/packages/sdks/react-sdk/README.md
+++ b/packages/sdks/react-sdk/README.md
@@ -914,7 +914,34 @@ To use an inbound app as an OIDC provider, you must provide both the `issuer` an
 </AuthProvider>
 ```
 
+`issuer` also accepts the full well-known URL as-is - you don't need to strip it yourself:
+
+```js
+oidcConfig={{
+  issuer:
+    'https://api.descope.com/v1/apps/<Project ID>/.well-known/openid-configuration',
+  clientId: 'your-inbound-app-client-id',
+}}
+```
+
+Federated apps (`applicationId`) and inbound apps (`issuer` + `clientId`) are distinct OIDC paths with distinct default scopes - the default scope is never inferred from the shape of the `issuer` URL, only from which fields you supplied.
+
 When using a custom `issuer` (including inbound apps), the default scope is `'openid'` instead of the full Descope scope. You can override this by providing a custom `scope` value.
+
+##### Requesting a resource-scoped token (`resource`)
+
+If your inbound app is scoped to a specific resource, pass `resource` (per [RFC 8707](https://www.rfc-editor.org/rfc/rfc8707)) to request an access token bound to that resource at sign-in. It's applied both when redirecting to sign in and when refreshing the token, and accepts either a single resource or an array:
+
+```js
+oidcConfig={{
+  issuer: 'https://api.descope.com/v1/apps/<Project ID>',
+  clientId: 'your-inbound-app-client-id',
+  resource: 'https://api.my-app.com',
+  // or: resource: ['https://api.my-app.com', 'https://other-api.my-app.com'],
+}}
+```
+
+You can also pass `resource` per-call, without setting it in `oidcConfig`, by forwarding it to `loginWithRedirect` (see below).
 
 ### Login
 
@@ -932,6 +959,8 @@ const MyComponent = () => {
           // By default, the login will redirect the user to the current URL
           // If you want to redirect the user to a different URL, you can specify it here
           redirect_uri: window.location.origin,
+          // resource can also be overridden per-call, without setting it in oidcConfig
+          resource: 'https://api.my-app.com',
         });
       }}
     >

--- a/packages/sdks/react-sdk/README.md
+++ b/packages/sdks/react-sdk/README.md
@@ -338,7 +338,7 @@ Pass `autoRefresh={{ customActivityTracking: true }}` to skip refresh calls for 
 ```jsx
 <AuthProvider projectId="my-project-id" autoRefresh={{ customActivityTracking: true }}>
   <App />
-</AuthProvider>
+</AuthProvider>;
 ```
 
 **Step 2:** Create a `useActivityTracking` hook that calls `markUserActive()` on user interactions:
@@ -383,7 +383,7 @@ function Layout() {
 
 <AuthProvider projectId="my-project-id" autoRefresh={{ customActivityTracking: true }}>
   <Layout />
-</AuthProvider>
+</AuthProvider>;
 ```
 
 **For more SDK usage examples refer to [docs](https://docs.descope.com/build/guides/client_sdks/)**

--- a/packages/sdks/react-sdk/README.md
+++ b/packages/sdks/react-sdk/README.md
@@ -890,23 +890,27 @@ const AppRoot = () => {
 };
 ```
 
-#### Using Inbound Apps as OIDC Provider
+#### Using Inbound Apps or Federated Apps as an OIDC Provider (`issuer`)
 
-To use an inbound app as an OIDC provider, you must provide both the `issuer` and `clientId` configuration options. The `issuer` is the OIDC authority URL, and the `clientId` is the client ID for your inbound app.
+Instead of picking `applicationId` vs. `clientId` up front, you can just paste the **discovery/authority URL** of whichever app you want to use - a Federated App or an Inbound App - into `issuer`, including the full well-known URL as-is (`.../.well-known/openid-configuration`); it's automatically normalized to the bare issuer. The SDK detects which kind of app it is from the URL's shape:
 
-> **Note:** When configuring an inbound app as an OIDC provider, you must obtain the issuer URL directly from the inbound app settings page in the Descope console. The issuer URL is specific to your inbound app configuration and cannot be constructed manually. In addition, you'll need to provide the client ID from the same inbound app settings.
+- **Federated App URL** (the default OIDC path derived from your project, e.g. `https://api.descope.com/<Project ID>` or `https://api.descope.com/<Project ID>/<Application ID>`): `clientId` defaults to your project ID - you only need to set it if you want to override that default.
+- **Inbound App URL** (always shaped like `https://api.descope.com/v1/apps/<Project ID>`), or any other custom domain: `clientId` is required.
+
+> **Note:** For an Inbound App, obtain the issuer URL directly from the inbound app's settings page in the Descope console - it cannot be constructed manually. You'll also need the client ID from the same settings page.
 
 ```js
 <AuthProvider
   projectId="my-project-id"
   oidcConfig={{
-    // Required: Get this from your inbound app settings page
+    // Paste the Inbound App's issuer/discovery URL from its settings page in the console
     issuer: 'https://api.descope.com/v1/apps/<Project ID>',
-    // Required: Client ID from your inbound app settings
+    // Required for an Inbound App URL; defaults to the project ID for a Federated App URL
     clientId: 'your-inbound-app-client-id',
     // Optional: Custom redirect URI (defaults to current URL)
     redirectUri: 'https://my-app.com/redirect',
-    // Optional: Custom scope (defaults to 'openid' when issuer is provided)
+    // Optional: Custom scope (defaults to 'openid' for an Inbound App URL, or the full
+    // Descope scope for a Federated App URL - see below)
     scope: 'openid profile email',
   }}
 >
@@ -914,23 +918,28 @@ To use an inbound app as an OIDC provider, you must provide both the `issuer` an
 </AuthProvider>
 ```
 
-`issuer` also accepts the full well-known URL as-is - you don't need to strip it yourself:
+##### Overriding the default `scope`
+
+`scope` is set once, at `AuthProvider` init - it isn't scoped per-resource or overridable per sign-in call. The default depends on which kind of app `issuer` (or `applicationId`) resolves to:
 
 ```js
+// Inbound App - default scope is 'openid'
 oidcConfig={{
-  issuer:
-    'https://api.descope.com/v1/apps/<Project ID>/.well-known/openid-configuration',
+  issuer: 'https://api.descope.com/v1/apps/<Project ID>',
   clientId: 'your-inbound-app-client-id',
+  scope: 'openid profile email', // overrides the 'openid'-only default
+}}
+
+// Federated App - default scope is 'openid email roles descope.custom_claims offline_access'
+oidcConfig={{
+  applicationId: 'my-application-id',
+  scope: 'openid profile email', // overrides the full Descope default scope
 }}
 ```
 
-Federated apps (`applicationId`) and inbound apps (`issuer` + `clientId`) are distinct OIDC paths with distinct default scopes - the default scope is never inferred from the shape of the `issuer` URL, only from which fields you supplied.
+##### Requesting a resource-scoped token (`resource` / `audience`)
 
-When using a custom `issuer` (including inbound apps), the default scope is `'openid'` instead of the full Descope scope. You can override this by providing a custom `scope` value.
-
-##### Requesting a resource-scoped token (`resource`)
-
-If your inbound app is scoped to a specific resource, pass `resource` (per [RFC 8707](https://www.rfc-editor.org/rfc/rfc8707)) to request an access token bound to that resource at sign-in. It's applied both when redirecting to sign in and when refreshing the token, and accepts either a single resource or an array:
+Pass `resource` (per [RFC 8707](https://www.rfc-editor.org/rfc/rfc8707)) to request an access token bound to a specific resource. `audience` is accepted as an alias for callers coming from an `audience`-based vocabulary - if both are provided, `resource` wins. Either can be set once at `AuthProvider` init (`oidcConfig`) **or** per sign-in call via `loginWithRedirect` (per-call takes precedence for that sign-in - see below); it's applied both when redirecting to sign in and when refreshing the token, and accepts either a single resource or an array:
 
 ```js
 oidcConfig={{
@@ -938,10 +947,11 @@ oidcConfig={{
   clientId: 'your-inbound-app-client-id',
   resource: 'https://api.my-app.com',
   // or: resource: ['https://api.my-app.com', 'https://other-api.my-app.com'],
+  // or, equivalently: audience: 'https://api.my-app.com',
 }}
 ```
 
-You can also pass `resource` per-call, without setting it in `oidcConfig`, by forwarding it to `loginWithRedirect` (see below).
+You can also pass `resource` (or `audience`) per-call, without setting it in `oidcConfig`, by forwarding it to `loginWithRedirect` (see below).
 
 ### Login
 
@@ -959,7 +969,8 @@ const MyComponent = () => {
           // By default, the login will redirect the user to the current URL
           // If you want to redirect the user to a different URL, you can specify it here
           redirect_uri: window.location.origin,
-          // resource can also be overridden per-call, without setting it in oidcConfig
+          // resource (or its alias, audience) can be set per-call, overriding oidcConfig
+          // for this sign-in - no need to set it in oidcConfig at all if you only need it here
           resource: 'https://api.my-app.com',
         });
       }}

--- a/packages/sdks/react-sdk/src/components/AccessKeyManagement.tsx
+++ b/packages/sdks/react-sdk/src/components/AccessKeyManagement.tsx
@@ -16,7 +16,7 @@ const AccessKeyManagementWC = lazy(async () => {
   return {
     default: withPropsMapping(
       React.forwardRef<HTMLElement>((props, ref) => (
-        <descope-access-key-management-widget ref={ref} {...props} />
+	<descope-access-key-management-widget ref={ref} {...props} />
       )),
     ),
   };
@@ -47,8 +47,8 @@ const AccessKeyManagement = React.forwardRef<
     }, [innerRef, onReady]);
 
     return (
-      <Suspense fallback={null}>
-        <AccessKeyManagementWC
+	<Suspense fallback={null}>
+		<AccessKeyManagementWC
           ref={setInnerRef}
           projectId={projectId}
           widgetId={widgetId}
@@ -67,7 +67,7 @@ const AccessKeyManagement = React.forwardRef<
             'logger.prop': logger,
           }}
         />
-      </Suspense>
+	</Suspense>
     );
   },
 );

--- a/packages/sdks/react-sdk/src/components/AuthProvider/AuthProvider.tsx
+++ b/packages/sdks/react-sdk/src/components/AuthProvider/AuthProvider.tsx
@@ -45,6 +45,10 @@ interface IAuthProviderProps {
   hooks?: Hooks;
   // If truthy he SDK refresh and logout functions will use the OIDC client
   // Accepts boolean or OIDC configuration
+  // `issuer` accepts either the bare issuer or a full well-known URL
+  // (`.../.well-known/openid-configuration`), which is auto-normalized.
+  // `resource` (RFC 8707) can be set here to request a resource-scoped access
+  // token at sign-in, for either federated (applicationId) or inbound (issuer) apps.
   oidcConfig?: OidcConfig;
   // Default is true. If true, last authenticated user will be stored on local storage and can accessed with getUser function
   storeLastAuthenticatedUser?: boolean;

--- a/packages/sdks/react-sdk/src/components/Descope.tsx
+++ b/packages/sdks/react-sdk/src/components/Descope.tsx
@@ -179,9 +179,9 @@ const Descope = React.forwardRef<HTMLElement, DescopeProps>(
        * it can be removed once this issue will be solved
        * https://bugs.chromium.org/p/chromium/issues/detail?id=1404106#c2
        */
-      <form>
-        <Suspense fallback={null}>
-          <DescopeWC
+	<form>
+		<Suspense fallback={null}>
+			<DescopeWC
             projectId={projectId}
             flowId={flowId}
             baseUrl={baseUrl}
@@ -222,10 +222,10 @@ const Descope = React.forwardRef<HTMLElement, DescopeProps>(
               'customStorage.prop': customStorage,
             }}
           >
-            {children}
-          </DescopeWC>
-        </Suspense>
-      </form>
+				{children}
+			</DescopeWC>
+		</Suspense>
+	</form>
     );
   },
 );

--- a/packages/sdks/react-sdk/src/utils.ts
+++ b/packages/sdks/react-sdk/src/utils.ts
@@ -28,4 +28,4 @@ export const wrapInTry =
 
 // Detect if running in a native flow (e.g., mobile app with Descope bridge in a webview)
 export const isDescopeBridge = () =>
-  typeof window !== 'undefined' && !!window['descopeBridge'];
+  typeof window !== 'undefined' && !!window.descopeBridge;

--- a/packages/sdks/web-js-sdk/README.md
+++ b/packages/sdks/web-js-sdk/README.md
@@ -134,46 +134,55 @@ const sdk = descopeSdk({
 });
 ```
 
-#### Using Inbound Apps as OIDC Provider
+#### Using Inbound Apps or Federated Apps as an OIDC Provider (`issuer`)
 
-To use an inbound app as an OIDC provider, you must provide both the `issuer` and `clientId` configuration options. The `issuer` is the OIDC authority URL, and the `clientId` is the client ID for your inbound app.
+Instead of picking `applicationId` vs. `clientId` up front, you can just paste the **discovery/authority URL** of whichever app you want to use - a Federated App or an Inbound App - into `issuer`, including the full well-known URL as-is (`.../.well-known/openid-configuration`); it's automatically normalized to the bare issuer. The SDK detects which kind of app it is from the URL's shape:
 
-> **Note:** When configuring an inbound app as an OIDC provider, you must obtain the issuer URL directly from the inbound app settings page in the Descope console. The issuer URL is specific to your inbound app configuration and cannot be constructed manually. In addition, you'll need to provide the client ID from the same inbound app settings.
+- **Federated App URL** (the default OIDC path derived from your project, e.g. `https://api.descope.com/<Project ID>` or `https://api.descope.com/<Project ID>/<Application ID>`): `clientId` defaults to your project ID - you only need to set it if you want to override that default.
+- **Inbound App URL** (always shaped like `https://api.descope.com/v1/apps/<Project ID>`), or any other custom domain: `clientId` is required.
+
+> **Note:** For an Inbound App, obtain the issuer URL directly from the inbound app's settings page in the Descope console - it cannot be constructed manually. You'll also need the client ID from the same settings page.
 
 ```js
 // Initialize the SDK with inbound app OIDC configuration
 const sdk = descopeSdk({
   projectId: 'xxx',
   oidcConfig: {
-    // Required: Get this from your inbound app settings page
+    // Paste the Inbound App's issuer/discovery URL from its settings page in the console
     issuer: 'https://api.descope.com/v1/apps/P1234567890',
-    // Required: Client ID from your inbound app settings
+    // Required for an Inbound App URL; defaults to the project ID for a Federated App URL
     clientId: 'your-inbound-app-client-id',
     // Optional: Custom redirect URI (defaults to current URL)
     redirectUri: 'https://my-app.com/redirect',
-    // Optional: Custom scope (defaults to 'openid' when issuer is provided)
+    // Optional: Custom scope (defaults to 'openid' for an Inbound App URL, or the full
+    // Descope scope for a Federated App URL - see below)
     scope: 'openid profile email',
   },
 });
 ```
 
-`issuer` also accepts the full well-known URL as-is - you don't need to strip it yourself:
+##### Overriding the default `scope`
+
+`scope` is set once, at SDK-init - it isn't scoped per-resource or overridable per sign-in call. The default depends on which kind of app `issuer` (or `applicationId`) resolves to:
 
 ```js
+// Inbound App - default scope is 'openid'
 oidcConfig: {
-  issuer:
-    'https://api.descope.com/v1/apps/P1234567890/.well-known/openid-configuration',
+  issuer: 'https://api.descope.com/v1/apps/P1234567890',
   clientId: 'your-inbound-app-client-id',
+  scope: 'openid profile email', // overrides the 'openid'-only default
+},
+
+// Federated App - default scope is 'openid email roles descope.custom_claims offline_access'
+oidcConfig: {
+  applicationId: 'my-application-id',
+  scope: 'openid profile email', // overrides the full Descope default scope
 },
 ```
 
-Federated apps (`applicationId`) and inbound apps (`issuer` + `clientId`) are distinct OIDC paths with distinct default scopes - the default scope is never inferred from the shape of the `issuer` URL, only from which fields you supplied.
+##### Requesting a resource-scoped token (`resource` / `audience`)
 
-When using a custom `issuer` (including inbound apps), the default scope is `'openid'` instead of the full Descope scope. You can override this by providing a custom `scope` value.
-
-##### Requesting a resource-scoped token (`resource`)
-
-If your inbound app is scoped to a specific resource, pass `resource` (per [RFC 8707](https://www.rfc-editor.org/rfc/rfc8707)) to request an access token bound to that resource at sign-in. It's applied both when redirecting to sign in and when refreshing the token, and accepts either a single resource or an array:
+Pass `resource` (per [RFC 8707](https://www.rfc-editor.org/rfc/rfc8707)) to request an access token bound to a specific resource. `audience` is accepted as an alias for callers coming from an `audience`-based vocabulary - if both are provided, `resource` wins. Either can be set once at SDK-init (`oidcConfig`) **or** per sign-in call via `loginWithRedirect` (per-call takes precedence for that sign-in - see below); it's applied both when redirecting to sign in and when refreshing the token, and accepts either a single resource or an array:
 
 ```js
 oidcConfig: {
@@ -181,10 +190,11 @@ oidcConfig: {
   clientId: 'your-inbound-app-client-id',
   resource: 'https://api.my-app.com',
   // or: resource: ['https://api.my-app.com', 'https://other-api.my-app.com'],
+  // or, equivalently: audience: 'https://api.my-app.com',
 },
 ```
 
-You can also pass `resource` per-call, without setting it in `oidcConfig`, by forwarding it to `loginWithRedirect`:
+You can also pass `resource` (or `audience`) per-call, without setting it in `oidcConfig`, by forwarding it to `loginWithRedirect`:
 
 ```js
 await sdk.oidc.loginWithRedirect({ resource: 'https://api.my-app.com' });

--- a/packages/sdks/web-js-sdk/README.md
+++ b/packages/sdks/web-js-sdk/README.md
@@ -157,7 +157,38 @@ const sdk = descopeSdk({
 });
 ```
 
+`issuer` also accepts the full well-known URL as-is - you don't need to strip it yourself:
+
+```js
+oidcConfig: {
+  issuer:
+    'https://api.descope.com/v1/apps/P1234567890/.well-known/openid-configuration',
+  clientId: 'your-inbound-app-client-id',
+},
+```
+
+Federated apps (`applicationId`) and inbound apps (`issuer` + `clientId`) are distinct OIDC paths with distinct default scopes - the default scope is never inferred from the shape of the `issuer` URL, only from which fields you supplied.
+
 When using a custom `issuer` (including inbound apps), the default scope is `'openid'` instead of the full Descope scope. You can override this by providing a custom `scope` value.
+
+##### Requesting a resource-scoped token (`resource`)
+
+If your inbound app is scoped to a specific resource, pass `resource` (per [RFC 8707](https://www.rfc-editor.org/rfc/rfc8707)) to request an access token bound to that resource at sign-in. It's applied both when redirecting to sign in and when refreshing the token, and accepts either a single resource or an array:
+
+```js
+oidcConfig: {
+  issuer: 'https://api.descope.com/v1/apps/P1234567890',
+  clientId: 'your-inbound-app-client-id',
+  resource: 'https://api.my-app.com',
+  // or: resource: ['https://api.my-app.com', 'https://other-api.my-app.com'],
+},
+```
+
+You can also pass `resource` per-call, without setting it in `oidcConfig`, by forwarding it to `loginWithRedirect`:
+
+```js
+await sdk.oidc.loginWithRedirect({ resource: 'https://api.my-app.com' });
+```
 
 #### Start OIDC login
 

--- a/packages/sdks/web-js-sdk/src/sdk/oidc/index.ts
+++ b/packages/sdks/web-js-sdk/src/sdk/oidc/index.ts
@@ -28,7 +28,12 @@ type OidcModule = {
 type SignInResponseStorage = Pick<
   SigninResponse,
   'id_token' | 'session_state' | 'profile'
->;
+> & {
+  // The resource actually used for this signin (per-call `loginWithRedirect({ resource })`
+  // arg if provided, else `oidcConfig.resource`) - persisted so refreshToken can honor it
+  // even when it was only ever passed per-call and never set on oidcConfig.
+  resource?: string | string[];
+};
 
 let scriptLoadingPromise: Promise<OidcModule>;
 
@@ -90,11 +95,13 @@ const loadOIDCModule = async (): Promise<OidcModule> => {
 
 function oidcSignInResToStorage(
   signInRes: SigninResponse,
+  resource?: string | string[],
 ): SignInResponseStorage {
   return {
     id_token: signInRes.id_token,
     session_state: signInRes.session_state,
     profile: signInRes.profile,
+    resource,
   };
 }
 
@@ -104,6 +111,19 @@ const getUserFromStorage = (
   const user = getLocalStorage(stateUserKey);
   return user ? JSON.parse(user) : null;
 };
+
+// Key for the resource requested by the in-flight signin, persisted across the full-page
+// redirect (set in loginWithRedirect, consumed and cleared in finishLogin) so it can be
+// folded into the cached user alongside session_state/profile.
+const getPendingResourceKey = (stateUserKey: string): string =>
+  `${stateUserKey}_pending_resource`;
+
+// Strips a trailing `/.well-known/openid-configuration` (with an optional trailing slash
+// before it) so callers can paste a full well-known URL directly as `issuer`. Must stay a
+// pure, deterministic, idempotent string operation - the result is re-derived on the
+// callback page load and compared byte-for-byte against the redirect-time value.
+const normalizeIssuer = (issuer: string): string =>
+  issuer.replace(/\/+\.well-known\/openid-configuration\/?$/, '');
 
 const getOidcClient = async (
   sdk: CoreSdk,
@@ -135,7 +155,7 @@ const getOidcClient = async (
         'clientId is required when providing a custom issuer/authority',
       );
     }
-    authority = oidcConfig.issuer;
+    authority = normalizeIssuer(oidcConfig.issuer);
     oidcClientId = oidcConfig.clientId;
     stateUserKey = `${oidcClientId}_user`;
     // For custom issuer with clientId, default scope is just 'openid'
@@ -169,6 +189,7 @@ const getOidcClient = async (
     }),
     loadUserInfo: true,
     fetchRequestCredentials: 'same-origin',
+    resource: oidcConfig?.resource,
   };
 
   if (oidcConfig?.redirectUri) {
@@ -206,9 +227,21 @@ const createOidc = (
     arg: CreateSigninRequestArgs = {},
     disableNavigation: boolean = false,
   ): Promise<SdkResponse<URLResponse>> => {
-    const { client } = await getCachedClient();
+    const { client, stateUserKey } = await getCachedClient();
     const res = await client.createSigninRequest(arg);
     const { url } = res;
+    // A per-call `resource` arg takes precedence over `oidcConfig.resource` for this signin
+    // (mirroring oidc-client-ts's own createSigninRequest precedence). Persist whichever one
+    // is actually in effect so refreshToken can honor it later, even if it only ever came from
+    // a per-call arg and was never set on oidcConfig.
+    const resource =
+      arg.resource ?? (oidcConfig as OidcConfigOptions)?.resource;
+    if (resource) {
+      setLocalStorage(
+        getPendingResourceKey(stateUserKey),
+        JSON.stringify(resource),
+      );
+    }
     if (!disableNavigation) {
       // In order to make sure all the after-hooks are running with the success response
       // we are generating a fake response with the success data and calling the http client after hook fn with it
@@ -234,7 +267,15 @@ const createOidc = (
       new Response(JSON.stringify(res)),
     );
 
-    setLocalStorage(stateUserKey, JSON.stringify(oidcSignInResToStorage(res)));
+    const pendingResourceKey = getPendingResourceKey(stateUserKey);
+    const pendingResource = getLocalStorage(pendingResourceKey);
+    const resource = pendingResource ? JSON.parse(pendingResource) : undefined;
+    removeLocalStorage(pendingResourceKey);
+
+    setLocalStorage(
+      stateUserKey,
+      JSON.stringify(oidcSignInResToStorage(res, resource)),
+    );
     // remove the code from the URL
     removeOidcParamFromUrl();
 
@@ -269,6 +310,7 @@ const createOidc = (
     const res = await client.createSignoutRequest(arg);
     const { url } = res;
     removeLocalStorage(stateUserKey);
+    removeLocalStorage(getPendingResourceKey(stateUserKey));
     if (!disableNavigation) {
       window.location.replace(url);
     }
@@ -297,6 +339,13 @@ const createOidc = (
         session_state: user.session_state,
         profile: user.profile,
       },
+      // resource must be re-supplied explicitly here: unlike createSigninRequest,
+      // oidc-client-ts's useRefreshToken does NOT fall back to `this.settings.resource`, so
+      // omitting it would silently stop applying resource-scoped tokens after the first
+      // refresh. Prefer the resource actually used at signin (covers a per-call
+      // `loginWithRedirect({ resource })` override, which oidcConfig never sees) and fall back
+      // to oidcConfig.resource for sessions cached before this field existed.
+      resource: user.resource ?? (oidcConfig as OidcConfigOptions)?.resource,
     });
 
     // In order to make sure all the after-hooks are running with the success response

--- a/packages/sdks/web-js-sdk/src/sdk/oidc/index.ts
+++ b/packages/sdks/web-js-sdk/src/sdk/oidc/index.ts
@@ -132,9 +132,11 @@ const normalizeIssuer = (issuer: string): string =>
 const isFederatedAuthority = (
   normalizedIssuer: string,
   federatedBase: string,
+  projectId: string,
 ): boolean =>
-  normalizedIssuer === federatedBase ||
-  normalizedIssuer.startsWith(`${federatedBase}/`);
+  !!projectId &&
+  (normalizedIssuer === federatedBase ||
+    normalizedIssuer.startsWith(`${federatedBase}/`));
 
 const resolveResource = (source?: {
   resource?: string | string[];
@@ -171,7 +173,7 @@ const getOidcClient = async (
     const normalizedIssuer = normalizeIssuer(oidcConfig.issuer);
     const federatedBase = sdk.httpClient.buildUrl(projectId);
 
-    if (isFederatedAuthority(normalizedIssuer, federatedBase)) {
+    if (isFederatedAuthority(normalizedIssuer, federatedBase, projectId)) {
       authority = normalizedIssuer;
       oidcClientId = oidcConfig.clientId || projectId;
       stateUserKey = `${oidcClientId}_user`;
@@ -256,14 +258,19 @@ const createOidc = (
     disableNavigation: boolean = false,
   ): Promise<SdkResponse<URLResponse>> => {
     const { client, stateUserKey } = await getCachedClient();
-    const res = await client.createSigninRequest(arg);
-    const { url } = res;
+    // Resolve resource/audience before calling into oidc-client-ts: its createSigninRequest
+    // only destructures `resource` (falling back to `this.settings.resource`) and has no
+    // concept of `audience` at all, so an `audience`-only arg would otherwise silently
+    // contribute nothing to the actual signin request even though we'd still persist it below.
     // A per-call `resource`/`audience` arg takes precedence over `oidcConfig.resource`/
     // `audience` for this signin (mirroring oidc-client-ts's own createSigninRequest
-    // precedence). Persist whichever one is actually in effect so refreshToken can honor it
-    // later, even if it only ever came from a per-call arg and was never set on oidcConfig.
+    // precedence).
     const resource =
       resolveResource(arg) ?? resolveResource(oidcConfig as OidcConfigOptions);
+    const res = await client.createSigninRequest({ ...arg, resource });
+    const { url } = res;
+    // Persist whichever resource/audience is actually in effect so refreshToken can honor it
+    // later, even if it only ever came from a per-call arg and was never set on oidcConfig.
     if (resource) {
       setLocalStorage(
         getPendingResourceKey(stateUserKey),

--- a/packages/sdks/web-js-sdk/src/sdk/oidc/index.ts
+++ b/packages/sdks/web-js-sdk/src/sdk/oidc/index.ts
@@ -125,6 +125,22 @@ const getPendingResourceKey = (stateUserKey: string): string =>
 const normalizeIssuer = (issuer: string): string =>
   issuer.replace(/\/+\.well-known\/openid-configuration\/?$/, '');
 
+// A federated app's authority is always `${baseUrl}/${projectId}` or
+// `${baseUrl}/${projectId}/${applicationId}` (no `/v1/apps/` segment). Anything else -
+// including the documented inbound-app shape `/v1/apps/{projectId}`, or a fully custom
+// domain - is treated as an inbound-style authority and still requires an explicit clientId.
+const isFederatedAuthority = (
+  normalizedIssuer: string,
+  federatedBase: string,
+): boolean =>
+  normalizedIssuer === federatedBase ||
+  normalizedIssuer.startsWith(`${federatedBase}/`);
+
+const resolveResource = (source?: {
+  resource?: string | string[];
+  audience?: string | string[];
+}): string | string[] | undefined => source?.resource ?? source?.audience;
+
 const getOidcClient = async (
   sdk: CoreSdk,
   projectId: string,
@@ -148,18 +164,30 @@ const getOidcClient = async (
   let stateUserKey: string;
   let defaultScope: string;
 
-  // Handle custom issuer (requires clientId)
+  // Handle custom issuer. A pasted Federated App discovery/authority URL is auto-detected
+  // (see isFederatedAuthority) and doesn't require clientId; anything else is treated as an
+  // inbound-app-style authority and does require clientId.
   if (oidcConfig?.issuer) {
-    if (!oidcConfig.clientId) {
-      throw new Error(
-        'clientId is required when providing a custom issuer/authority',
-      );
+    const normalizedIssuer = normalizeIssuer(oidcConfig.issuer);
+    const federatedBase = sdk.httpClient.buildUrl(projectId);
+
+    if (isFederatedAuthority(normalizedIssuer, federatedBase)) {
+      authority = normalizedIssuer;
+      oidcClientId = oidcConfig.clientId || projectId;
+      stateUserKey = `${oidcClientId}_user`;
+      defaultScope = 'openid email roles descope.custom_claims offline_access';
+    } else {
+      if (!oidcConfig.clientId) {
+        throw new Error(
+          'clientId is required when providing a custom issuer/authority',
+        );
+      }
+      authority = normalizedIssuer;
+      oidcClientId = oidcConfig.clientId;
+      stateUserKey = `${oidcClientId}_user`;
+      // For custom issuer with clientId, default scope is just 'openid'
+      defaultScope = 'openid';
     }
-    authority = normalizeIssuer(oidcConfig.issuer);
-    oidcClientId = oidcConfig.clientId;
-    stateUserKey = `${oidcClientId}_user`;
-    // For custom issuer with clientId, default scope is just 'openid'
-    defaultScope = 'openid';
   } else if (oidcConfig?.applicationId) {
     // Handle federated apps with applicationId (existing behavior)
     authority = sdk.httpClient.buildUrl(projectId);
@@ -189,7 +217,7 @@ const getOidcClient = async (
     }),
     loadUserInfo: true,
     fetchRequestCredentials: 'same-origin',
-    resource: oidcConfig?.resource,
+    resource: resolveResource(oidcConfig),
   };
 
   if (oidcConfig?.redirectUri) {
@@ -224,18 +252,18 @@ const createOidc = (
   // Start the login process by creating a signin request
   // And redirecting the user to the returned URL
   const loginWithRedirect = async (
-    arg: CreateSigninRequestArgs = {},
+    arg: CreateSigninRequestArgs & { audience?: string | string[] } = {},
     disableNavigation: boolean = false,
   ): Promise<SdkResponse<URLResponse>> => {
     const { client, stateUserKey } = await getCachedClient();
     const res = await client.createSigninRequest(arg);
     const { url } = res;
-    // A per-call `resource` arg takes precedence over `oidcConfig.resource` for this signin
-    // (mirroring oidc-client-ts's own createSigninRequest precedence). Persist whichever one
-    // is actually in effect so refreshToken can honor it later, even if it only ever came from
-    // a per-call arg and was never set on oidcConfig.
+    // A per-call `resource`/`audience` arg takes precedence over `oidcConfig.resource`/
+    // `audience` for this signin (mirroring oidc-client-ts's own createSigninRequest
+    // precedence). Persist whichever one is actually in effect so refreshToken can honor it
+    // later, even if it only ever came from a per-call arg and was never set on oidcConfig.
     const resource =
-      arg.resource ?? (oidcConfig as OidcConfigOptions)?.resource;
+      resolveResource(arg) ?? resolveResource(oidcConfig as OidcConfigOptions);
     if (resource) {
       setLocalStorage(
         getPendingResourceKey(stateUserKey),
@@ -344,8 +372,9 @@ const createOidc = (
       // omitting it would silently stop applying resource-scoped tokens after the first
       // refresh. Prefer the resource actually used at signin (covers a per-call
       // `loginWithRedirect({ resource })` override, which oidcConfig never sees) and fall back
-      // to oidcConfig.resource for sessions cached before this field existed.
-      resource: user.resource ?? (oidcConfig as OidcConfigOptions)?.resource,
+      // to oidcConfig.resource/audience for sessions cached before this field existed.
+      resource:
+        user.resource ?? resolveResource(oidcConfig as OidcConfigOptions),
     });
 
     // In order to make sure all the after-hooks are running with the success response

--- a/packages/sdks/web-js-sdk/src/types.ts
+++ b/packages/sdks/web-js-sdk/src/types.ts
@@ -10,12 +10,17 @@ export type OidcConfigOptions = {
   clientId?: string;
   // Custom issuer/authority URL. If provided, clientId is required.
   // For inbound apps, construct the issuer URL manually: `${baseUrl}/v1/apps/${projectId}`
+  // Also accepts a full well-known URL (`.../.well-known/openid-configuration`) - it is
+  // automatically normalized to the bare issuer.
   issuer?: string;
   // default is current URL
   redirectUri?: string;
   // default is openid email roles descope.custom_claims offline_access
   // default is 'openid' if issuer (and clientId) is provided
   scope?: string;
+  // RFC 8707 resource indicator(s) requested at sign-in and on refresh.
+  // Applies to both federated (applicationId) and inbound (issuer) apps.
+  resource?: string | string[];
 };
 
 export type OidcConfig = boolean | OidcConfigOptions;

--- a/packages/sdks/web-js-sdk/src/types.ts
+++ b/packages/sdks/web-js-sdk/src/types.ts
@@ -5,22 +5,27 @@ type Head<T extends ReadonlyArray<any>> = T extends readonly [] ? never : T[0];
 
 export type OidcConfigOptions = {
   applicationId?: string;
-  // Client ID for OIDC. Required if issuer is provided.
-  // For inbound apps, provide issuer with this clientId (e.g., issuer: 'https://api.descope.com/v1/apps/{projectId}')
+  // Client ID for OIDC. Required when `issuer` is a non-federated (e.g. inbound-app)
+  // authority. If `issuer` is a Federated App's discovery/authority URL, this defaults to
+  // the project ID and only needs to be set to override it.
   clientId?: string;
-  // Custom issuer/authority URL. If provided, clientId is required.
-  // For inbound apps, construct the issuer URL manually: `${baseUrl}/v1/apps/${projectId}`
-  // Also accepts a full well-known URL (`.../.well-known/openid-configuration`) - it is
-  // automatically normalized to the bare issuer.
+  // Custom issuer/authority URL - paste the discovery/authority URL of either a Federated
+  // App or an Inbound App as-is, including a full well-known URL
+  // (`.../.well-known/openid-configuration`), which is automatically normalized to the bare
+  // issuer. Which kind of app it is gets auto-detected from the URL shape; see `clientId`.
   issuer?: string;
   // default is current URL
   redirectUri?: string;
   // default is openid email roles descope.custom_claims offline_access
-  // default is 'openid' if issuer (and clientId) is provided
+  // default is 'openid' if issuer resolves to a non-federated (e.g. inbound-app) authority
   scope?: string;
   // RFC 8707 resource indicator(s) requested at sign-in and on refresh.
   // Applies to both federated (applicationId) and inbound (issuer) apps.
   resource?: string | string[];
+  // Alias for `resource` - RFC 8707 resource indicator(s). If both `resource` and
+  // `audience` are supplied, `resource` wins. Provided for callers coming from an
+  // `audience`-based OAuth/OIDC vocabulary; the wire parameter sent is always `resource`.
+  audience?: string | string[];
 };
 
 export type OidcConfig = boolean | OidcConfigOptions;

--- a/packages/sdks/web-js-sdk/test/oidc.test.ts
+++ b/packages/sdks/web-js-sdk/test/oidc.test.ts
@@ -405,6 +405,43 @@ describe('OIDC', () => {
         expect.objectContaining({ resource: 'https://per-call.example.com' }),
       );
     });
+
+    it('should persist a per-call audience (aliased to resource) so refreshToken honors it', async () => {
+      const mockCreateSigninRequest = jest
+        .fn()
+        .mockResolvedValue({ url: 'mockUrl' });
+      const mockProcessSigninResponse = jest.fn().mockResolvedValue({
+        id_token: 'idToken',
+        session_state: 'sessionState',
+        profile: { sub: 'user123' },
+      });
+      const mockUseRefreshToken = jest
+        .fn()
+        .mockResolvedValue({ id_token: 'newIdToken' });
+      (OidcClient as jest.Mock).mockImplementation(() => ({
+        createSigninRequest: mockCreateSigninRequest,
+        processSigninResponse: mockProcessSigninResponse,
+        useRefreshToken: mockUseRefreshToken,
+      }));
+
+      const oidc = createOidc(sdk, 'projectID', {
+        issuer: 'https://custom-issuer.com',
+        clientId: 'custom-client-id',
+      });
+
+      await oidc.loginWithRedirect(
+        { audience: 'https://per-call-audience.example.com' },
+        true,
+      );
+      await oidc.finishLogin('https://my-app.com/redirect?code=1&state=2');
+      await oidc.refreshToken('oldRefreshToken');
+
+      expect(mockUseRefreshToken).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resource: 'https://per-call-audience.example.com',
+        }),
+      );
+    });
   });
 
   describe('logout', () => {
@@ -548,9 +585,13 @@ describe('OIDC', () => {
         createSigninRequest: mockCreateSigninRequest,
       }));
 
-      // Mock buildUrl to return base URL for inbound apps
-      (sdk.httpClient.buildUrl as jest.Mock).mockReturnValue(
-        'http://example.com',
+      // Mock buildUrl to mirror real behavior (`${baseUrl}/${projectId}`), so the inbound
+      // app's `/v1/apps/{projectId}` issuer is correctly distinguished from a federated
+      // authority sharing the same host. Use `mockReturnValueOnce` (rather than
+      // `mockReturnValue`) so this override doesn't leak into later tests -
+      // `jest.clearAllMocks()` in `beforeEach` clears call history but not implementations.
+      (sdk.httpClient.buildUrl as jest.Mock).mockReturnValueOnce(
+        'http://example.com/projectID',
       );
 
       const oidc = createOidc(sdk, 'projectID', {
@@ -700,7 +741,7 @@ describe('OIDC', () => {
       );
     });
 
-    it('should keep federated and inbound default scopes distinct regardless of issuer URL shape', async () => {
+    it('should default to openid scope for a custom-domain issuer that does not match the federated authority shape', async () => {
       const mockCreateSigninRequest = jest
         .fn()
         .mockResolvedValue({ url: 'mockUrl' });
@@ -708,9 +749,8 @@ describe('OIDC', () => {
         createSigninRequest: mockCreateSigninRequest,
       }));
 
-      // An inbound-app issuer that happens NOT to follow the illustrative
-      // `/v1/apps/{projectId}` shape - scope must still default to 'openid',
-      // since it's keyed on the issuer field being supplied, not URL sniffing.
+      // A custom domain that doesn't match `${buildUrl(projectId)}[/...]` - treated as an
+      // inbound-style authority, so clientId is required and scope defaults to 'openid'.
       const oidc = createOidc(sdk, 'projectID', {
         issuer: 'https://totally-custom-domain.example.com',
         clientId: 'inbound-client-id',
@@ -735,6 +775,53 @@ describe('OIDC', () => {
 
       expect(OidcClient).toHaveBeenCalledWith(
         expect.objectContaining({
+          scope: 'openid email roles descope.custom_claims offline_access',
+        }),
+      );
+    });
+
+    it('should auto-detect a federated-shaped issuer URL and default clientId to the projectId', async () => {
+      const mockCreateSigninRequest = jest
+        .fn()
+        .mockResolvedValue({ url: 'mockUrl' });
+      (OidcClient as jest.Mock).mockImplementation(() => ({
+        createSigninRequest: mockCreateSigninRequest,
+      }));
+
+      // buildUrl(projectId) mocked to 'http://example.com' - a federated app's discovery URL
+      // for that project is `http://example.com/projectID/.well-known/openid-configuration`.
+      const oidc = createOidc(sdk, 'projectID', {
+        issuer: 'http://example.com/projectID/.well-known/openid-configuration',
+      });
+      await oidc.loginWithRedirect({}, true);
+
+      expect(OidcClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authority: 'http://example.com/projectID',
+          client_id: 'projectID',
+          scope: 'openid email roles descope.custom_claims offline_access',
+        }),
+      );
+    });
+
+    it('should let clientId override the projectId default for a federated-shaped issuer URL', async () => {
+      const mockCreateSigninRequest = jest
+        .fn()
+        .mockResolvedValue({ url: 'mockUrl' });
+      (OidcClient as jest.Mock).mockImplementation(() => ({
+        createSigninRequest: mockCreateSigninRequest,
+      }));
+
+      const oidc = createOidc(sdk, 'projectID', {
+        issuer: 'http://example.com/projectID/app123',
+        clientId: 'custom-client-id',
+      });
+      await oidc.loginWithRedirect({}, true);
+
+      expect(OidcClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authority: 'http://example.com/projectID/app123',
+          client_id: 'custom-client-id',
           scope: 'openid email roles descope.custom_claims offline_access',
         }),
       );
@@ -780,6 +867,73 @@ describe('OIDC', () => {
       expect(OidcClient).toHaveBeenCalledWith(
         expect.objectContaining({
           resource: ['https://api-a.example.com', 'https://api-b.example.com'],
+        }),
+      );
+    });
+
+    it('should treat oidcConfig.audience as an alias for oidcConfig.resource', async () => {
+      const mockCreateSigninRequest = jest
+        .fn()
+        .mockResolvedValue({ url: 'mockUrl' });
+      (OidcClient as jest.Mock).mockImplementation(() => ({
+        createSigninRequest: mockCreateSigninRequest,
+      }));
+
+      const oidc = createOidc(sdk, 'projectID', {
+        issuer: 'https://custom-issuer.com',
+        clientId: 'custom-client-id',
+        audience: 'https://api.example.com',
+      });
+      await oidc.loginWithRedirect({}, true);
+
+      expect(OidcClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resource: 'https://api.example.com',
+        }),
+      );
+    });
+
+    it('should treat an array oidcConfig.audience as an alias for oidcConfig.resource', async () => {
+      const mockCreateSigninRequest = jest
+        .fn()
+        .mockResolvedValue({ url: 'mockUrl' });
+      (OidcClient as jest.Mock).mockImplementation(() => ({
+        createSigninRequest: mockCreateSigninRequest,
+      }));
+
+      const oidc = createOidc(sdk, 'projectID', {
+        issuer: 'https://custom-issuer.com',
+        clientId: 'custom-client-id',
+        audience: ['https://api-a.example.com', 'https://api-b.example.com'],
+      });
+      await oidc.loginWithRedirect({}, true);
+
+      expect(OidcClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resource: ['https://api-a.example.com', 'https://api-b.example.com'],
+        }),
+      );
+    });
+
+    it('should prefer oidcConfig.resource over oidcConfig.audience when both are provided', async () => {
+      const mockCreateSigninRequest = jest
+        .fn()
+        .mockResolvedValue({ url: 'mockUrl' });
+      (OidcClient as jest.Mock).mockImplementation(() => ({
+        createSigninRequest: mockCreateSigninRequest,
+      }));
+
+      const oidc = createOidc(sdk, 'projectID', {
+        issuer: 'https://custom-issuer.com',
+        clientId: 'custom-client-id',
+        resource: 'https://resource-wins.example.com',
+        audience: 'https://audience-loses.example.com',
+      });
+      await oidc.loginWithRedirect({}, true);
+
+      expect(OidcClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resource: 'https://resource-wins.example.com',
         }),
       );
     });

--- a/packages/sdks/web-js-sdk/test/oidc.test.ts
+++ b/packages/sdks/web-js-sdk/test/oidc.test.ts
@@ -436,7 +436,35 @@ describe('OIDC', () => {
       await oidc.finishLogin('https://my-app.com/redirect?code=1&state=2');
       await oidc.refreshToken('oldRefreshToken');
 
+      expect(mockCreateSigninRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resource: 'https://per-call-audience.example.com',
+        }),
+      );
       expect(mockUseRefreshToken).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resource: 'https://per-call-audience.example.com',
+        }),
+      );
+    });
+
+    it('should pass a per-call audience (aliased to resource) to createSigninRequest even with no resource anywhere', async () => {
+      const mockCreateSigninRequest = jest
+        .fn()
+        .mockResolvedValue({ url: 'mockUrl' });
+      (OidcClient as jest.Mock).mockImplementation(() => ({
+        createSigninRequest: mockCreateSigninRequest,
+      }));
+
+      // No `resource` set on oidcConfig or anywhere else - `audience` is the only thing
+      // in play, and must still make it into the actual signin request as `resource`.
+      const oidc = createOidc(sdk, 'projectID');
+      await oidc.loginWithRedirect(
+        { audience: 'https://per-call-audience.example.com' },
+        true,
+      );
+
+      expect(mockCreateSigninRequest).toHaveBeenCalledWith(
         expect.objectContaining({
           resource: 'https://per-call-audience.example.com',
         }),
@@ -824,6 +852,20 @@ describe('OIDC', () => {
           client_id: 'custom-client-id',
           scope: 'openid email roles descope.custom_claims offline_access',
         }),
+      );
+    });
+
+    it('should not misclassify a matching issuer as a federated authority when projectId is falsy', async () => {
+      // An empty projectId must never make isFederatedAuthority over-match: `buildUrl('')`
+      // would otherwise degrade to a bare host with no path, and any issuer under that host
+      // (including this one, which equals the default mocked buildUrl return value) would be
+      // wrongly treated as federated - silently skipping the clientId requirement.
+      const oidc = createOidc(sdk, '', {
+        issuer: 'http://example.com',
+      });
+
+      await expect(oidc.loginWithRedirect({}, true)).rejects.toThrow(
+        'clientId is required when providing a custom issuer/authority',
       );
     });
 

--- a/packages/sdks/web-js-sdk/test/oidc.test.ts
+++ b/packages/sdks/web-js-sdk/test/oidc.test.ts
@@ -266,8 +266,42 @@ describe('OIDC', () => {
           session_state: 'sessionState',
           profile: { sub: 'user123' },
         },
+        resource: undefined,
       });
       expect(response).toEqual(mockResponse);
+    });
+
+    it('should pass resource to useRefreshToken so it keeps applying after a refresh', async () => {
+      const mockResponse = {
+        id_token: 'newIdToken',
+        refresh_token: 'newRefreshToken',
+      };
+      const mockUseRefreshToken = jest.fn().mockResolvedValue(mockResponse);
+      (OidcClient as jest.Mock).mockImplementation(() => ({
+        useRefreshToken: mockUseRefreshToken,
+      }));
+
+      const mockUser = {
+        id_token: 'oldToken',
+        session_state: 'sessionState',
+        profile: { sub: 'user123' },
+      };
+      Storage.prototype.getItem = jest
+        .fn()
+        .mockReturnValue(JSON.stringify(mockUser));
+
+      const oidc = createOidc(sdk, 'projectID', {
+        issuer: 'https://custom-issuer.com',
+        clientId: 'custom-client-id',
+        resource: 'https://api.example.com',
+      });
+      await oidc.refreshToken('oldRefreshToken');
+
+      expect(mockUseRefreshToken).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resource: 'https://api.example.com',
+        }),
+      );
     });
 
     it('should handle missing user in storage', async () => {
@@ -276,6 +310,99 @@ describe('OIDC', () => {
       const oidc = createOidc(sdk, 'projectID');
       await expect(oidc.refreshToken('refreshToken')).rejects.toThrow(
         'User not found in storage to refresh token',
+      );
+    });
+  });
+
+  describe('resource persistence across signin -> finishLogin -> refreshToken', () => {
+    // Use a real in-memory store rather than a fixed mockReturnValue, since this scenario
+    // needs setItem/getItem/removeItem to actually round-trip across the three calls.
+    let store: Map<string, string>;
+
+    beforeEach(() => {
+      store = new Map();
+      Storage.prototype.getItem = jest.fn(
+        (key: string) => store.get(key) ?? null,
+      );
+      Storage.prototype.setItem = jest.fn((key: string, value: string) => {
+        store.set(key, value);
+      });
+      Storage.prototype.removeItem = jest.fn((key: string) => {
+        store.delete(key);
+      });
+    });
+
+    it('should persist a per-call resource so refreshToken honors it even when oidcConfig.resource is unset', async () => {
+      const mockCreateSigninRequest = jest
+        .fn()
+        .mockResolvedValue({ url: 'mockUrl' });
+      const mockProcessSigninResponse = jest.fn().mockResolvedValue({
+        id_token: 'idToken',
+        session_state: 'sessionState',
+        profile: { sub: 'user123' },
+      });
+      const mockUseRefreshToken = jest
+        .fn()
+        .mockResolvedValue({ id_token: 'newIdToken' });
+      (OidcClient as jest.Mock).mockImplementation(() => ({
+        createSigninRequest: mockCreateSigninRequest,
+        processSigninResponse: mockProcessSigninResponse,
+        useRefreshToken: mockUseRefreshToken,
+      }));
+
+      // No `resource` set on oidcConfig - it's only ever passed per-call to loginWithRedirect.
+      const oidc = createOidc(sdk, 'projectID', {
+        issuer: 'https://custom-issuer.com',
+        clientId: 'custom-client-id',
+      });
+
+      await oidc.loginWithRedirect(
+        { resource: 'https://api.example.com' },
+        true,
+      );
+      await oidc.finishLogin('https://my-app.com/redirect?code=1&state=2');
+      await oidc.refreshToken('oldRefreshToken');
+
+      expect(mockUseRefreshToken).toHaveBeenCalledWith(
+        expect.objectContaining({ resource: 'https://api.example.com' }),
+      );
+      // the pending key used to ferry the resource across the redirect should be cleaned up
+      expect(store.has('custom-client-id_user_pending_resource')).toBe(false);
+    });
+
+    it('should prefer a per-call resource over oidcConfig.resource for the signin that requested it', async () => {
+      const mockCreateSigninRequest = jest
+        .fn()
+        .mockResolvedValue({ url: 'mockUrl' });
+      const mockProcessSigninResponse = jest.fn().mockResolvedValue({
+        id_token: 'idToken',
+        session_state: 'sessionState',
+        profile: { sub: 'user123' },
+      });
+      const mockUseRefreshToken = jest
+        .fn()
+        .mockResolvedValue({ id_token: 'newIdToken' });
+      (OidcClient as jest.Mock).mockImplementation(() => ({
+        createSigninRequest: mockCreateSigninRequest,
+        processSigninResponse: mockProcessSigninResponse,
+        useRefreshToken: mockUseRefreshToken,
+      }));
+
+      const oidc = createOidc(sdk, 'projectID', {
+        issuer: 'https://custom-issuer.com',
+        clientId: 'custom-client-id',
+        resource: 'https://config-level.example.com',
+      });
+
+      await oidc.loginWithRedirect(
+        { resource: 'https://per-call.example.com' },
+        true,
+      );
+      await oidc.finishLogin('https://my-app.com/redirect?code=1&state=2');
+      await oidc.refreshToken('oldRefreshToken');
+
+      expect(mockUseRefreshToken).toHaveBeenCalledWith(
+        expect.objectContaining({ resource: 'https://per-call.example.com' }),
       );
     });
   });
@@ -477,6 +604,182 @@ describe('OIDC', () => {
       expect(OidcClient).toHaveBeenCalledWith(
         expect.objectContaining({
           scope: 'openid profile',
+        }),
+      );
+    });
+
+    it('should normalize a well-known URL issuer to the bare issuer authority', async () => {
+      const mockCreateSigninRequest = jest
+        .fn()
+        .mockResolvedValue({ url: 'mockUrl' });
+      (OidcClient as jest.Mock).mockImplementation(() => ({
+        createSigninRequest: mockCreateSigninRequest,
+      }));
+
+      const oidc = createOidc(sdk, 'projectID', {
+        issuer:
+          'https://api.descope.com/v1/apps/P123/.well-known/openid-configuration',
+        clientId: 'inbound-client-id',
+      });
+      await oidc.loginWithRedirect({}, true);
+
+      expect(OidcClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authority: 'https://api.descope.com/v1/apps/P123',
+        }),
+      );
+    });
+
+    it('should normalize a well-known URL issuer with a trailing slash', async () => {
+      const mockCreateSigninRequest = jest
+        .fn()
+        .mockResolvedValue({ url: 'mockUrl' });
+      (OidcClient as jest.Mock).mockImplementation(() => ({
+        createSigninRequest: mockCreateSigninRequest,
+      }));
+
+      const oidc = createOidc(sdk, 'projectID', {
+        issuer:
+          'https://api.descope.com/v1/apps/P123/.well-known/openid-configuration/',
+        clientId: 'inbound-client-id',
+      });
+      await oidc.loginWithRedirect({}, true);
+
+      expect(OidcClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authority: 'https://api.descope.com/v1/apps/P123',
+        }),
+      );
+    });
+
+    it('should produce an identical authority across separate calls built from the same well-known URL (idempotence)', async () => {
+      const mockCreateSigninRequest = jest
+        .fn()
+        .mockResolvedValue({ url: 'mockUrl' });
+      (OidcClient as jest.Mock).mockImplementation(() => ({
+        createSigninRequest: mockCreateSigninRequest,
+      }));
+
+      const config = {
+        issuer:
+          'https://api.descope.com/v1/apps/P123/.well-known/openid-configuration',
+        clientId: 'inbound-client-id',
+      };
+
+      await createOidc(sdk, 'projectID', config).loginWithRedirect({}, true);
+      await createOidc(sdk, 'projectID', config).loginWithRedirect({}, true);
+
+      const authorities = (OidcClient as jest.Mock).mock.calls.map(
+        ([settings]) => settings.authority,
+      );
+      expect(authorities[0]).toBe(authorities[1]);
+      expect(authorities[0]).toBe('https://api.descope.com/v1/apps/P123');
+    });
+
+    it('should prefer issuer over applicationId when both are provided', async () => {
+      const mockCreateSigninRequest = jest
+        .fn()
+        .mockResolvedValue({ url: 'mockUrl' });
+      (OidcClient as jest.Mock).mockImplementation(() => ({
+        createSigninRequest: mockCreateSigninRequest,
+      }));
+
+      const oidc = createOidc(sdk, 'projectID', {
+        issuer: 'https://custom-issuer.com',
+        clientId: 'custom-client-id',
+        applicationId: 'app123',
+      });
+      await oidc.loginWithRedirect({}, true);
+
+      expect(OidcClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authority: 'https://custom-issuer.com',
+          client_id: 'custom-client-id',
+          scope: 'openid',
+        }),
+      );
+    });
+
+    it('should keep federated and inbound default scopes distinct regardless of issuer URL shape', async () => {
+      const mockCreateSigninRequest = jest
+        .fn()
+        .mockResolvedValue({ url: 'mockUrl' });
+      (OidcClient as jest.Mock).mockImplementation(() => ({
+        createSigninRequest: mockCreateSigninRequest,
+      }));
+
+      // An inbound-app issuer that happens NOT to follow the illustrative
+      // `/v1/apps/{projectId}` shape - scope must still default to 'openid',
+      // since it's keyed on the issuer field being supplied, not URL sniffing.
+      const oidc = createOidc(sdk, 'projectID', {
+        issuer: 'https://totally-custom-domain.example.com',
+        clientId: 'inbound-client-id',
+      });
+      await oidc.loginWithRedirect({}, true);
+
+      expect(OidcClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scope: 'openid',
+        }),
+      );
+
+      jest.clearAllMocks();
+      (OidcClient as jest.Mock).mockImplementation(() => ({
+        createSigninRequest: mockCreateSigninRequest,
+      }));
+
+      const federatedOidc = createOidc(sdk, 'projectID', {
+        applicationId: 'app123',
+      });
+      await federatedOidc.loginWithRedirect({}, true);
+
+      expect(OidcClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scope: 'openid email roles descope.custom_claims offline_access',
+        }),
+      );
+    });
+
+    it('should pass a string resource to the OidcClient constructor', async () => {
+      const mockCreateSigninRequest = jest
+        .fn()
+        .mockResolvedValue({ url: 'mockUrl' });
+      (OidcClient as jest.Mock).mockImplementation(() => ({
+        createSigninRequest: mockCreateSigninRequest,
+      }));
+
+      const oidc = createOidc(sdk, 'projectID', {
+        issuer: 'https://custom-issuer.com',
+        clientId: 'custom-client-id',
+        resource: 'https://api.example.com',
+      });
+      await oidc.loginWithRedirect({}, true);
+
+      expect(OidcClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resource: 'https://api.example.com',
+        }),
+      );
+    });
+
+    it('should pass an array resource to the OidcClient constructor', async () => {
+      const mockCreateSigninRequest = jest
+        .fn()
+        .mockResolvedValue({ url: 'mockUrl' });
+      (OidcClient as jest.Mock).mockImplementation(() => ({
+        createSigninRequest: mockCreateSigninRequest,
+      }));
+
+      const oidc = createOidc(sdk, 'projectID', {
+        issuer: 'https://custom-issuer.com',
+        clientId: 'custom-client-id',
+        resource: ['https://api-a.example.com', 'https://api-b.example.com'],
+      });
+      await oidc.loginWithRedirect({}, true);
+
+      expect(OidcClient).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resource: ['https://api-a.example.com', 'https://api-b.example.com'],
         }),
       );
     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -931,7 +931,7 @@ importers:
         version: 2.0.5
       ts-jest:
         specifier: ^29.0.0
-        version: 29.2.5(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(esbuild@0.25.0)(jest@29.7.0(@types/node@20.17.13)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(esbuild@0.25.0)(jest@29.7.0(@types/node@20.17.13)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.4.5)))(typescript@5.4.5)
       ts-node:
         specifier: 10.9.2
         version: 10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.4.5)
@@ -1412,6 +1412,8 @@ importers:
         specifier: ^5.0.2
         version: 5.4.5
 
+  packages/sdks/react-sdk/dist/cjs: {}
+
   packages/sdks/vue-sdk:
     dependencies:
       '@descope/access-key-management-widget':
@@ -1586,7 +1588,7 @@ importers:
     devDependencies:
       '@descope/web-components-ui':
         specifier: latest
-        version: 3.14.1
+        version: 3.14.8
       '@open-wc/rollup-plugin-html':
         specifier: 1.2.5
         version: 1.2.5
@@ -1715,7 +1717,7 @@ importers:
         version: 1.0.2
       ts-jest:
         specifier: ^29.0.0
-        version: 29.1.5(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(jest@29.7.0(@types/node@20.17.13)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.1.5(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(esbuild@0.25.3)(jest@29.7.0(@types/node@20.17.13)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.4.5)))(typescript@5.4.5)
       ts-node:
         specifier: 10.9.2
         version: 10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.4.5)
@@ -1863,7 +1865,7 @@ importers:
         version: 2.0.5
       ts-jest:
         specifier: ^29.0.0
-        version: 29.1.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(esbuild@0.25.3)(jest@29.7.0(@types/node@20.17.13)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.1.5(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(esbuild@0.25.3)(jest@29.7.0(@types/node@20.17.13)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.4.5)))(typescript@5.4.5)
       ts-node:
         specifier: 10.9.2
         version: 10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.4.5)
@@ -1911,7 +1913,7 @@ importers:
         version: link:../../libs/e2e-helpers
       '@descope/web-components-ui':
         specifier: latest
-        version: 3.14.1
+        version: 3.14.8
       '@open-wc/rollup-plugin-html':
         specifier: 1.2.5
         version: 1.2.5
@@ -2046,7 +2048,7 @@ importers:
         version: 1.0.2
       ts-jest:
         specifier: ^29.0.0
-        version: 29.1.5(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(jest@29.7.0(@types/node@20.17.13)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.1.5(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(esbuild@0.25.3)(jest@29.7.0(@types/node@20.17.13)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.4.5)))(typescript@5.4.5)
       ts-node:
         specifier: 10.9.2
         version: 10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.4.5)
@@ -2092,7 +2094,7 @@ importers:
         version: link:../../libs/e2e-helpers
       '@descope/web-components-ui':
         specifier: latest
-        version: 3.14.1
+        version: 3.14.8
       '@open-wc/rollup-plugin-html':
         specifier: 1.2.5
         version: 1.2.5
@@ -2273,7 +2275,7 @@ importers:
         version: link:../../libs/e2e-helpers
       '@descope/web-components-ui':
         specifier: latest
-        version: 3.14.1
+        version: 3.14.8
       '@open-wc/rollup-plugin-html':
         specifier: 1.2.5
         version: 1.2.5
@@ -2408,7 +2410,7 @@ importers:
         version: 1.0.2
       ts-jest:
         specifier: ^29.0.0
-        version: 29.1.5(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(jest@29.7.0(@types/node@20.17.13)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.1.5(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(esbuild@0.25.3)(jest@29.7.0(@types/node@20.17.13)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.4.5)))(typescript@5.4.5)
       ts-node:
         specifier: 10.9.2
         version: 10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.4.5)
@@ -2457,7 +2459,7 @@ importers:
         version: link:../../libs/e2e-helpers
       '@descope/web-components-ui':
         specifier: latest
-        version: 3.14.1
+        version: 3.14.8
       '@open-wc/rollup-plugin-html':
         specifier: 1.2.5
         version: 1.2.5
@@ -2638,7 +2640,7 @@ importers:
         version: link:../../libs/e2e-helpers
       '@descope/web-components-ui':
         specifier: latest
-        version: 3.14.1
+        version: 3.14.8
       '@open-wc/rollup-plugin-html':
         specifier: 1.2.5
         version: 1.2.5
@@ -2773,7 +2775,7 @@ importers:
         version: 1.0.2
       ts-jest:
         specifier: ^29.0.0
-        version: 29.1.5(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(jest@29.7.0(@types/node@20.17.13)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.1.5(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(esbuild@0.25.3)(jest@29.7.0(@types/node@20.17.13)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.4.5)))(typescript@5.4.5)
       ts-node:
         specifier: 10.9.2
         version: 10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.4.5)
@@ -2822,7 +2824,7 @@ importers:
         version: link:../../libs/e2e-helpers
       '@descope/web-components-ui':
         specifier: latest
-        version: 3.14.1
+        version: 3.14.8
       '@open-wc/rollup-plugin-html':
         specifier: 1.2.5
         version: 1.2.5
@@ -3013,7 +3015,7 @@ importers:
         version: link:../../libs/e2e-helpers
       '@descope/web-components-ui':
         specifier: latest
-        version: 3.14.1
+        version: 3.14.8
       '@open-wc/rollup-plugin-html':
         specifier: 1.2.5
         version: 1.2.5
@@ -3148,7 +3150,7 @@ importers:
         version: 1.0.2
       ts-jest:
         specifier: ^29.0.0
-        version: 29.1.5(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(jest@29.7.0(@types/node@20.17.13)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.1.5(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(esbuild@0.25.3)(jest@29.7.0(@types/node@20.17.13)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.4.5)))(typescript@5.4.5)
       ts-node:
         specifier: 10.9.2
         version: 10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.4.5)
@@ -3197,7 +3199,7 @@ importers:
         version: link:../../libs/e2e-helpers
       '@descope/web-components-ui':
         specifier: latest
-        version: 3.14.1
+        version: 3.14.8
       '@open-wc/rollup-plugin-html':
         specifier: 1.2.5
         version: 1.2.5
@@ -3332,7 +3334,7 @@ importers:
         version: 1.0.2
       ts-jest:
         specifier: ^29.0.0
-        version: 29.1.5(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(jest@29.7.0(@types/node@20.17.13)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.1.5(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(esbuild@0.25.3)(jest@29.7.0(@types/node@20.17.13)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.4.5)))(typescript@5.4.5)
       ts-node:
         specifier: 10.9.2
         version: 10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.4.5)
@@ -4521,116 +4523,116 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
-  '@descope-ui/common@3.14.1':
-    resolution: {integrity: sha512-rx64IRbx6RQ1J6pvXHQ9rDsqJPgAwV/37vmQZA+4SYbPEfQ33q7PSXmUbRcz2AZD8LqqItwq28eSzT1x+QO6JQ==}
+  '@descope-ui/common@3.14.8':
+    resolution: {integrity: sha512-NAQB7D9p25bj7RqT/bi6IRQ07g/MAYAdhSVW7MEGlH46iIYx4NQ92Jng+XTbITNtOw+ZzXax9T63dyHZCuAPag==}
 
-  '@descope-ui/descope-address-field@3.14.1':
-    resolution: {integrity: sha512-4I9Lpl2O7kaKBKb3xbosRttE2vBwr2hTeXmGz1gkZAjsNsTZByUH8NkFZWpjKZPlWTpB2wSKuoDzRwqEf8Tv1w==}
+  '@descope-ui/descope-address-field@3.14.8':
+    resolution: {integrity: sha512-XyG0QRpUUEpVK/07HgUTXW5jUThS9qzxo2Z5C7gzqUuLxHowq/QGbxKogaWotstNHOYHkt7cGNMEUg7Zl+XBOg==}
 
-  '@descope-ui/descope-anchored@3.14.1':
-    resolution: {integrity: sha512-oBcDWpWLB3WQ0RcMglVFpVlGgXTS4qRJGhG1Pi8xfok0PY0yAnqJ0065a+dKgcF/g22GArgZ5aHogqAcBm6iIw==}
+  '@descope-ui/descope-anchored@3.14.8':
+    resolution: {integrity: sha512-x9VEG4DvXoBFa4OP7r7rXED3wnOgSEXIpvJzC2NawQkMXE5mQoKXHhe+3cr5edg02oAo3xcDfh2oqPOOePinIg==}
 
-  '@descope-ui/descope-apps-list@3.14.1':
-    resolution: {integrity: sha512-kvn9M2nL0SNz5yduUPPfVWS5PXnOekplbipAy81NGq0S0M7ik190JhtnDhhSJbCmU7GK8KmMbTRl9I264CH60A==}
+  '@descope-ui/descope-apps-list@3.14.8':
+    resolution: {integrity: sha512-oku6Ad+8CWDYAO4c9iNwSE2CavuLIox4bwnaUPULpByJF7b9Q0MdICtWgg4p/x5grDIx4wYOjBzCrbUp9UlH8A==}
 
-  '@descope-ui/descope-attachment@3.14.1':
-    resolution: {integrity: sha512-/8419+EFdEAevYK3Di++Aj0wwinpuIVPWiCqglxzQJrBH1SZMAdcYA50Qj9HB1F4fHdgx9Yvj8f3TDuaCHyqew==}
+  '@descope-ui/descope-attachment@3.14.8':
+    resolution: {integrity: sha512-lK3ASiTHGUGKtdBY7mrh4cY2zgnkeWptKPUY112qQg67fE+neRz/J7IiztJZ3K/d3UDt7FqAhJyYePVdPltRMA==}
 
-  '@descope-ui/descope-autocomplete-field@3.14.1':
-    resolution: {integrity: sha512-AmJyXvz2Hfx2HKjPOK40gB8a6j1JY0ywcdQn2qMgyLIKE3vFE+gJtqKbnBqfALbzt2u1aElQm85olRDf+0xpsg==}
+  '@descope-ui/descope-autocomplete-field@3.14.8':
+    resolution: {integrity: sha512-Jf9hkjSxEtHSOM+GxavNttnai9ibQRxfhXY6ZCPnAo1dwfBfec06WX8/x3uFP1nWldT6fO2Pp2ScoNK3GQMJdg==}
 
-  '@descope-ui/descope-avatar@3.14.1':
-    resolution: {integrity: sha512-7As0q7QWqV2ikVsAN5b+AcpIzZWEya6JoT73VJx1pVp9ZxP9Ahk5qZXdtPBFP+08B109Fa5l7ndYcLYsKibRYA==}
+  '@descope-ui/descope-avatar@3.14.8':
+    resolution: {integrity: sha512-wPa1E99H89PUW+XrMFi2QJEnE8OJF+22/V/jov/c1pNKlGSYXdyxlS9IVMhY2MmnjfeAWy7gCY1Cu44Mt3Zc5w==}
 
-  '@descope-ui/descope-badge@3.14.1':
-    resolution: {integrity: sha512-W0UTF1E59gFrtUz/mmr1Rr39lsW+Q12BoLrMvFXzL0PKiI/ViDKCMFEUbHeLbnkq4g7NEezZgQ3X1uA9mAKafQ==}
+  '@descope-ui/descope-badge@3.14.8':
+    resolution: {integrity: sha512-DrzXtEQy6WJreU3LeTxnUtiMjONloUp1H8mHCalbMZea419QjyEZjFEKhc32+7uGT8ts2iCSlemHKKSfigh97A==}
 
-  '@descope-ui/descope-button@3.14.1':
-    resolution: {integrity: sha512-SFmP2UjHOr+NqJCwMBaFmCKxIXfnI6hsmJBu9O0e+MnkkZyHJzrINb26Ke2RNhqsu+i5nxtNrw5cEK5MWdzDYQ==}
+  '@descope-ui/descope-button@3.14.8':
+    resolution: {integrity: sha512-RfN9NQshVRHFVMb5bJHbP6Mtd8zZzHjOnpwU3lKeIQFzOr2zixiTnAlAQ/VoJoX7+nGFZakEGBJ3Yev9MDm+2Q==}
 
-  '@descope-ui/descope-collapsible-container@3.14.1':
-    resolution: {integrity: sha512-n56xBI1/EATa0ltNfCNjvMzPVCoUXE+PS+HhdWlpnEFyOJ49zCU8wIDDKwXTabkVc67R8EbnNVmPpi44AFRM/w==}
+  '@descope-ui/descope-collapsible-container@3.14.8':
+    resolution: {integrity: sha512-pwX3J4EPCt/w2B1z7KD+ZNwk7VZkizWgXN7ZiCQuMnEL1yAYdpjGQ22Le4ZlJA1rZuYiqUxO8add2tFvdXGRxQ==}
 
-  '@descope-ui/descope-combo-box@3.14.1':
-    resolution: {integrity: sha512-s0TDdUp2yMbn/sf9Szc2AUdrOFfK+m/+dEceMyoniyltBsHB6T/u2n/dW3ZO3YYi3/Qo8tAEFFryVgH3s6u4Gw==}
+  '@descope-ui/descope-combo-box@3.14.8':
+    resolution: {integrity: sha512-Uvu4dboaQr9sKhyBdQRyeW/dOOcSQ5SNz5BvfcbQPo8wV0UHs/6N4l2mkKPHFV1oQ8aDd+mpZjt+KrzBzetV6Q==}
 
-  '@descope-ui/descope-country-subdivision-city-field@3.14.1':
-    resolution: {integrity: sha512-6nz5bGWy0apNdRcsMkOJ/QUKvj0W5LWHJPDwZpDjy8BDQDhkPkmXhsvVFogo6yE/giu6VcLiBkdTRplgQpQRlw==}
+  '@descope-ui/descope-country-subdivision-city-field@3.14.8':
+    resolution: {integrity: sha512-Mj0xmiJgEWae3ArO2HBYnhh0rQzVpO7JvjfEbBVBk4DePbEz+Vghm1Rb6sjjJQNYNyZc/KrRtGD22O3VlE4VAQ==}
 
-  '@descope-ui/descope-enriched-text@3.14.1':
-    resolution: {integrity: sha512-45vRYKLr/ObkDzTNBOCuQca8hK31sURIFuCSHFfsJZghuhHCXXmZCk+aDG62KdTrrBI77mXIssc2tKAg0aoCnw==}
+  '@descope-ui/descope-enriched-text@3.14.8':
+    resolution: {integrity: sha512-HI3PVyZ42nOij66n9BweWsOQA6jEg97MkvVLDSjPXeczHz5NDgwz0L5AT5+CuPEyDHiF+YzLFhOKArEpes2CrA==}
 
-  '@descope-ui/descope-icon@3.14.1':
-    resolution: {integrity: sha512-Eik9k4LDsON6/GyRBHhrPwOWAKZOCcMmjfAHgG8YDWjBCVSA7Mt4xwMqqcI/GTArmNAtAm1LhwFqFnkdQjMGoA==}
+  '@descope-ui/descope-icon@3.14.8':
+    resolution: {integrity: sha512-NF77hjIXebqy6999qqgCU7sxOahFBquFVEbS3WbLUlnh/WeACqWHLy6ApzJdGLvBZC+gPE0cs4XsZtFOw/C2Pw==}
 
-  '@descope-ui/descope-image@3.14.1':
-    resolution: {integrity: sha512-EhXr6wxWhoImoCmT91IEEa9gMOkxBNRfvtoXmJgOa3PSUns9cYheydZ5rpoj8rSKYbsA8CxiQO/KSTz7mmzFSQ==}
+  '@descope-ui/descope-image@3.14.8':
+    resolution: {integrity: sha512-HHzLTNNa3oWwaRfiFoO+I5NNPg5Gm1aliCLUePOJfrX6vVSBCA/lVTniYAb/3HQ9+j1Uro5U+eB4ze9Pd1EhQg==}
 
-  '@descope-ui/descope-link@3.14.1':
-    resolution: {integrity: sha512-71kOesn6g6BsQGc8XCt4mSkuT0sZKHDJIqW0YEl6u2Hu/+QX1FxfCyOGHR8JVskkY2ONWc9vaSYW9eEGDZgkbw==}
+  '@descope-ui/descope-link@3.14.8':
+    resolution: {integrity: sha512-jjMB2+fGWAItL6+dqW7RUho9e7Rp5jLh3VQvGEibYyqS0plbAVAcsnWKt8FZ3XIyETf5TdY1ss0Zklmx3W8f/Q==}
 
-  '@descope-ui/descope-list-item@3.14.1':
-    resolution: {integrity: sha512-aF7W56vhN1RNKPTnlCem80iqepqxNRLXgHKZ0qLDNCqaZpM/j6nvDVL0PkaNehik75ukHMy2O8zgT96xkDQ+pA==}
+  '@descope-ui/descope-list-item@3.14.8':
+    resolution: {integrity: sha512-5XLMNtSq51GU8y4blDqtO6l43yLrUMtSiGt0fzQW4uHhwnEIsVq089SzUfaExMNODSiJ4xbJDBSz0OEI1rUXWg==}
 
-  '@descope-ui/descope-list@3.14.1':
-    resolution: {integrity: sha512-OLZUj08kgb6OkUvjKOUVMhBMScMpvlCFxls+HRIeiQDQzO/XU1hCyO5J2HRk1woxUz/2ZOedEX9mZOZ+OSG5bg==}
+  '@descope-ui/descope-list@3.14.8':
+    resolution: {integrity: sha512-0onki6hSBF7+cVMKMkbCMYE4ppKVia08qeADja3uadxMeRKEbMk2Df8hATNh5TKaiOogsuo9fdKcPBLR4TPeVg==}
 
-  '@descope-ui/descope-month-day-field-picker@3.14.1':
-    resolution: {integrity: sha512-KPiRLQ+kTsvYKJJlQs156/O4a4IO+L+4SM34/E4HIbffAqufWH4aV5/qMzPm5bVoh0W7AGf3XTo2QONwofX9mg==}
+  '@descope-ui/descope-month-day-field-picker@3.14.8':
+    resolution: {integrity: sha512-8sTxbZof4QCy+aYitaLlBKZ3pp2OuwbZGdEmZ4b65v5Jy5nPZ6OkRceYAzB+wj9Utj7DtaEmziUkQO0A2EkuMw==}
 
-  '@descope-ui/descope-month-day-field@3.14.1':
-    resolution: {integrity: sha512-JFo3R5FyEHF+jd5VfgxFh1qx08gMWOl+Wk0vYxUNadZ4tqZ9DxQjE5dYNY4TR3TbWEs4zvymHCH3y+gcc6wi3w==}
+  '@descope-ui/descope-month-day-field@3.14.8':
+    resolution: {integrity: sha512-piOId4WCHK1bgrO3egF9o1MC/cilHmRXDuzMMzmm02g5mWNKXAr5umWp96LXkMQZb+EOFN6ZuMw0Vfu1JJEVbA==}
 
-  '@descope-ui/descope-multi-line-mappings@3.14.1':
-    resolution: {integrity: sha512-HQcDFctDQ1sQdhVMcMDYaTL96OtotNdTQsaLxIdE14DI/0KJq9c5pkU3r+F1fadWnDaqtun0JZVs8KEYolQReA==}
+  '@descope-ui/descope-multi-line-mappings@3.14.8':
+    resolution: {integrity: sha512-TPL35hdHqXmXaLT1e6X2Q/nSZZOn3JtVHstrnhJr2SR/PUiaiYCxPTv++y0CbZyHm55wNxiN7U3QZlyZ6opE+w==}
 
-  '@descope-ui/descope-multi-select-combo-box@3.14.1':
-    resolution: {integrity: sha512-oO7ggTsYxMMMts1F2dY/R8Gx7SZZ1rexlIT1Y/PNXC75A4VFfWtlc4EEYD9e9Q258u9VEeE7WpZNE1Kx0b7mTA==}
+  '@descope-ui/descope-multi-select-combo-box@3.14.8':
+    resolution: {integrity: sha512-6ybR2YWZLWhEePrHxEt6MylqgP480WpEl0NoFeKv9JpS7wphrOTBV6k8MkNLkoYEbd6MTrstcnI/3xG2kkm1EQ==}
 
-  '@descope-ui/descope-multi-sso@3.14.1':
-    resolution: {integrity: sha512-WLhofGaW4yNU2g6C5vkpH3F0+45qPmV3bJYo1X9sxE+tXiuFeOu/jmxbaU3wC2kRxcyPp4uyPOW5QT9enXDExA==}
+  '@descope-ui/descope-multi-sso@3.14.8':
+    resolution: {integrity: sha512-Ney+Zr/eGfy4/dBbv4b++sVIdWDqyl3WeRdCuOAal/ibYbSeVIJ+OeqMi1c/CkCfFi4jz52bDBq9KOGY5cFdcQ==}
 
-  '@descope-ui/descope-outbound-app-button@3.14.1':
-    resolution: {integrity: sha512-ykSnFXeQ8gTu1CaJ6T/D4AIr2ialMt1YCkfwkbjwyhxAZCCIN3uNXE8aY4WZ67b3eYNLref1hKloqjKk8eOXbw==}
+  '@descope-ui/descope-outbound-app-button@3.14.8':
+    resolution: {integrity: sha512-IQmmqNPbma1fv6g7Li2Q+TZ1peGU5GAF9OE5kOpj+3fvAi+Jv9qg/lw/7i3va1j5AR5/xHP1N4Hk8+jPWgdZXA==}
 
-  '@descope-ui/descope-outbound-apps@3.14.1':
-    resolution: {integrity: sha512-eBwH8aRiYi0EztUp5/joP3xeDX89tij6mDstHB8uftT5gdr3wb26u4cy5G4XQFCcqiFL/sEuLaOPmntIirR14w==}
+  '@descope-ui/descope-outbound-apps@3.14.8':
+    resolution: {integrity: sha512-3q3IuqcYLvWj+142xjKqq5U2VIX1wUyrrPw1zcPjLWOEVom0aH9fWnQcV+veqRsmH4YvWn4eOIzCbIaHppyFUw==}
 
-  '@descope-ui/descope-password-strength@3.14.1':
-    resolution: {integrity: sha512-kRDUwKFyvuCeEAFp80SN3JrRGBSttOpuG0deJARFZorZoJo3UVSfCIirhfFZYNqNDon/HBfU7CtYQmWQNMAHNw==}
+  '@descope-ui/descope-password-strength@3.14.8':
+    resolution: {integrity: sha512-gekWtHTSMyTbAJjme19Lc5ntOT0dsgWIZgsvPY1BZ45MRwtAHXSjWh3DQcc6lyR0mX+IGEyPcis9qh0HPggJMg==}
 
-  '@descope-ui/descope-ponyhot@3.14.1':
-    resolution: {integrity: sha512-6Qjt9mViZ6oBp6jZPDKzPOW1YmU/+Y+GVMUKWB7JLTlyTeb7zJ5UAC4Fx0Um/2Y1FgNdwMgrTfqcbmi2JEc6AA==}
+  '@descope-ui/descope-ponyhot@3.14.8':
+    resolution: {integrity: sha512-MV2Ol8F2G0BItN4891laWx4S44vN2oxR97EySKD5iGlBk4pVdAPci+OsDvOwWkmTVBPR+rpnSW4tUepYQn85HQ==}
 
-  '@descope-ui/descope-recovery-codes@3.14.1':
-    resolution: {integrity: sha512-rxeVlnAmEL805hNixB0v8xgWNAYiDdu7zc1duyYrlMnKn50q3f+3hNIaBQiOZ6e/rEkeu07/s3Vtevg3jI4xsw==}
+  '@descope-ui/descope-recovery-codes@3.14.8':
+    resolution: {integrity: sha512-owhGYOIbVEjU6Cwk+fiaW03TG6TopnLCGpPGJD+IoAltZLz8jiYm/dUXGBmaqITc8yHuQhZQjdD9FwhEKm0KeQ==}
 
-  '@descope-ui/descope-text-field@3.14.1':
-    resolution: {integrity: sha512-38rMIQIF0j1kjO7MQzwiIfSIjZjwvTKMhb6v3V1JxW9/Zi5J9wNjaqsZ+2cn8mTgVo1Lq7yCvUI5yJoGKjzp/A==}
+  '@descope-ui/descope-text-field@3.14.8':
+    resolution: {integrity: sha512-1CTruC2uX6zGyPpUbbjjZWWElL8g6qE1q12MfxPHElsxAviVceCYhCLHJTARCBxN1YyHtkwsnVGUBqNhL551MA==}
 
-  '@descope-ui/descope-text@3.14.1':
-    resolution: {integrity: sha512-ys8Z0DiXYAuY2m9y2MeFmSUD0fPCU6JneSQLaPtH+u6a91kOgJdzBfEBbCe7dDJSJBnJCL3fAx3H32CcrG9ZSA==}
+  '@descope-ui/descope-text@3.14.8':
+    resolution: {integrity: sha512-Oh8122Z1Poz4mG0fexP4MUQ8QyjnoD613+C3WfK8beeYGyyxzwKfsvx/GJKPXoC5zKpy6NiA65A9mpXqAJ8HnA==}
 
-  '@descope-ui/descope-timer-button@3.14.1':
-    resolution: {integrity: sha512-MgCn8YkI2wtGmyh7E1N7021yNN/ykmrbUmYFc1ZwS4KOwjlsTwLfNVeN0zG+cH0t94CEuInT31DMyM6zuL4ebg==}
+  '@descope-ui/descope-timer-button@3.14.8':
+    resolution: {integrity: sha512-Y4W48/IEu/Fvl6z+trktwY1nSic6lfQxs35ip5acDuHYaL9IPvDjv4Zr9AGglW1mAtrBM1fPoWDsKeEiDKk2RA==}
 
-  '@descope-ui/descope-timer@3.14.1':
-    resolution: {integrity: sha512-i+wH3qGn0oPww8abiHGbdPwJkuocL6jxNgxJleG2qaJyQ+R/VgUCsu2zO0z7MM8ILdj2Oqa4A0Jc5LkMXzbbrg==}
+  '@descope-ui/descope-timer@3.14.8':
+    resolution: {integrity: sha512-Ddf+X6U3+tPMe07564DAlFJUWTvh2sqcj3+PbfNwIa9nG11Yg8L3edvwixDD3OS8Jhdho3Ixse9gwokComXcHw==}
 
-  '@descope-ui/descope-tooltip@3.14.1':
-    resolution: {integrity: sha512-flm1kKLX6rMe8r9lVyi9K3xWUWJ45pxLDXrBvJg0/duAY7UXQ2UUHOl39gFq2hcWEI98FT3bx7kJTTDvblTEKw==}
+  '@descope-ui/descope-tooltip@3.14.8':
+    resolution: {integrity: sha512-9nrNaUnoTp6C/EQgir89lDJQYejCfa/v7+IivFZXkZrwgnKe54s/EFXOwVXzDkvzsSwhF5NwYsZt31kc9fTlyA==}
 
-  '@descope-ui/descope-trusted-devices@3.14.1':
-    resolution: {integrity: sha512-VN3yLNe8jtMXMFTkephA9d1iZH4UJtENHvNtyFsCu/37JuWCDYV9n4GBZd4xpvRUL865O8nFAUonwZ9roVNOMg==}
+  '@descope-ui/descope-trusted-devices@3.14.8':
+    resolution: {integrity: sha512-TiAodIDHkPcH9SxH006W1aqy0ovJUQ8d7b5NLAvUOnNMGaWaHVN4qtCLvYHtnnfLilszJzZQFK4tARNdqAu78w==}
 
-  '@descope-ui/descope-user-passkeys@3.14.1':
-    resolution: {integrity: sha512-Sz88WfTwzM97GURGBNXUpXM3MFyFPd6lCRzrCcygQKW6OAnkDrGsGB0UjtpSa850ndJlkNIkMCRDuo7Xc8dN1w==}
+  '@descope-ui/descope-user-passkeys@3.14.8':
+    resolution: {integrity: sha512-EVJNXwpC5OHHpyeGmzyo3l7umgGAAs2U5jHBJnSNu0CNFNv5WEA+C9J2vPA/1RIf5oDm+56ZSEnkRmyDoROc5Q==}
 
-  '@descope-ui/theme-globals@3.14.1':
-    resolution: {integrity: sha512-nBD3xH3Dg0xOx4PYCVa9nYy4VdZE/Zk2ZOr/TJQyN+wkBBVYB5M6ADoqYnfBSznP9doo7xmdI4JOJ7shwpsr8Q==}
+  '@descope-ui/theme-globals@3.14.8':
+    resolution: {integrity: sha512-rb0f8Rz3Ost/k6Mmfp8ylGGhjoC7Z11ZZBx2zdfPvn34fXv4KEPbiTuPS5CX0wPUX8wytcMjv/xN6Lo6oPUtXw==}
 
-  '@descope-ui/theme-input-wrapper@3.14.1':
-    resolution: {integrity: sha512-I9OGdxXsmHyAIIgetAT2IPldcLRc7QEph47FOk58h7nzSV08b529asS6JR5D9+7C1ci0OI64LvDT56591saO4A==}
+  '@descope-ui/theme-input-wrapper@3.14.8':
+    resolution: {integrity: sha512-lmdd5CLCQHwaEfAZmWt+OpHzfmkpBCuEqSVllfAnXA99CVUU6wKpKPzrRd1UMRy+U3n3SZaxvsbvqlMc4y9KZQ==}
 
   '@descope/core-js-sdk@2.40.0':
     resolution: {integrity: sha512-hFr/SzQO0QbyDaI1LlN//HKi3hXNJAnU0lFUpsqwo92YmCvYzhSZ7r6aBvT0DU2jaXmvt/0Y9TyNQuEKsGpT/A==}
@@ -4642,8 +4644,8 @@ packages:
     resolution: {integrity: sha512-+FM75wTRU0ND6EZJJ4f+d0Fi6OiU/+N/PWiQ5bMr1UrL1xOmNxyPWGrN65Cens22dfEb3//uh7Lo4ZBSM67BnA==}
     engines: {node: '>= 16.0.0'}
 
-  '@descope/web-components-ui@3.14.1':
-    resolution: {integrity: sha512-3BhqqOcP4gsHopNvcxa8RaOX3XV5eJfnx0EJwIFqthHEWPDtpi3Tw85fKW5afXs3wvVss6aNtlULBRWoaUs0gg==}
+  '@descope/web-components-ui@3.14.8':
+    resolution: {integrity: sha512-xhg5tkEGiYZNNmUQtinWG88gzROlXayKGJXMr3Fv54zMPsWhA3x6CVL7NRBrJxdbfw+FTqAlfjn0e7Tqn40IVQ==}
 
   '@descope/web-js-sdk@1.29.1':
     resolution: {integrity: sha512-YUMJQ9TrEhp8SDtOcERF4tr7IguBt5//0sm8k8/tFc/9qb1uZ9Hz1z2+1NX8cnni+tMpOUH7tRFEoprpKayPEw==}
@@ -8933,8 +8935,8 @@ packages:
     resolution: {integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==}
     engines: {node: ^4.5.0 || >= 5.9}
 
-  baseline-browser-mapping@2.10.34:
-    resolution: {integrity: sha512-IMDedajPifLnHNY0X9n8hKxRTQ6/eTHwr5bDo04WnuqxyKw6LYtQywCuuqPZwhl3aBXMvQpJov42GLCwRRdQzw==}
+  baseline-browser-mapping@2.10.38:
+    resolution: {integrity: sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -9111,8 +9113,8 @@ packages:
   caniuse-lite@1.0.30001696:
     resolution: {integrity: sha512-pDCPkvzfa39ehJtJ+OwGT/2yvT2SbjfHhiIW2LWOAcMQ7BzwxT/XuyUp4OTOd0XFWA6BKw0JalnBHgSi5DGJBQ==}
 
-  caniuse-lite@1.0.30001797:
-    resolution: {integrity: sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==}
+  caniuse-lite@1.0.30001799:
+    resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
 
   case-sensitive-paths-webpack-plugin@2.4.0:
     resolution: {integrity: sha512-roIFONhcxog0JSSWbvVAh3OocukmSgpqOH6YpMkCvav/ySIV3JKg4Dc8vYtQjYi/UxpNE36r/9v+VqTQqgkYmw==}
@@ -10160,8 +10162,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.8:
-    resolution: {integrity: sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==}
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
@@ -10238,8 +10240,8 @@ packages:
   electron-to-chromium@1.4.825:
     resolution: {integrity: sha512-OCcF+LwdgFGcsYPYC5keEEFC2XT0gBhrYbeGzHCx7i9qRFbzO/AqTmc/C/1xNhJj+JA7rzlN7mpBuStshh96Cg==}
 
-  electron-to-chromium@1.5.370:
-    resolution: {integrity: sha512-D5tSHJReAb/Kf3Hu9F/GO4lJuSWzEWHwvQ/kKSUP7pimNgvxkSKj+gUQhHpKKACwrin7rS3byU7IxreF56rl5g==}
+  electron-to-chromium@1.5.375:
+    resolution: {integrity: sha512-ZWP5eB4BVPW/ZYo9252hQZHZ5XavtsTgpbhcmMmRwymavC5AsLWQWBPaKMeNd2LW0KGby5HPXvj7+sr4ta5j/Q==}
 
   electron-to-chromium@1.5.90:
     resolution: {integrity: sha512-C3PN4aydfW91Natdyd449Kw+BzhLmof6tzy5W1pFC5SpQxVXT+oyiyOG9AgYYSN9OdA/ik3YkCrpwqI8ug5Tug==}
@@ -12695,8 +12697,8 @@ packages:
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
 
-  markdown-it@14.1.1:
-    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
+  markdown-it@14.2.0:
+    resolution: {integrity: sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==}
     hasBin: true
 
   math-intrinsics@1.1.0:
@@ -17903,277 +17905,277 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@descope-ui/common@3.14.1':
+  '@descope-ui/common@3.14.8':
     dependencies:
       color: 4.2.3
       element-internals-polyfill: 1.3.11
       lodash.debounce: 4.0.8
       lodash.merge: 4.6.2
 
-  '@descope-ui/descope-address-field@3.14.1':
+  '@descope-ui/descope-address-field@3.14.8':
     dependencies:
-      '@descope-ui/common': 3.14.1
-      '@descope-ui/descope-autocomplete-field': 3.14.1
-      '@descope-ui/theme-input-wrapper': 3.14.1
+      '@descope-ui/common': 3.14.8
+      '@descope-ui/descope-autocomplete-field': 3.14.8
+      '@descope-ui/theme-input-wrapper': 3.14.8
       '@vaadin/custom-field': 24.3.4
 
-  '@descope-ui/descope-anchored@3.14.1':
+  '@descope-ui/descope-anchored@3.14.8':
     dependencies:
-      '@descope-ui/common': 3.14.1
-      '@descope-ui/theme-globals': 3.14.1
+      '@descope-ui/common': 3.14.8
+      '@descope-ui/theme-globals': 3.14.8
 
-  '@descope-ui/descope-apps-list@3.14.1':
+  '@descope-ui/descope-apps-list@3.14.8':
     dependencies:
-      '@descope-ui/common': 3.14.1
-      '@descope-ui/descope-avatar': 3.14.1
-      '@descope-ui/descope-list': 3.14.1
-      '@descope-ui/descope-list-item': 3.14.1
-      '@descope-ui/descope-text': 3.14.1
-      '@descope-ui/theme-globals': 3.14.1
+      '@descope-ui/common': 3.14.8
+      '@descope-ui/descope-avatar': 3.14.8
+      '@descope-ui/descope-list': 3.14.8
+      '@descope-ui/descope-list-item': 3.14.8
+      '@descope-ui/descope-text': 3.14.8
+      '@descope-ui/theme-globals': 3.14.8
 
-  '@descope-ui/descope-attachment@3.14.1':
+  '@descope-ui/descope-attachment@3.14.8':
     dependencies:
-      '@descope-ui/common': 3.14.1
-      '@descope-ui/descope-anchored': 3.14.1
-      '@descope-ui/theme-globals': 3.14.1
+      '@descope-ui/common': 3.14.8
+      '@descope-ui/descope-anchored': 3.14.8
+      '@descope-ui/theme-globals': 3.14.8
 
-  '@descope-ui/descope-autocomplete-field@3.14.1':
+  '@descope-ui/descope-autocomplete-field@3.14.8':
     dependencies:
-      '@descope-ui/common': 3.14.1
-      '@descope-ui/descope-combo-box': 3.14.1
-      '@descope-ui/theme-globals': 3.14.1
-      '@descope-ui/theme-input-wrapper': 3.14.1
+      '@descope-ui/common': 3.14.8
+      '@descope-ui/descope-combo-box': 3.14.8
+      '@descope-ui/theme-globals': 3.14.8
+      '@descope-ui/theme-input-wrapper': 3.14.8
       '@vaadin/custom-field': 24.3.4
 
-  '@descope-ui/descope-avatar@3.14.1':
+  '@descope-ui/descope-avatar@3.14.8':
     dependencies:
-      '@descope-ui/common': 3.14.1
-      '@descope-ui/theme-globals': 3.14.1
+      '@descope-ui/common': 3.14.8
+      '@descope-ui/theme-globals': 3.14.8
       '@vaadin/avatar': 24.3.4
       '@vaadin/icon': 24.3.4
       '@vaadin/icons': 24.3.4
 
-  '@descope-ui/descope-badge@3.14.1':
+  '@descope-ui/descope-badge@3.14.8':
     dependencies:
-      '@descope-ui/common': 3.14.1
-      '@descope-ui/theme-globals': 3.14.1
+      '@descope-ui/common': 3.14.8
+      '@descope-ui/theme-globals': 3.14.8
 
-  '@descope-ui/descope-button@3.14.1':
+  '@descope-ui/descope-button@3.14.8':
     dependencies:
-      '@descope-ui/common': 3.14.1
-      '@descope-ui/descope-icon': 3.14.1
-      '@descope-ui/theme-globals': 3.14.1
+      '@descope-ui/common': 3.14.8
+      '@descope-ui/descope-icon': 3.14.8
+      '@descope-ui/theme-globals': 3.14.8
       '@vaadin/button': 24.3.4
 
-  '@descope-ui/descope-collapsible-container@3.14.1':
+  '@descope-ui/descope-collapsible-container@3.14.8':
     dependencies:
-      '@descope-ui/common': 3.14.1
-      '@descope-ui/descope-icon': 3.14.1
-      '@descope-ui/descope-text': 3.14.1
-      '@descope-ui/theme-globals': 3.14.1
+      '@descope-ui/common': 3.14.8
+      '@descope-ui/descope-icon': 3.14.8
+      '@descope-ui/descope-text': 3.14.8
+      '@descope-ui/theme-globals': 3.14.8
 
-  '@descope-ui/descope-combo-box@3.14.1':
+  '@descope-ui/descope-combo-box@3.14.8':
     dependencies:
-      '@descope-ui/common': 3.14.1
-      '@descope-ui/theme-globals': 3.14.1
-      '@descope-ui/theme-input-wrapper': 3.14.1
+      '@descope-ui/common': 3.14.8
+      '@descope-ui/theme-globals': 3.14.8
+      '@descope-ui/theme-input-wrapper': 3.14.8
       '@vaadin/combo-box': 24.3.4
 
-  '@descope-ui/descope-country-subdivision-city-field@3.14.1':
+  '@descope-ui/descope-country-subdivision-city-field@3.14.8':
     dependencies:
-      '@descope-ui/common': 3.14.1
-      '@descope-ui/descope-combo-box': 3.14.1
-      '@descope-ui/theme-input-wrapper': 3.14.1
+      '@descope-ui/common': 3.14.8
+      '@descope-ui/descope-combo-box': 3.14.8
+      '@descope-ui/theme-input-wrapper': 3.14.8
       '@vaadin/custom-field': 24.3.4
 
-  '@descope-ui/descope-enriched-text@3.14.1':
+  '@descope-ui/descope-enriched-text@3.14.8':
     dependencies:
-      '@descope-ui/common': 3.14.1
-      '@descope-ui/descope-link': 3.14.1
-      '@descope-ui/descope-text': 3.14.1
-      '@descope-ui/theme-globals': 3.14.1
-      markdown-it: 14.1.1
+      '@descope-ui/common': 3.14.8
+      '@descope-ui/descope-link': 3.14.8
+      '@descope-ui/descope-text': 3.14.8
+      '@descope-ui/theme-globals': 3.14.8
+      markdown-it: 14.2.0
 
-  '@descope-ui/descope-icon@3.14.1':
+  '@descope-ui/descope-icon@3.14.8':
     dependencies:
-      '@descope-ui/common': 3.14.1
-      '@descope-ui/descope-image': 3.14.1
-      '@descope-ui/theme-globals': 3.14.1
+      '@descope-ui/common': 3.14.8
+      '@descope-ui/descope-image': 3.14.8
+      '@descope-ui/theme-globals': 3.14.8
       '@vaadin/icon': 24.3.4
-      dompurify: 3.4.8
+      dompurify: 3.4.11
 
-  '@descope-ui/descope-image@3.14.1':
+  '@descope-ui/descope-image@3.14.8':
     dependencies:
-      '@descope-ui/common': 3.14.1
-      '@descope-ui/theme-globals': 3.14.1
-      dompurify: 3.4.8
+      '@descope-ui/common': 3.14.8
+      '@descope-ui/theme-globals': 3.14.8
+      dompurify: 3.4.11
 
-  '@descope-ui/descope-link@3.14.1':
+  '@descope-ui/descope-link@3.14.8':
     dependencies:
-      '@descope-ui/common': 3.14.1
-      '@descope-ui/theme-globals': 3.14.1
+      '@descope-ui/common': 3.14.8
+      '@descope-ui/theme-globals': 3.14.8
 
-  '@descope-ui/descope-list-item@3.14.1':
+  '@descope-ui/descope-list-item@3.14.8':
     dependencies:
-      '@descope-ui/common': 3.14.1
-      '@descope-ui/theme-globals': 3.14.1
+      '@descope-ui/common': 3.14.8
+      '@descope-ui/theme-globals': 3.14.8
 
-  '@descope-ui/descope-list@3.14.1':
+  '@descope-ui/descope-list@3.14.8':
     dependencies:
-      '@descope-ui/common': 3.14.1
-      '@descope-ui/descope-list-item': 3.14.1
-      '@descope-ui/theme-globals': 3.14.1
+      '@descope-ui/common': 3.14.8
+      '@descope-ui/descope-list-item': 3.14.8
+      '@descope-ui/theme-globals': 3.14.8
 
-  '@descope-ui/descope-month-day-field-picker@3.14.1':
+  '@descope-ui/descope-month-day-field-picker@3.14.8':
     dependencies:
-      '@descope-ui/common': 3.14.1
-      '@descope-ui/descope-combo-box': 3.14.1
-      '@descope-ui/theme-globals': 3.14.1
-      '@descope-ui/theme-input-wrapper': 3.14.1
+      '@descope-ui/common': 3.14.8
+      '@descope-ui/descope-combo-box': 3.14.8
+      '@descope-ui/theme-globals': 3.14.8
+      '@descope-ui/theme-input-wrapper': 3.14.8
 
-  '@descope-ui/descope-month-day-field@3.14.1':
+  '@descope-ui/descope-month-day-field@3.14.8':
     dependencies:
-      '@descope-ui/common': 3.14.1
-      '@descope-ui/descope-button': 3.14.1
-      '@descope-ui/descope-combo-box': 3.14.1
-      '@descope-ui/descope-icon': 3.14.1
-      '@descope-ui/descope-month-day-field-picker': 3.14.1
-      '@descope-ui/descope-text-field': 3.14.1
-      '@descope-ui/theme-globals': 3.14.1
-      '@descope-ui/theme-input-wrapper': 3.14.1
+      '@descope-ui/common': 3.14.8
+      '@descope-ui/descope-button': 3.14.8
+      '@descope-ui/descope-combo-box': 3.14.8
+      '@descope-ui/descope-icon': 3.14.8
+      '@descope-ui/descope-month-day-field-picker': 3.14.8
+      '@descope-ui/descope-text-field': 3.14.8
+      '@descope-ui/theme-globals': 3.14.8
+      '@descope-ui/theme-input-wrapper': 3.14.8
       '@vaadin/popover': 24.5.3
 
-  '@descope-ui/descope-multi-line-mappings@3.14.1':
+  '@descope-ui/descope-multi-line-mappings@3.14.8':
     dependencies:
-      '@descope-ui/common': 3.14.1
-      '@descope-ui/descope-button': 3.14.1
-      '@descope-ui/descope-multi-select-combo-box': 3.14.1
-      '@descope-ui/theme-globals': 3.14.1
-      '@descope-ui/theme-input-wrapper': 3.14.1
+      '@descope-ui/common': 3.14.8
+      '@descope-ui/descope-button': 3.14.8
+      '@descope-ui/descope-multi-select-combo-box': 3.14.8
+      '@descope-ui/theme-globals': 3.14.8
+      '@descope-ui/theme-input-wrapper': 3.14.8
 
-  '@descope-ui/descope-multi-select-combo-box@3.14.1':
+  '@descope-ui/descope-multi-select-combo-box@3.14.8':
     dependencies:
-      '@descope-ui/common': 3.14.1
-      '@descope-ui/theme-globals': 3.14.1
-      '@descope-ui/theme-input-wrapper': 3.14.1
+      '@descope-ui/common': 3.14.8
+      '@descope-ui/theme-globals': 3.14.8
+      '@descope-ui/theme-input-wrapper': 3.14.8
       '@vaadin/multi-select-combo-box': 24.3.4
 
-  '@descope-ui/descope-multi-sso@3.14.1':
+  '@descope-ui/descope-multi-sso@3.14.8':
     dependencies:
-      '@descope-ui/common': 3.14.1
-      '@descope-ui/descope-badge': 3.14.1
-      '@descope-ui/descope-button': 3.14.1
-      '@descope-ui/descope-icon': 3.14.1
-      '@descope-ui/descope-list': 3.14.1
-      '@descope-ui/descope-list-item': 3.14.1
-      '@descope-ui/descope-text': 3.14.1
-      '@descope-ui/theme-globals': 3.14.1
+      '@descope-ui/common': 3.14.8
+      '@descope-ui/descope-badge': 3.14.8
+      '@descope-ui/descope-button': 3.14.8
+      '@descope-ui/descope-icon': 3.14.8
+      '@descope-ui/descope-list': 3.14.8
+      '@descope-ui/descope-list-item': 3.14.8
+      '@descope-ui/descope-text': 3.14.8
+      '@descope-ui/theme-globals': 3.14.8
 
-  '@descope-ui/descope-outbound-app-button@3.14.1':
+  '@descope-ui/descope-outbound-app-button@3.14.8':
     dependencies:
-      '@descope-ui/common': 3.14.1
-      '@descope-ui/descope-button': 3.14.1
-      '@descope-ui/descope-icon': 3.14.1
-      '@descope-ui/theme-globals': 3.14.1
+      '@descope-ui/common': 3.14.8
+      '@descope-ui/descope-button': 3.14.8
+      '@descope-ui/descope-icon': 3.14.8
+      '@descope-ui/theme-globals': 3.14.8
 
-  '@descope-ui/descope-outbound-apps@3.14.1':
+  '@descope-ui/descope-outbound-apps@3.14.8':
     dependencies:
-      '@descope-ui/common': 3.14.1
-      '@descope-ui/descope-avatar': 3.14.1
-      '@descope-ui/descope-button': 3.14.1
-      '@descope-ui/descope-icon': 3.14.1
-      '@descope-ui/descope-list': 3.14.1
-      '@descope-ui/descope-list-item': 3.14.1
-      '@descope-ui/descope-text': 3.14.1
-      '@descope-ui/theme-globals': 3.14.1
+      '@descope-ui/common': 3.14.8
+      '@descope-ui/descope-avatar': 3.14.8
+      '@descope-ui/descope-button': 3.14.8
+      '@descope-ui/descope-icon': 3.14.8
+      '@descope-ui/descope-list': 3.14.8
+      '@descope-ui/descope-list-item': 3.14.8
+      '@descope-ui/descope-text': 3.14.8
+      '@descope-ui/theme-globals': 3.14.8
 
-  '@descope-ui/descope-password-strength@3.14.1':
+  '@descope-ui/descope-password-strength@3.14.8':
     dependencies:
-      '@descope-ui/common': 3.14.1
-      '@descope-ui/theme-globals': 3.14.1
-      '@descope-ui/theme-input-wrapper': 3.14.1
+      '@descope-ui/common': 3.14.8
+      '@descope-ui/theme-globals': 3.14.8
+      '@descope-ui/theme-input-wrapper': 3.14.8
       '@zxcvbn-ts/core': 3.0.4
       '@zxcvbn-ts/language-common': 3.0.4
       '@zxcvbn-ts/language-en': 3.0.2
 
-  '@descope-ui/descope-ponyhot@3.14.1':
+  '@descope-ui/descope-ponyhot@3.14.8':
     dependencies:
-      '@descope-ui/common': 3.14.1
-      '@descope-ui/theme-globals': 3.14.1
+      '@descope-ui/common': 3.14.8
+      '@descope-ui/theme-globals': 3.14.8
 
-  '@descope-ui/descope-recovery-codes@3.14.1':
+  '@descope-ui/descope-recovery-codes@3.14.8':
     dependencies:
-      '@descope-ui/common': 3.14.1
-      '@descope-ui/descope-text': 3.14.1
-      '@descope-ui/theme-globals': 3.14.1
+      '@descope-ui/common': 3.14.8
+      '@descope-ui/descope-text': 3.14.8
+      '@descope-ui/theme-globals': 3.14.8
       '@vaadin/icon': 24.3.4
       '@vaadin/icons': 24.3.4
 
-  '@descope-ui/descope-text-field@3.14.1':
+  '@descope-ui/descope-text-field@3.14.8':
     dependencies:
-      '@descope-ui/common': 3.14.1
-      '@descope-ui/theme-globals': 3.14.1
-      '@descope-ui/theme-input-wrapper': 3.14.1
+      '@descope-ui/common': 3.14.8
+      '@descope-ui/theme-globals': 3.14.8
+      '@descope-ui/theme-input-wrapper': 3.14.8
       '@vaadin/icon': 24.3.4
       '@vaadin/icons': 24.3.4
       '@vaadin/text-field': 24.3.4
 
-  '@descope-ui/descope-text@3.14.1':
+  '@descope-ui/descope-text@3.14.8':
     dependencies:
-      '@descope-ui/common': 3.14.1
-      '@descope-ui/theme-globals': 3.14.1
+      '@descope-ui/common': 3.14.8
+      '@descope-ui/theme-globals': 3.14.8
 
-  '@descope-ui/descope-timer-button@3.14.1':
+  '@descope-ui/descope-timer-button@3.14.8':
     dependencies:
-      '@descope-ui/common': 3.14.1
-      '@descope-ui/descope-button': 3.14.1
-      '@descope-ui/descope-timer': 3.14.1
-      '@descope-ui/theme-globals': 3.14.1
+      '@descope-ui/common': 3.14.8
+      '@descope-ui/descope-button': 3.14.8
+      '@descope-ui/descope-timer': 3.14.8
+      '@descope-ui/theme-globals': 3.14.8
 
-  '@descope-ui/descope-timer@3.14.1':
+  '@descope-ui/descope-timer@3.14.8':
     dependencies:
-      '@descope-ui/common': 3.14.1
-      '@descope-ui/descope-icon': 3.14.1
-      '@descope-ui/theme-globals': 3.14.1
+      '@descope-ui/common': 3.14.8
+      '@descope-ui/descope-icon': 3.14.8
+      '@descope-ui/theme-globals': 3.14.8
 
-  '@descope-ui/descope-tooltip@3.14.1':
+  '@descope-ui/descope-tooltip@3.14.8':
     dependencies:
-      '@descope-ui/common': 3.14.1
-      '@descope-ui/descope-anchored': 3.14.1
-      '@descope-ui/descope-enriched-text': 3.14.1
-      '@descope-ui/theme-globals': 3.14.1
+      '@descope-ui/common': 3.14.8
+      '@descope-ui/descope-anchored': 3.14.8
+      '@descope-ui/descope-enriched-text': 3.14.8
+      '@descope-ui/theme-globals': 3.14.8
       '@vaadin/tooltip': 24.3.4
 
-  '@descope-ui/descope-trusted-devices@3.14.1':
+  '@descope-ui/descope-trusted-devices@3.14.8':
     dependencies:
-      '@descope-ui/common': 3.14.1
-      '@descope-ui/descope-badge': 3.14.1
-      '@descope-ui/descope-icon': 3.14.1
-      '@descope-ui/descope-link': 3.14.1
-      '@descope-ui/descope-list': 3.14.1
-      '@descope-ui/descope-list-item': 3.14.1
-      '@descope-ui/descope-text': 3.14.1
-      '@descope-ui/theme-globals': 3.14.1
+      '@descope-ui/common': 3.14.8
+      '@descope-ui/descope-badge': 3.14.8
+      '@descope-ui/descope-icon': 3.14.8
+      '@descope-ui/descope-link': 3.14.8
+      '@descope-ui/descope-list': 3.14.8
+      '@descope-ui/descope-list-item': 3.14.8
+      '@descope-ui/descope-text': 3.14.8
+      '@descope-ui/theme-globals': 3.14.8
 
-  '@descope-ui/descope-user-passkeys@3.14.1':
+  '@descope-ui/descope-user-passkeys@3.14.8':
     dependencies:
-      '@descope-ui/common': 3.14.1
-      '@descope-ui/descope-button': 3.14.1
-      '@descope-ui/descope-icon': 3.14.1
-      '@descope-ui/descope-link': 3.14.1
-      '@descope-ui/descope-list': 3.14.1
-      '@descope-ui/descope-list-item': 3.14.1
-      '@descope-ui/descope-text': 3.14.1
-      '@descope-ui/theme-globals': 3.14.1
+      '@descope-ui/common': 3.14.8
+      '@descope-ui/descope-button': 3.14.8
+      '@descope-ui/descope-icon': 3.14.8
+      '@descope-ui/descope-link': 3.14.8
+      '@descope-ui/descope-list': 3.14.8
+      '@descope-ui/descope-list-item': 3.14.8
+      '@descope-ui/descope-text': 3.14.8
+      '@descope-ui/theme-globals': 3.14.8
 
-  '@descope-ui/theme-globals@3.14.1':
+  '@descope-ui/theme-globals@3.14.8':
     dependencies:
-      '@descope-ui/common': 3.14.1
+      '@descope-ui/common': 3.14.8
 
-  '@descope-ui/theme-input-wrapper@3.14.1':
+  '@descope-ui/theme-input-wrapper@3.14.8':
     dependencies:
-      '@descope-ui/common': 3.14.1
-      '@descope-ui/theme-globals': 3.14.1
+      '@descope-ui/common': 3.14.8
+      '@descope-ui/theme-globals': 3.14.8
 
   '@descope/core-js-sdk@2.40.0':
     dependencies:
@@ -18193,43 +18195,43 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@descope/web-components-ui@3.14.1':
+  '@descope/web-components-ui@3.14.8':
     dependencies:
-      '@descope-ui/common': 3.14.1
-      '@descope-ui/descope-address-field': 3.14.1
-      '@descope-ui/descope-anchored': 3.14.1
-      '@descope-ui/descope-apps-list': 3.14.1
-      '@descope-ui/descope-attachment': 3.14.1
-      '@descope-ui/descope-autocomplete-field': 3.14.1
-      '@descope-ui/descope-avatar': 3.14.1
-      '@descope-ui/descope-badge': 3.14.1
-      '@descope-ui/descope-button': 3.14.1
-      '@descope-ui/descope-collapsible-container': 3.14.1
-      '@descope-ui/descope-combo-box': 3.14.1
-      '@descope-ui/descope-country-subdivision-city-field': 3.14.1
-      '@descope-ui/descope-enriched-text': 3.14.1
-      '@descope-ui/descope-icon': 3.14.1
-      '@descope-ui/descope-image': 3.14.1
-      '@descope-ui/descope-link': 3.14.1
-      '@descope-ui/descope-list': 3.14.1
-      '@descope-ui/descope-list-item': 3.14.1
-      '@descope-ui/descope-month-day-field': 3.14.1
-      '@descope-ui/descope-month-day-field-picker': 3.14.1
-      '@descope-ui/descope-multi-line-mappings': 3.14.1
-      '@descope-ui/descope-multi-select-combo-box': 3.14.1
-      '@descope-ui/descope-multi-sso': 3.14.1
-      '@descope-ui/descope-outbound-app-button': 3.14.1
-      '@descope-ui/descope-outbound-apps': 3.14.1
-      '@descope-ui/descope-password-strength': 3.14.1
-      '@descope-ui/descope-ponyhot': 3.14.1
-      '@descope-ui/descope-recovery-codes': 3.14.1
-      '@descope-ui/descope-text': 3.14.1
-      '@descope-ui/descope-text-field': 3.14.1
-      '@descope-ui/descope-timer': 3.14.1
-      '@descope-ui/descope-timer-button': 3.14.1
-      '@descope-ui/descope-tooltip': 3.14.1
-      '@descope-ui/descope-trusted-devices': 3.14.1
-      '@descope-ui/descope-user-passkeys': 3.14.1
+      '@descope-ui/common': 3.14.8
+      '@descope-ui/descope-address-field': 3.14.8
+      '@descope-ui/descope-anchored': 3.14.8
+      '@descope-ui/descope-apps-list': 3.14.8
+      '@descope-ui/descope-attachment': 3.14.8
+      '@descope-ui/descope-autocomplete-field': 3.14.8
+      '@descope-ui/descope-avatar': 3.14.8
+      '@descope-ui/descope-badge': 3.14.8
+      '@descope-ui/descope-button': 3.14.8
+      '@descope-ui/descope-collapsible-container': 3.14.8
+      '@descope-ui/descope-combo-box': 3.14.8
+      '@descope-ui/descope-country-subdivision-city-field': 3.14.8
+      '@descope-ui/descope-enriched-text': 3.14.8
+      '@descope-ui/descope-icon': 3.14.8
+      '@descope-ui/descope-image': 3.14.8
+      '@descope-ui/descope-link': 3.14.8
+      '@descope-ui/descope-list': 3.14.8
+      '@descope-ui/descope-list-item': 3.14.8
+      '@descope-ui/descope-month-day-field': 3.14.8
+      '@descope-ui/descope-month-day-field-picker': 3.14.8
+      '@descope-ui/descope-multi-line-mappings': 3.14.8
+      '@descope-ui/descope-multi-select-combo-box': 3.14.8
+      '@descope-ui/descope-multi-sso': 3.14.8
+      '@descope-ui/descope-outbound-app-button': 3.14.8
+      '@descope-ui/descope-outbound-apps': 3.14.8
+      '@descope-ui/descope-password-strength': 3.14.8
+      '@descope-ui/descope-ponyhot': 3.14.8
+      '@descope-ui/descope-recovery-codes': 3.14.8
+      '@descope-ui/descope-text': 3.14.8
+      '@descope-ui/descope-text-field': 3.14.8
+      '@descope-ui/descope-timer': 3.14.8
+      '@descope-ui/descope-timer-button': 3.14.8
+      '@descope-ui/descope-tooltip': 3.14.8
+      '@descope-ui/descope-trusted-devices': 3.14.8
+      '@descope-ui/descope-user-passkeys': 3.14.8
       '@vaadin/checkbox': 24.3.4
       '@vaadin/custom-field': 24.3.4
       '@vaadin/dialog': 24.3.4
@@ -23844,7 +23846,7 @@ snapshots:
 
   base64id@2.0.0: {}
 
-  baseline-browser-mapping@2.10.34:
+  baseline-browser-mapping@2.10.38:
     optional: true
 
   basic-auth@2.0.1:
@@ -24003,9 +24005,9 @@ snapshots:
 
   browserslist@4.28.1:
     dependencies:
-      baseline-browser-mapping: 2.10.34
-      caniuse-lite: 1.0.30001797
-      electron-to-chromium: 1.5.370
+      baseline-browser-mapping: 2.10.38
+      caniuse-lite: 1.0.30001799
+      electron-to-chromium: 1.5.375
       node-releases: 2.0.47
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
     optional: true
@@ -24128,7 +24130,7 @@ snapshots:
 
   caniuse-lite@1.0.30001696: {}
 
-  caniuse-lite@1.0.30001797:
+  caniuse-lite@1.0.30001799:
     optional: true
 
   case-sensitive-paths-webpack-plugin@2.4.0: {}
@@ -25163,7 +25165,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.8:
+  dompurify@3.4.11:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -25239,7 +25241,7 @@ snapshots:
 
   electron-to-chromium@1.4.825: {}
 
-  electron-to-chromium@1.5.370:
+  electron-to-chromium@1.5.375:
     optional: true
 
   electron-to-chromium@1.5.90: {}
@@ -25698,7 +25700,7 @@ snapshots:
     dependencies:
       confusing-browser-globals: 1.0.11
       eslint: 8.57.1
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
       object.assign: 4.1.5
       object.entries: 1.1.8
       semver: 6.3.1
@@ -25793,7 +25795,7 @@ snapshots:
   eslint-config-standard@17.1.0(eslint-plugin-import@2.31.0)(eslint-plugin-n@17.9.0(eslint@8.57.1))(eslint-plugin-promise@6.6.0(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.7.3))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.1)
       eslint-plugin-n: 17.9.0(eslint@8.57.1)
       eslint-plugin-promise: 6.6.0(eslint@8.57.1)
 
@@ -29545,7 +29547,7 @@ snapshots:
     dependencies:
       tmpl: 1.0.5
 
-  markdown-it@14.1.1:
+  markdown-it@14.2.0:
     dependencies:
       argparse: 2.0.1
       entities: 4.5.0
@@ -32856,25 +32858,6 @@ snapshots:
       babel-jest: 29.7.0(@babel/core@7.26.10)
       esbuild: 0.25.3
 
-  ts-jest@29.1.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(esbuild@0.25.3)(jest@29.7.0(@types/node@20.17.13)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.4.5)))(typescript@5.4.5):
-    dependencies:
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@20.17.13)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.4.5))
-      jest-util: 29.7.0
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.6.0
-      typescript: 5.4.5
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.26.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.26.0)
-      esbuild: 0.25.3
-
   ts-jest@29.1.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@20.14.7)(ts-node@10.9.1(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.14.7)(typescript@5.4.5)))(typescript@5.4.5):
     dependencies:
       bs-logger: 0.2.6
@@ -32893,7 +32876,7 @@ snapshots:
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.26.0)
 
-  ts-jest@29.1.5(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(jest@29.7.0(@types/node@20.17.13)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.4.5)))(typescript@5.4.5):
+  ts-jest@29.1.5(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(esbuild@0.25.3)(jest@29.7.0(@types/node@20.17.13)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.4.5)))(typescript@5.4.5):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -32910,6 +32893,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.26.10)
+      esbuild: 0.25.3
 
   ts-jest@29.1.5(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(jest@29.7.0(@types/node@20.17.13)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.5.4)))(typescript@5.5.4):
     dependencies:
@@ -32946,6 +32930,26 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.26.10)
+
+  ts-jest@29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(esbuild@0.25.0)(jest@29.7.0(@types/node@20.17.13)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.4.5)))(typescript@5.4.5):
+    dependencies:
+      bs-logger: 0.2.6
+      ejs: 3.1.10
+      fast-json-stable-stringify: 2.1.0
+      jest: 29.7.0(@types/node@20.17.13)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.4.5))
+      jest-util: 29.7.0
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.7.0
+      typescript: 5.4.5
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.26.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.26.0)
+      esbuild: 0.25.0
 
   ts-jest@29.2.5(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(esbuild@0.25.2)(jest@29.7.0(@types/node@22.13.17)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3)))(typescript@5.7.3):
     dependencies:
@@ -32985,26 +32989,6 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.26.0)
-
-  ts-jest@29.2.5(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(esbuild@0.25.0)(jest@29.7.0(@types/node@20.17.13)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.4.5)))(typescript@5.4.5):
-    dependencies:
-      bs-logger: 0.2.6
-      ejs: 3.1.10
-      fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@20.17.13)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.4.5))
-      jest-util: 29.7.0
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.7.0
-      typescript: 5.4.5
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.26.10
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.26.10)
-      esbuild: 0.25.0
 
   ts-jest@29.2.5(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(jest@29.7.0(@types/node@20.17.13)(ts-node@10.9.2(@swc/core@1.7.1(@swc/helpers@0.5.15))(@types/node@20.17.13)(typescript@5.7.3)))(typescript@5.7.3):
     dependencies:


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/descope/etc/issues/14584

## Related PRs

| branch       | PR         |
| ------------ | ---------- |
| service a PR | Link to PR |
| service b PR | Link to PR |

## Description

This branch adds the complete client-to-server story for OIDC with Inbound Apps; sign in against any Descope Inbound App by pasting its well-known URL, optionally request a resource-scoped access token, and have nextjs-sdk's server-side middleware validate that token's audience correctly (including the audience-mismatch edge case).

Manually verified end-to-end against a live project; Federated-App (applicationId) OIDC path is untouched.

## Must

- [x] Tests (new ones added)
- [x] Documentation (updated)
