### PR TITLE
fix(web-js-sdk): keep DSLI try-refresh indicator in real localStorage under customStorage

### DIFF
--- a/packages/sdks/react-sdk/README.md
+++ b/packages/sdks/react-sdk/README.md
@@ -543,7 +543,7 @@ const AppRoot = () => {
 
 ### Custom Storage
 
-By default the SDK reads and writes to `window.localStorage` for state that needs to outlive a single page load (last-authenticated user, client-side session-refresh optimization markers, etc.). If `localStorage` is unavailable or you want to back these keys with something else — `sessionStorage`, an in-memory store, an encrypted wrapper — pass a `customStorage` prop to the `AuthProvider`.
+By default the SDK reads and writes to `window.localStorage` for state that needs to outlive a single page load (last-authenticated user, tokens when they aren't stored in cookies, etc.). If `localStorage` is unavailable or you want to back these keys with something else — `sessionStorage`, an in-memory store, an encrypted wrapper — pass a `customStorage` prop to the `AuthProvider`.
 
 ```js
 import { AuthProvider } from '@descope/react-sdk';
@@ -578,13 +578,15 @@ type CustomStorage = {
 };
 ```
 
-> **Note:** The SDK writes a small set of internal keys (e.g. for the last-authenticated user feature and client-side session-refresh optimizations). Make sure your implementation round-trips these keys cleanly — `getItem(key)` should return the same string that was last passed to `setItem(key, value)`. If your storage drops, filters, or namespaces keys so that they don't survive a round-trip, some optimizations may degrade — for example, an extra `/v1/auth/try-refresh` round-trip may be made on every page load even for anonymous visitors.
+> **Note:** `customStorage` backs the keys the SDK persists on your behalf (tokens, last-authenticated user). Make sure your implementation round-trips these keys cleanly — `getItem(key)` should return the same string that was last passed to `setItem(key, value)`. If your storage drops, filters, or namespaces keys so that they don't survive a round-trip, the features that rely on them may degrade.
+>
+> The internal, non-PII markers for the client-side session-refresh optimization (`DSLI` / `DSLI_DISABLED`) are the exception: the SDK always keeps them in real `window.localStorage`, independent of `customStorage`. This is what makes the optimization behave correctly even when you back the other keys with `sessionStorage` or an in-memory store.
 
 ### Last User Persistence
 
 Descope stores the last user information in local storage. If you wish to disable this feature, you can pass `storeLastAuthenticatedUser={false}` to the `AuthProvider` component. Please note that some features related to the last authenticated user may not function as expected if this behavior is disabled. Local storage is being cleared when the user logs out, if you want the avoid clearing the local storage, you can pass `keepLastAuthenticatedUserAfterLogout={true}` to the `AuthProvider` component.
 
-The last-user key also serves as a signal for the SDK's session initialization optimization: on mount, the `AuthProvider` skips the initial `/try-refresh` network call if no prior session indicator is found in `localStorage` (neither the last-user key nor the `DSLI` key written on every successful authentication). This means anonymous visitors never pay a round-trip at startup. If `storeLastAuthenticatedUser={false}`, only the `DSLI` key is used as the indicator.
+The last-user key also serves as a signal for the SDK's session initialization optimization: on mount, the `AuthProvider` skips the initial `/try-refresh` network call when it finds no prior session indicator — neither the `DSLI` key (written to real `window.localStorage` on every successful authentication, independent of `customStorage`) nor the last-user key. This means anonymous visitors never pay a round-trip at startup. If `storeLastAuthenticatedUser={false}`, only the `DSLI` key is used as the indicator.
 
 ### Seamless Session Migration
 

--- a/packages/sdks/web-js-sdk/README.md
+++ b/packages/sdks/web-js-sdk/README.md
@@ -222,7 +222,7 @@ This is useful when Descope's session inactivity feature is enabled, ensuring re
 
 ### Custom Storage
 
-By default the SDK reads and writes to `window.localStorage` for state that needs to outlive a single page load (last-authenticated user, client-side session-refresh optimization markers, etc.). If `localStorage` is unavailable or you want to back these keys with something else — `sessionStorage`, an in-memory store, an encrypted wrapper, a cross-frame bridge — pass a `customStorage` object to the SDK.
+By default the SDK reads and writes to `window.localStorage` for state that needs to outlive a single page load (last-authenticated user, tokens when they aren't stored in cookies, etc.). If `localStorage` is unavailable or you want to back these keys with something else — `sessionStorage`, an in-memory store, an encrypted wrapper, a cross-frame bridge — pass a `customStorage` object to the SDK.
 
 ```js
 const inMemoryStorage = (() => {
@@ -254,11 +254,13 @@ type CustomStorage = {
 };
 ```
 
-> **Note:** The SDK writes a small set of internal keys (e.g. for the last-authenticated user feature and client-side session-refresh optimizations). Make sure your implementation round-trips these keys cleanly — `getItem(key)` should return the same string that was last passed to `setItem(key, value)`. If your storage drops, filters, or namespaces keys so that they don't survive a round-trip, some optimizations may degrade — for example, an extra `/v1/auth/try-refresh` round-trip may be made on every page load even for anonymous visitors.
+> **Note:** `customStorage` backs the keys the SDK persists on your behalf (tokens, last-authenticated user). Make sure your implementation round-trips these keys cleanly — `getItem(key)` should return the same string that was last passed to `setItem(key, value)`. If your storage drops, filters, or namespaces keys so that they don't survive a round-trip, the features that rely on them may degrade.
+>
+> The internal, non-PII markers for the client-side session-refresh optimization (`DSLI` / `DSLI_DISABLED`) are the exception: the SDK always keeps them in real `window.localStorage`, independent of `customStorage`. This is what makes the optimization behave correctly even when you back the other keys with `sessionStorage` or an in-memory store.
 
 ### Last Login Indicator
 
-The SDK maintains a `DSLI` (Descope Session Login Indicator) entry in `localStorage` that tracks whether this browser has previously had an active authenticated session. On every successful authentication, `DSLI` is written. On logout or an invalid-session response, it is cleared.
+The SDK maintains a `DSLI` (Descope Session Login Indicator) entry in real `window.localStorage` — always, even when a `customStorage` is provided — that tracks whether this browser has previously had an active authenticated session. On every successful authentication, `DSLI` is written. On logout or an invalid-session response, it is cleared.
 
 When `sdk.refresh()` is called in "try-refresh" mode (i.e. on SDK initialization, to restore a prior session), the SDK skips the network call entirely if neither `DSLI` nor the last-user key (`dls_last_user_login_id`) is present. This eliminates a redundant `/v1/auth/try-refresh` round-trip for anonymous visitors who have never logged in.
 

--- a/packages/sdks/web-js-sdk/src/enhancers/helpers/index.ts
+++ b/packages/sdks/web-js-sdk/src/enhancers/helpers/index.ts
@@ -195,3 +195,27 @@ export const getLocalStorageKey = (index: number): string | null =>
 export const setCustomStorage = (storage: CustomStorage) => {
   customStorage = storage;
 };
+
+// Internal indicator keys (DSLI, DSLI_DISABLED) are non-PII booleans that must
+// live in real localStorage regardless of customStorage, so the try-refresh
+// optimization stays correct when the app routes token storage elsewhere
+// (sessionStorage, consent-gated bags, etc).
+export const isInternalStorageAvailable = (): boolean =>
+  IS_BROWSER && typeof window.localStorage !== 'undefined';
+
+export const getInternalStorage = (key: string) =>
+  (IS_BROWSER && window.localStorage?.getItem?.(key)) || null;
+export const setInternalStorage = (key: string, value: string) => {
+  try {
+    if (IS_BROWSER) window.localStorage?.setItem?.(key, value);
+  } catch {
+    /* blocked / quota-exceeded storage — indicator is best-effort */
+  }
+};
+export const removeInternalStorage = (key: string) => {
+  try {
+    if (IS_BROWSER) window.localStorage?.removeItem?.(key);
+  } catch {
+    /* blocked storage — nothing to clear */
+  }
+};

--- a/packages/sdks/web-js-sdk/src/enhancers/withLoggedInIndicator/helpers.ts
+++ b/packages/sdks/web-js-sdk/src/enhancers/withLoggedInIndicator/helpers.ts
@@ -1,4 +1,4 @@
-import { getLocalStorage } from '../helpers';
+import { getInternalStorage, getLocalStorage } from '../helpers';
 import { LOCAL_STORAGE_LAST_USER_LOGIN_ID } from '../withLastLoggedInUser/constants';
 import { LOGGED_IN_INDICATOR_KEY } from './constants';
 
@@ -6,20 +6,25 @@ import { LOGGED_IN_INDICATOR_KEY } from './constants';
  * Returns true if the browser shows any sign of an authenticated session.
  *
  * Primary signal: the DSLI key, written by `withLoggedInIndicator` after every
- * successful auth response and cleared on logout / invalid-session.
+ * successful auth response and cleared on logout / invalid-session. It is read
+ * from real `localStorage` (not `customStorage`) so the skip decision stays
+ * correct when the app routes token storage elsewhere (sessionStorage, etc).
  *
  * Bootstrap fallback: the lastUser key (`dls_last_user_login_id`) written by
  * `withLastLoggedInUser`. This exists so users authenticated under a previous
  * SDK version (before DSLI existed) aren't wrongly treated as anonymous on the
- * first page load after upgrade. Once any successful auth has written DSLI,
- * the fallback is no longer load-bearing and can be dropped in a future cleanup.
+ * first page load after upgrade. It stays on `customStorage` (it may hold PII,
+ * so it must not move to localStorage), which also lets it recognize a returning
+ * user during the transition before DSLI has been written to real localStorage.
+ * Once any successful auth has written DSLI, the fallback is no longer
+ * load-bearing and can be dropped in a future cleanup.
  *
  * Both keys are intentionally unprefixed — `storagePrefix` is consumed by
  * `withPersistTokens` and not propagated to other enhancers.
  */
 export function hasLoginIndicator(): boolean {
   return (
-    !!getLocalStorage(LOGGED_IN_INDICATOR_KEY) ||
+    !!getInternalStorage(LOGGED_IN_INDICATOR_KEY) ||
     !!getLocalStorage(LOCAL_STORAGE_LAST_USER_LOGIN_ID)
   );
 }

--- a/packages/sdks/web-js-sdk/src/enhancers/withLoggedInIndicator/index.ts
+++ b/packages/sdks/web-js-sdk/src/enhancers/withLoggedInIndicator/index.ts
@@ -5,8 +5,8 @@ import {
   addHooks,
   getAuthInfoFromResponse,
   isInvalidSessionResponse,
-  removeLocalStorage,
-  setLocalStorage,
+  removeInternalStorage,
+  setInternalStorage,
 } from '../helpers';
 import { LOGGED_IN_INDICATOR_KEY } from './constants';
 
@@ -14,7 +14,7 @@ const logoutWrapper: SdkFnWrapper<{}> =
   (fn) =>
   async (...args) => {
     const resp = await fn(...args);
-    removeLocalStorage(LOGGED_IN_INDICATOR_KEY);
+    removeInternalStorage(LOGGED_IN_INDICATOR_KEY);
     return resp;
   };
 
@@ -26,14 +26,14 @@ const withLoggedInIndicator =
   (config: Parameters<T>[0]): ReturnType<T> => {
     const afterRequest: AfterRequestHook = async (req, res) => {
       if (isInvalidSessionResponse(req, res)) {
-        removeLocalStorage(LOGGED_IN_INDICATOR_KEY);
+        removeInternalStorage(LOGGED_IN_INDICATOR_KEY);
         return;
       }
       const authInfo = await getAuthInfoFromResponse(res);
       // sessionExpiration is the reliable auth-success signal — JWTs may live in
       // HttpOnly cookies, but sessionExpiration is always in the response body.
       if (authInfo?.sessionExpiration) {
-        setLocalStorage(
+        setInternalStorage(
           LOGGED_IN_INDICATOR_KEY,
           String(authInfo.sessionExpiration),
         );

--- a/packages/sdks/web-js-sdk/src/sdk/index.ts
+++ b/packages/sdks/web-js-sdk/src/sdk/index.ts
@@ -8,7 +8,6 @@ import {
 } from '../enhancers/withPersistTokens/helpers';
 import { hasLoginIndicator } from '../enhancers/withLoggedInIndicator/helpers';
 import { LOGGED_IN_INDICATOR_DISABLED_KEY } from '../enhancers/withLoggedInIndicator/constants';
-import { getLocalStorage } from '../enhancers/helpers';
 import createOidc from './oidc';
 import { CoreSdk, WebSdkConfig } from '../types';
 import {
@@ -17,7 +16,11 @@ import {
   REFRESH_DISABLED,
 } from '../constants';
 import logger from '../enhancers/helpers/logger';
-import { isDescopeBridge } from '../enhancers/helpers';
+import {
+  getInternalStorage,
+  isDescopeBridge,
+  isInternalStorageAvailable,
+} from '../enhancers/helpers';
 
 const createSdk = (config: WebSdkConfig) => {
   const coreSdk = createCoreSdk(config);
@@ -60,6 +63,10 @@ const createSdk = (config: WebSdkConfig) => {
       // Skip the up-front /try-refresh round-trip when localStorage has no sign
       // of a prior authenticated session. `withLoggedInIndicator` writes DSLI
       // on every successful auth and clears it on logout / invalid session.
+      // The indicator is read from real localStorage (not customStorage) so the
+      // decision holds when the app routes token storage elsewhere; if real
+      // localStorage is unavailable we can't trust the signal, so we skip the
+      // optimization and fall through to the normal try-refresh.
       // DSLI_DISABLED overrides the skip — escape hatch for apps that hit the
       // storeLastAuthenticatedUser=false edge case after upgrading.
       // OIDC mode is handled above and bypasses this optimization, since OIDC
@@ -67,8 +74,9 @@ const createSdk = (config: WebSdkConfig) => {
       // performs its own no-session short-circuit.
       if (
         tryRefresh &&
+        isInternalStorageAvailable() &&
         !hasLoginIndicator() &&
-        !getLocalStorage(LOGGED_IN_INDICATOR_DISABLED_KEY)
+        !getInternalStorage(LOGGED_IN_INDICATOR_DISABLED_KEY)
       ) {
         return Promise.resolve({ ok: true });
       }

--- a/packages/sdks/web-js-sdk/test/loggedInIndicator.test.ts
+++ b/packages/sdks/web-js-sdk/test/loggedInIndicator.test.ts
@@ -1,8 +1,24 @@
 import { LOGGED_IN_INDICATOR_KEY } from '../src/enhancers/withLoggedInIndicator/constants';
 import { hasLoginIndicator } from '../src/enhancers/withLoggedInIndicator/helpers';
+import { setCustomStorage } from '../src/enhancers/helpers';
 import createSdk from '../src/index';
 import { authInfo } from './mocks';
 import { createMockReturnValue } from './testUtils';
+
+// In-memory customStorage bag that is NOT backed by window.localStorage —
+// mirrors a consent-gated / sessionStorage adapter a customer might pass.
+const makeBag = () => {
+  const store = new Map<string, string>();
+  return {
+    getItem: jest.fn((k: string) => store.get(k) ?? null),
+    setItem: jest.fn((k: string, v: string) => {
+      store.set(k, v);
+    }),
+    removeItem: jest.fn((k: string) => {
+      store.delete(k);
+    }),
+  };
+};
 
 const mockFetch = jest.fn().mockReturnValueOnce(new Promise(() => {}));
 global.fetch = mockFetch;
@@ -204,6 +220,49 @@ describe('withLoggedInIndicator', () => {
     });
 
     it('returns false when neither key is set', () => {
+      expect(hasLoginIndicator()).toBe(false);
+    });
+  });
+
+  // Regression for the customStorage bug: the DSLI indicator must live in real
+  // localStorage regardless of a customStorage adapter, otherwise a returning
+  // user whose adapter is sessionStorage-backed is misread as a fresh device.
+  describe('with customStorage', () => {
+    afterEach(() => {
+      setCustomStorage(undefined);
+    });
+
+    it('writes DSLI to real localStorage, not to the customStorage bag', async () => {
+      const bag = makeBag();
+      const fetchMock = jest
+        .fn()
+        .mockReturnValue(createMockReturnValue(authInfo));
+      global.fetch = fetchMock;
+
+      const sdk = createSdk({ projectId: 'pid', customStorage: bag });
+      await sdk.httpClient.get('1/2/3');
+      await new Promise(process.nextTick);
+
+      expect(localStorage.getItem(LOGGED_IN_INDICATOR_KEY)).toEqual(
+        String(authInfo.sessionExpiration),
+      );
+      expect(bag.setItem).not.toHaveBeenCalledWith(
+        LOGGED_IN_INDICATOR_KEY,
+        expect.anything(),
+      );
+    });
+
+    it('reads DSLI from real localStorage even when customStorage is set', () => {
+      const bag = makeBag();
+      createSdk({ projectId: 'pid', customStorage: bag }); // installs the singleton
+      localStorage.setItem(LOGGED_IN_INDICATOR_KEY, '1');
+      expect(hasLoginIndicator()).toBe(true);
+    });
+
+    it('does not read DSLI from the customStorage bag', () => {
+      const bag = makeBag();
+      bag.setItem(LOGGED_IN_INDICATOR_KEY, '1'); // only in the bag, not real localStorage
+      createSdk({ projectId: 'pid', customStorage: bag });
       expect(hasLoginIndicator()).toBe(false);
     });
   });

--- a/packages/sdks/web-js-sdk/test/sdk.test.ts
+++ b/packages/sdks/web-js-sdk/test/sdk.test.ts
@@ -1,4 +1,5 @@
 import createSdk, { REFRESH_TOKEN_KEY, SESSION_TOKEN_KEY } from '../src/index';
+import { setCustomStorage } from '../src/enhancers/helpers';
 import { flowResponse } from './mocks';
 import { createMockReturnValue } from './testUtils';
 
@@ -187,6 +188,10 @@ describe('sdk', () => {
       localStorage.removeItem(LAST_USER_KEY);
     });
 
+    afterEach(() => {
+      setCustomStorage(undefined);
+    });
+
     it('skips fetch and returns ok when neither DSLI nor lastUser is set', async () => {
       const mockFetch = jest
         .fn()
@@ -237,6 +242,25 @@ describe('sdk', () => {
       global.fetch = mockFetch;
       const sdk = createSdk({ projectId: 'pid' });
       await sdk.refresh('token');
+      expect(mockFetch).toHaveBeenCalled();
+    });
+
+    // Core customStorage regression: DSLI lives in real localStorage, so a
+    // returning user is recognized (try-refresh runs) even though their
+    // customStorage bag is empty on a fresh session — no wrong skip.
+    it('calls fetch when DSLI is in real localStorage even with customStorage set', async () => {
+      const bag = {
+        getItem: () => null,
+        setItem: () => {},
+        removeItem: () => {},
+      };
+      localStorage.setItem(DSLI_KEY, '1');
+      const mockFetch = jest
+        .fn()
+        .mockReturnValue(createMockReturnValue(flowResponse));
+      global.fetch = mockFetch;
+      const sdk = createSdk({ projectId: 'pid', customStorage: bag });
+      await sdk.refresh(undefined, true);
       expect(mockFetch).toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
## Related Issues
Fixes: https://github.com/descope/etc/issues/17009

## Problem

The try-refresh optimization from #1383 skips the up-front `/try-refresh` call when the device shows no sign of a prior authenticated session, decided by reading the `DSLI` / `DSLI_DISABLED` indicator keys.

Those keys were read/written via `getLocalStorage` / `setLocalStorage`, which route **every** key through `customStorage` once an app supplies one. When an app's `customStorage` is backed by **sessionStorage** (or a consent-gated JSON bag), the indicator doesn't survive across tabs/sessions. A returning user holding a valid HttpOnly refresh cookie is then misread as a **fresh device** → SDK skips try-refresh → user is treated as logged out → their backend `/me` is hit with an expired/absent token.

This is what caused a customer's expired-token spike right after upgrading.

## Fix

`DSLI` and `DSLI_DISABLED` are non-PII internal booleans, so bind them directly to real `window.localStorage`, independent of `customStorage`:

- **`helpers/index.ts`** — add `getInternalStorage` / `setInternalStorage` / `removeInternalStorage` (bound to `window.localStorage`, writes try/catch-guarded) + `isInternalStorageAvailable`
- **`withLoggedInIndicator/index.ts`** — write DSLI on auth success and clear on logout / invalid-session via internal storage
- **`withLoggedInIndicator/helpers.ts`** — `hasLoginIndicator` reads DSLI from internal storage; the `dls_last_user_login_id` fallback **stays on `customStorage`** (it may hold PII, and it keeps recognizing same-session returning users during the upgrade transition)
- **`sdk/index.ts`** — gate the skip on `isInternalStorageAvailable()` (fall through to normal try-refresh when real localStorage is unavailable), and read `DSLI_DISABLED` from internal storage

### Side fix
The escape hatch `localStorage.setItem('DSLI_DISABLED','ok')` didn't work under `customStorage` before (it was read through the app's bag, not localStorage). It now does.

## Effect

- Returning users are recognized regardless of the app's `customStorage` backend → no wrong-skip → no expired-token spike
- Apps using `customStorage` need **no** custom-adapter workaround after this ships
- Optimization stays fully intact for the common (no-`customStorage`) case

### Known residual gap (accepted)
A user who logged in only under a pre-DSLI SDK **and** whose `customStorage` is a *fresh-session* sessionStorage bag has no `DSLI` in real localStorage and no readable last-user key — indistinguishable from a genuinely fresh device, so it gets one wrong skip until re-login. `DSLI_DISABLED` covers apps that can't tolerate this.

## Tests

`packages/sdks/web-js-sdk` — 261 passing, including new regression tests:
- DSLI written to real localStorage, **not** the customStorage bag
- `hasLoginIndicator` reads DSLI from real localStorage, not the bag
- try-refresh **runs** for a returning user (DSLI in localStorage) even with an empty customStorage bag

🤖 Generated with [Claude Code](https://claude.com/claude-code)