### PR TITLE
fix(nextjs-sdk): read session cookie from request in getSession

### DIFF
--- a/packages/sdks/nextjs-sdk/src/server/session.ts
+++ b/packages/sdks/nextjs-sdk/src/server/session.ts
@@ -20,30 +20,14 @@ type SessionConfig = CreateSdkParams & {
 	refreshTokenCookieName?: string;
 };
 
-const getSessionFromCookie = async (
-	config?: SessionConfig
-): Promise<AuthenticationInfo | undefined> => {
-	logger.debug('attempting to get session from cookie');
-	try {
-		const sessionCookie = (await cookies()).get(
-			config?.sessionCookieName || descopeSdk.SessionTokenCookieName
-		);
-		if (!sessionCookie?.value) {
-			logger.debug('Session cookie not found');
-			return undefined;
-		}
-		const sdk = getGlobalSdk(config);
-		return await sdk.validateJwt(sessionCookie.value);
-	} catch (err) {
-		logger.debug('Error getting session from cookie', err);
-		return undefined;
-	}
-};
+const getSessionCookieName = (config?: SessionConfig) =>
+	config?.sessionCookieName || descopeSdk.SessionTokenCookieName;
 
 // tries to validate the Authorization header,
-// if it doesn't exist or is invalid, it will attempt to get the session from the cookie
+// if it doesn't exist or is invalid, it will attempt to validate the session cookie
 const getSessionFromAuthorizationOrCookie = async (
-	authorization?: string | null,
+	authorization: string | null | undefined,
+	cookieJwt: string | undefined,
 	config?: SessionConfig
 ): Promise<AuthenticationInfo | undefined> => {
 	const sessionJwt = authorization?.split(' ')[1];
@@ -56,7 +40,18 @@ const getSessionFromAuthorizationOrCookie = async (
 		}
 	}
 
-	return getSessionFromCookie(config);
+	logger.debug('attempting to get session from cookie');
+	if (!cookieJwt) {
+		logger.debug('Session cookie not found');
+		return undefined;
+	}
+	try {
+		const sdk = getGlobalSdk(config);
+		return await sdk.validateJwt(cookieJwt);
+	} catch (err) {
+		logger.debug('Error getting session from cookie', err);
+		return undefined;
+	}
 };
 
 // returns the session token if it exists in the Authorization header or cookie
@@ -65,8 +60,10 @@ export const session = async (
 ): Promise<AuthenticationInfo | undefined> => {
 	setLogger(config?.logLevel);
 	const reqHeaders = await headers();
+	const cookieJwt = (await cookies()).get(getSessionCookieName(config))?.value;
 	return getSessionFromAuthorizationOrCookie(
 		reqHeaders.get('Authorization'),
+		cookieJwt,
 		config
 	);
 };
@@ -80,6 +77,9 @@ export const getSession = async (
 	const { authorization } = req.headers;
 	return getSessionFromAuthorizationOrCookie(
 		typeof authorization === 'string' ? authorization : undefined,
+		// Pages Router request - next/headers cookies() is not available here,
+		// so the session cookie must be read directly from the request
+		req.cookies?.[getSessionCookieName(config)],
 		config
 	);
 };

