### PR TITLE
feat(core-js): expose externalToken on JWTResponse

### DIFF
--- a/packages/sdks/core-js-sdk/src/sdk/types.ts
+++ b/packages/sdks/core-js-sdk/src/sdk/types.ts
@@ -149,6 +149,7 @@ export type JWTResponse = {
   claims: Claims;
   trustedDeviceJwt?: string;
   nextRefreshSeconds?: number;
+  externalToken?: string;
 };
 
 /** Authentication info result from exchanging access keys for a session */


### PR DESCRIPTION
## Related Issues
https://github.com/descope/etc/issues/16830

## Description
- Add `externalToken?: string` to `JWTResponse` so typed consumers (including descope-react-native) can read the connector-minted token the server already returns

## Must
- [ ] Tests
- [ ] Documentation