--- a/packages/sdks/nextjs-sdk/test/server/session.test.ts
+++ b/packages/sdks/nextjs-sdk/test/server/session.test.ts
@@ -85,6 +85,7 @@ describe('session utilities', () => {
 			(headers as jest.Mock).mockImplementation(
 				() => new Map([['Authorization', 'Bearer authorizationJwt']])
 			);
+			(cookies as jest.Mock).mockImplementation(() => new Map());
 			const result = await session({ projectId: 'test' });
 			expect(mockValidateJwt).toHaveBeenCalledWith('authorizationJwt');
 			expect(result).toEqual(authInfo);
@@ -137,17 +138,15 @@ describe('session utilities', () => {
 
 		it('should return undefined if session header is missing', async () => {
 			(headers as jest.Mock).mockImplementation(() => new Map());
-			jest.mock('next/headers', () => ({
-				headers: jest.fn().mockImplementation(() => new Map())
-			}));
+			(cookies as jest.Mock).mockImplementation(() => new Map());
 			const result = await session();
 			expect(result).toBeUndefined();
 		});
 	});
 
 	describe('getSession', () => {
-		it('should return session if session is in the cookie', async () => {
-			const mockReq = { headers: {} };
+		it('should return session if session is in the request cookie', async () => {
+			const mockReq = { headers: {}, cookies: { DS: 'validJwt' } };
 
 			// Mock validateJwt to simulate an authenticated user
 			const authInfo = {
@@ -155,47 +154,48 @@ describe('session utilities', () => {
 				token: { iss: 'project-1', sub: 'user-123' }
 			};
 			mockValidateJwt.mockImplementation(() => authInfo);
-			(cookies as jest.Mock).mockImplementation(
-				() =>
-					new Map([
-						[
-							'DS',
-							{
-								value: 'validJwt'
-							}
-						]
-					])
-			);
-			(headers as jest.Mock).mockImplementation(() => new Map());
-			jest.mock('next/headers', () => ({
-				headers: jest.fn().mockImplementation(() => new Map())
-			}));
 			const result = await getSession(mockReq as any, {
 				projectId: 'test',
 				baseUrl: 'http://example.com'
 			});
+			expect(mockValidateJwt).toHaveBeenCalledWith('validJwt');
+			expect(result).toEqual(authInfo);
+		});
+
+		it('should read the request cookie even when next/headers is unavailable (Pages Router)', async () => {
+			const authInfo = {
+				jwt: 'cookieJwt',
+				token: { iss: 'project-1', sub: 'user-123' }
+			};
+			mockValidateJwt.mockResolvedValue(authInfo);
+			(cookies as jest.Mock).mockImplementation(() => {
+				throw new Error('`cookies` was called outside a request scope');
+			});
+			const mockReq = { headers: {}, cookies: { DS: 'cookieJwt' } };
+			const result = await getSession(mockReq as any, { projectId: 'test' });
+			expect(mockValidateJwt).toHaveBeenCalledWith('cookieJwt');
+			expect(result).toEqual(authInfo);
+		});
+
+		it('should support a custom session cookie name', async () => {
+			const authInfo = {
+				jwt: 'customJwt',
+				token: { iss: 'project-1', sub: 'user-123' }
+			};
+			mockValidateJwt.mockResolvedValue(authInfo);
+			const mockReq = { headers: {}, cookies: { 'my-session': 'customJwt' } };
+			const result = await getSession(mockReq as any, {
+				projectId: 'test',
+				sessionCookieName: 'my-session'
+			});
+			expect(mockValidateJwt).toHaveBeenCalledWith('customJwt');
 			expect(result).toEqual(authInfo);
 		});
 
 		it('should return undefined if session in cookie is not valid', async () => {
-			const mockReq = { headers: {} };
+			const mockReq = { headers: {}, cookies: { DS: 'invalidJwt' } };
 			// Mock validateJwt to simulate invalid JWT
 			mockValidateJwt.mockRejectedValue(new Error('Invalid JWT'));
-			(cookies as jest.Mock).mockImplementation(
-				() =>
-					new Map([
-						[
-							'DS',
-							{
-								value: 'invalidJwt'
-							}
-						]
-					])
-			);
-			(headers as jest.Mock).mockImplementation(() => new Map());
-			jest.mock('next/headers', () => ({
-				headers: jest.fn().mockImplementation(() => new Map())
-			}));
 			const result = await getSession(mockReq as any, {
 				projectId: 'test',
 				baseUrl: 'http://example.com'


### PR DESCRIPTION
## Problem

`getSession(req)` returns `undefined` in Pages Router API routes when the `Authorization` header is missing, even when a valid `DS` session cookie is present (customer report)

The cookie fallback used `cookies()` from `next/headers`, which only works in App Router request scope. In a Pages Router API route it throws, the error is swallowed (debug-level log only), and `undefined` is returned - the request cookie is never read

## Fix

- `getSession(req)` reads the session cookie directly from `req.cookies` (respecting `sessionCookieName` config) instead of `next/headers`
- `getSessionFromAuthorizationOrCookie` now takes the resolved cookie JWT value; each entry point supplies it from the right source (`next/headers` for App Router `session()`, `req.cookies` for Pages Router `getSession()`)

## Tests

- `getSession` cookie tests now go through `req.cookies`
- Regression test: `next/headers` `cookies()` throwing (Pages Router) while the request cookie is present
- Custom `sessionCookieName` test

🤖 Generated with [Claude Code](https://claude.com/claude-code)