### PR TITLE
fix(web-component): refresh captcha token on abandoned OAuth popup RELEASE

### DIFF
--- a/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
+++ b/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
@@ -1883,27 +1883,17 @@ class DescopeWc extends BaseDescopeWc {
       this.loggerWrapper.debug('Restoring components state');
       this.removeEventListener('popupclosed', restoreComponentsState);
 
-      // Only a genuine web-popup-closed-without-response arms the token-refresh
-      // gate below. No-event callers (pageshow, same-screen resubmit) and
-      // non-web-popup emitters fall through to false, keeping today's behavior.
+      // Only a genuine web-popup-closed-without-response arms the refresh below;
+      // no-event callers (pageshow, same-screen) fall through to today's path.
       const abandoned = (e as CustomEvent)?.detail?.abandoned === true;
 
       if (abandoned && screenClientScripts.length) {
-        // A popup returns a *redirect*, not a screen, so the usual "reload the
-        // screen's client scripts" step (see #handleStepUpdate) never runs when
-        // the popup closes. That is why the captcha token that was already spent
-        // by the popup attempt gets reused on the next submit and the backend
-        // rejects it as a duplicate ("DUPE").
-        //
-        // Reload the screen's client scripts (captured at click time - the
-        // captcha lives there) to regenerate a fresh single-use token. Only
-        // clientScripts are reloaded, NOT sdkScripts (forter, darwinium, ...),
-        // which must not re-run just because a popup closed.
-        //
-        // Assigned to #sdkScriptsLoading before we re-enable the button, so the
-        // next submit blocks on the fresh token via `await this.#sdkScriptsLoading`.
-        // Wrapped so it can never reject - a rejected #sdkScriptsLoading would
-        // throw out of #runSdkScriptsModules and break the submit.
+        // The abandoned popup already spent the single-use captcha token, and a
+        // popup returns a redirect (not a screen) so the usual screen-scripts
+        // reload never runs - reusing that token would be rejected as "DUPE".
+        // Reload the screen's clientScripts (only these, not sdkScripts) to mint
+        // a fresh token, and gate the next submit on it via #sdkScriptsLoading
+        // (assigned before re-enabling the button; wrapped so it never rejects).
         this.#sdkScriptsLoading = (async () => {
           try {
             await this.loadSdkScripts(screenClientScripts);

--- a/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
+++ b/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
@@ -925,6 +925,13 @@ class DescopeWc extends BaseDescopeWc {
           }`,
         );
 
+        // whether the popup sent a response back (code or exchange error) before
+        // it closed. if it did, the popup was NOT abandoned - so we should not
+        // regenerate the risk token on close. this is a per-popup signal, kept
+        // local on purpose (reading the global flowState.code would false-positive
+        // after any earlier successful OAuth, since it is never cleared).
+        let receivedCode = false;
+
         const onPostMessage = (event: MessageEvent) => {
           this.loggerWrapper.debug(
             'Received popup message',
@@ -943,6 +950,9 @@ class DescopeWc extends BaseDescopeWc {
 
           const { action: popupAction, data } = event.data || {};
           if (popupAction === 'code') {
+            // a response came back (success code or exchange error) - the popup
+            // completed, it was not abandoned.
+            receivedCode = true;
             this.flowState.update({
               code: data.code,
               exchangeError: data.exchangeError,
@@ -959,7 +969,9 @@ class DescopeWc extends BaseDescopeWc {
               'Popup closed, dispatching popupclosed event',
             );
             clearInterval(intervalId);
-            this.#dispatch('popupclosed', {});
+            // mark whether the popup was abandoned (closed without sending a
+            // response) so the close handler can regenerate the risk token.
+            this.#dispatch('popupclosed', { abandoned: !receivedCode });
 
             this.loggerWrapper.debug('Cleaning up popup listeners');
             cleanup?.();
@@ -1849,6 +1861,16 @@ class DescopeWc extends BaseDescopeWc {
       ),
     ).filter((ele) => ele !== submitter);
 
+    // Capture the current screen's client scripts NOW, at click time. If this
+    // submit opens an OAuth popup, the redirect response overwrites screenState
+    // (screenState.clientScripts becomes empty), so by the time the popup closes
+    // we can no longer read them. We need them to regenerate the captcha token
+    // if the popup is abandoned. The captcha is a screen-level clientScript
+    // (screenState), not a flow-level one, so this is the only place it's still
+    // available.
+    const screenClientScripts =
+      this.flowState.current?.screenState?.clientScripts || [];
+
     // reset the in-flight loading/disabled state set when the next request started
     const resetComponentsState = () => {
       submitter.removeAttribute('loading');
@@ -1857,9 +1879,47 @@ class DescopeWc extends BaseDescopeWc {
       });
     };
 
-    const restoreComponentsState = async () => {
+    const restoreComponentsState = async (e?: Event) => {
       this.loggerWrapper.debug('Restoring components state');
       this.removeEventListener('popupclosed', restoreComponentsState);
+
+      // Only a genuine web-popup-closed-without-response arms the token-refresh
+      // gate below. No-event callers (pageshow, same-screen resubmit) and
+      // non-web-popup emitters fall through to false, keeping today's behavior.
+      const abandoned = (e as CustomEvent)?.detail?.abandoned === true;
+
+      if (abandoned && screenClientScripts.length) {
+        // A popup returns a *redirect*, not a screen, so the usual "reload the
+        // screen's client scripts" step (see #handleStepUpdate) never runs when
+        // the popup closes. That is why the captcha token that was already spent
+        // by the popup attempt gets reused on the next submit and the backend
+        // rejects it as a duplicate ("DUPE").
+        //
+        // Reload the screen's client scripts (captured at click time - the
+        // captcha lives there) to regenerate a fresh single-use token. Only
+        // clientScripts are reloaded, NOT sdkScripts (forter, darwinium, ...),
+        // which must not re-run just because a popup closed.
+        //
+        // Assigned to #sdkScriptsLoading before we re-enable the button, so the
+        // next submit blocks on the fresh token via `await this.#sdkScriptsLoading`.
+        // Wrapped so it can never reject - a rejected #sdkScriptsLoading would
+        // throw out of #runSdkScriptsModules and break the submit.
+        this.#sdkScriptsLoading = (async () => {
+          try {
+            await this.loadSdkScripts(screenClientScripts);
+          } catch (err) {
+            this.loggerWrapper.warn(
+              'Failed to refresh client scripts on popup close',
+              (err as Error)?.message,
+            );
+          }
+        })();
+        resetComponentsState();
+        return;
+      }
+
+      // Re-enable first (before the awaited reload below) so the button never
+      // stays stuck if getFlowConfig rejects.
       resetComponentsState();
       // if there are client scripts, we want to reload them
       const flowConfig = await this.getFlowConfig();

--- a/packages/sdks/web-component/test/descope-wc.popupTokenRefresh.test.ts
+++ b/packages/sdks/web-component/test/descope-wc.popupTokenRefresh.test.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 /* eslint-disable @typescript-eslint/no-use-before-define */
 /* eslint-disable import/order */
 /* eslint-disable import/first */
@@ -179,37 +180,23 @@ describe('web-component popup token refresh', () => {
     jest.useRealTimers();
   });
 
-  // When the popup is abandoned we reload the current screen's client scripts
-  // (the captcha lives there, in screenState) to mint a fresh token - NOT the
-  // sdk scripts (forter, etc.), which must not re-run just because a popup
-  // closed. The captcha is a screen-level clientScript, captured at click time
-  // because the popup redirect response wipes screenState.
-  it('reloads the screen captcha script (not sdk scripts) after an abandoned popup', async () => {
-    const makeModule = (id: string) =>
-      jest.fn(() => ({
-        id,
-        start: jest.fn(),
-        stop: jest.fn(() => true),
-        refresh: jest.fn(),
-        present: jest.fn(),
-      }));
-    (window as any).descope = {
-      grecaptcha: makeModule('grecaptcha'),
-      forter: makeModule('forter'),
-    };
+  // End-to-end reproduction of the DUPE issue: the recaptcha token is a
+  // single-use screen-level clientScript. It is minted before the popup and
+  // sent with the OAuth `next`; when the popup is abandoned the fix must mint a
+  // FRESH token so the following submit does not resend the spent one (which the
+  // backend rejects as a duplicate).
+  it('sends a fresh captcha token on the next submit after an abandoned popup', async () => {
+    const TOKEN_KEY = 'sdkScriptsResults.grecaptcha_riskToken';
+    const grecaptcha = jest.fn(() => ({
+      id: 'grecaptcha',
+      start: jest.fn(),
+      stop: jest.fn(() => true),
+      refresh: jest.fn(),
+      present: jest.fn(),
+    }));
+    (window as any).descope = { grecaptcha };
 
-    // grecaptcha is a screen-level client script (arrives in screen.state);
-    // forter is a flow-level sdk script.
-    fixtures.configContent = {
-      flows: {
-        'sign-in': {
-          version: 1,
-          sdkScripts: [
-            { id: 'forter', initArgs: { siteId: 'x' }, resultKey: 'token' },
-          ],
-        },
-      },
-    };
+    // the welcome screen carries the grecaptcha client script (screen-level)
     startMock.mockReturnValue(
       generateSdkResponse({
         screenState: {
@@ -223,8 +210,8 @@ describe('web-component popup token refresh', () => {
         },
       }),
     );
-    // clicking the social button opens an OAuth popup (redirect response)
-    nextMock.mockReturnValue({
+    // first submit (social) opens an OAuth popup; later submits render a screen
+    nextMock.mockReturnValueOnce({
       ok: true,
       data: {
         stepId: 's2',
@@ -241,38 +228,48 @@ describe('web-component popup token refresh', () => {
       },
       error: {},
     });
+    nextMock.mockReturnValue(generateSdkResponse());
 
     fixtures.pageContent =
-      '<descope-button id="social">Continue with Google</descope-button><span>ready</span>';
+      '<descope-button id="social">Continue with Google</descope-button>' +
+      '<descope-button id="submit">Submit</descope-button><span>ready</span>';
 
     document.body.innerHTML = `<descope-wc flow-id="sign-in" project-id="1"></descope-wc>`;
-    const wc: any = document.querySelector('descope-wc');
 
     await waitFor(() => screen.getByShadowText('ready'), {
       timeout: WAIT_TIMEOUT,
     });
 
-    // click the social button -> flow.next returns a popup redirect
+    // screen render loads grecaptcha -> deliver the first token (before popup)
+    await waitFor(() => expect(grecaptcha).toHaveBeenCalledTimes(1), {
+      timeout: WAIT_TIMEOUT,
+    });
+    grecaptcha.mock.calls[0][2]('TOKEN_1');
+
+    // click the social button -> the OAuth next carries the first token
     fireEvent.click(screen.getByShadowText('Continue with Google'));
     await waitFor(() => expect(helpers.openCenteredPopup).toHaveBeenCalled(), {
       timeout: WAIT_TIMEOUT,
     });
+    expect(nextMock.mock.calls[0][5][TOKEN_KEY]).toBe('TOKEN_1');
 
-    // watch what gets reloaded when the popup closes
-    const loadSpy = jest.spyOn(wc, 'loadSdkScripts');
-
-    // user closes the popup without completing
+    // user closes the popup without completing -> the fix reloads grecaptcha
     popupObj.closed = true;
     await jest.advanceTimersByTimeAsync(1100);
     await jest.runAllTimersAsync();
-
-    await waitFor(() => expect(loadSpy).toHaveBeenCalled(), {
+    await waitFor(() => expect(grecaptcha).toHaveBeenCalledTimes(2), {
       timeout: WAIT_TIMEOUT,
     });
-    const reloadedIds = loadSpy.mock.calls
-      .flatMap(([scripts]) => (scripts as { id: string }[]) || [])
-      .map((s) => s.id);
-    expect(reloadedIds).toContain('grecaptcha');
-    expect(reloadedIds).not.toContain('forter');
+    // the reloaded module mints a fresh token
+    grecaptcha.mock.calls[1][2]('TOKEN_2');
+
+    // next submit must carry the FRESH token, not the spent one (no DUPE)
+    fireEvent.click(screen.getByShadowText('Submit'));
+    await waitFor(() => expect(nextMock).toHaveBeenCalledTimes(2), {
+      timeout: WAIT_TIMEOUT,
+    });
+    const secondSubmit = nextMock.mock.calls[1][5];
+    expect(secondSubmit[TOKEN_KEY]).toBe('TOKEN_2');
+    expect(secondSubmit[TOKEN_KEY]).not.toBe('TOKEN_1');
   });
 });

--- a/packages/sdks/web-component/test/descope-wc.popupTokenRefresh.test.ts
+++ b/packages/sdks/web-component/test/descope-wc.popupTokenRefresh.test.ts
@@ -1,0 +1,278 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
+/* eslint-disable import/order */
+/* eslint-disable import/first */
+
+// Disable source-map-support for this file to avoid source map parsing errors
+if (typeof Error.prepareStackTrace !== 'undefined') {
+  Error.prepareStackTrace = undefined;
+}
+
+import {
+  fixtures,
+  setupWebComponentTestEnv,
+  startMock,
+  nextMock,
+  teardownWebComponentTestEnv,
+  generateSdkResponse,
+  WAIT_TIMEOUT,
+} from './descope-wc.test-harness';
+
+import '@testing-library/jest-dom';
+import { waitFor, fireEvent } from '@testing-library/dom';
+import { screen } from 'shadow-dom-testing-library';
+
+import '../src/lib/descope-wc';
+
+// eslint-disable-next-line import/no-namespace
+import * as helpers from '../src/lib/helpers/helpers';
+import { RESPONSE_ACTIONS } from '../src/lib/constants';
+
+// The recaptcha risk token is regenerated when a social-login popup is *abandoned*
+// (closed without completing). The web component signals that on the `popupclosed`
+// event via `detail.abandoned`, so the close handler only refreshes the token when
+// there really was no OAuth response. These tests lock in that signal.
+describe('web-component popup token refresh', () => {
+  const EXECUTION_ID = 'exec-popup-token';
+
+  let originalBroadcastChannel: typeof global.BroadcastChannel;
+  let broadcastInstances: any[];
+  let popupObj: any;
+
+  beforeEach(() => {
+    setupWebComponentTestEnv();
+
+    originalBroadcastChannel = global.BroadcastChannel;
+    broadcastInstances = [];
+    class MockBroadcastChannel {
+      name: string;
+
+      closed = false;
+
+      onMessageInternal: ((event: any) => void) | null = null;
+
+      constructor(name: string) {
+        this.name = name;
+        broadcastInstances.push(this);
+      }
+
+      close() {
+        this.closed = true;
+      }
+
+      set onmessage(fn: ((event: any) => void) | null) {
+        this.onMessageInternal = fn;
+      }
+
+      get onmessage() {
+        return this.onMessageInternal;
+      }
+
+      emit(event: any) {
+        this.onMessageInternal?.(event);
+      }
+    }
+    // @ts-expect-error - Mocking BroadcastChannel for tests
+    global.BroadcastChannel = jest.fn((name) => new MockBroadcastChannel(name));
+
+    popupObj = {
+      closed: false,
+      name: '',
+      location: { href: '' },
+      focus: jest.fn(),
+    };
+    jest.spyOn(helpers, 'openCenteredPopup').mockReturnValue(popupObj);
+
+    // a start response that opens an OAuth popup
+    startMock.mockReturnValue({
+      ok: true,
+      data: {
+        stepId: 's1',
+        stepName: 'Step 1',
+        action: RESPONSE_ACTIONS.redirect,
+        screen: { id: '0', state: {} },
+        redirect: { url: 'https://auth.example', isPopup: true },
+        executionId: EXECUTION_ID,
+        status: 'running',
+        authInfo: 'auth info',
+        webauthn: { options: '', transactionId: '' },
+        samlIdpResponse: { url: '', samlResponse: '', relayState: '' },
+        lastAuth: {},
+        nativeResponse: { type: '', payload: {} },
+      },
+      error: {},
+    });
+  });
+
+  afterEach(() => {
+    global.BroadcastChannel = originalBroadcastChannel;
+    teardownWebComponentTestEnv();
+  });
+
+  const mountAndOpenPopup = async () => {
+    jest.useFakeTimers();
+    fixtures.pageContent = '';
+    document.body.innerHTML = `<descope-wc flow-id="otpSignInEmail" project-id="1"></descope-wc>`;
+    const wc: any = document.querySelector('descope-wc');
+    const detail: { abandoned?: boolean } = {};
+    wc.addEventListener('popupclosed', (e: CustomEvent) => {
+      Object.assign(detail, { abandoned: e.detail?.abandoned });
+    });
+    await waitFor(() => expect(startMock).toHaveBeenCalled(), {
+      timeout: 2000,
+    });
+    // the popup opens on a deferred flow-state update; flush timers so
+    // openCenteredPopup runs and the broadcast channel is created.
+    await jest.advanceTimersByTimeAsync(100);
+    await waitFor(() => expect(helpers.openCenteredPopup).toHaveBeenCalled(), {
+      timeout: 2000,
+    });
+    return { wc, detail };
+  };
+
+  it('marks the popup as abandoned when it is closed without a response', async () => {
+    const { detail } = await mountAndOpenPopup();
+
+    // user closes the popup without completing OAuth
+    popupObj.closed = true;
+    await jest.advanceTimersByTimeAsync(1100);
+    await jest.runAllTimersAsync();
+
+    expect(detail.abandoned).toBe(true);
+    jest.useRealTimers();
+  });
+
+  it('does NOT mark the popup as abandoned when a code response arrived before it closed', async () => {
+    const { detail } = await mountAndOpenPopup();
+
+    // the popup posts back an OAuth response (success code) via the broadcast channel
+    const channel = broadcastInstances.find((b) => b.name === EXECUTION_ID);
+    expect(channel).toBeTruthy();
+    channel.emit({
+      origin: window.location.origin,
+      data: { action: 'code', data: { code: 'the-code' } },
+    });
+
+    // then the popup closes
+    popupObj.closed = true;
+    await jest.advanceTimersByTimeAsync(1100);
+    await jest.runAllTimersAsync();
+
+    expect(detail.abandoned).toBe(false);
+    jest.useRealTimers();
+  });
+
+  it('marks as abandoned when a non-code message arrived (popup was not completed)', async () => {
+    const { detail } = await mountAndOpenPopup();
+
+    // an unrelated message that is not an OAuth response must not count as completion
+    const channel = broadcastInstances.find((b) => b.name === EXECUTION_ID);
+    channel.emit({
+      origin: window.location.origin,
+      data: { action: 'something-else' },
+    });
+
+    popupObj.closed = true;
+    await jest.advanceTimersByTimeAsync(1100);
+    await jest.runAllTimersAsync();
+
+    expect(detail.abandoned).toBe(true);
+    jest.useRealTimers();
+  });
+
+  // When the popup is abandoned we reload the current screen's client scripts
+  // (the captcha lives there, in screenState) to mint a fresh token - NOT the
+  // sdk scripts (forter, etc.), which must not re-run just because a popup
+  // closed. The captcha is a screen-level clientScript, captured at click time
+  // because the popup redirect response wipes screenState.
+  it('reloads the screen captcha script (not sdk scripts) after an abandoned popup', async () => {
+    const makeModule = (id: string) =>
+      jest.fn(() => ({
+        id,
+        start: jest.fn(),
+        stop: jest.fn(() => true),
+        refresh: jest.fn(),
+        present: jest.fn(),
+      }));
+    (window as any).descope = {
+      grecaptcha: makeModule('grecaptcha'),
+      forter: makeModule('forter'),
+    };
+
+    // grecaptcha is a screen-level client script (arrives in screen.state);
+    // forter is a flow-level sdk script.
+    fixtures.configContent = {
+      flows: {
+        'sign-in': {
+          version: 1,
+          sdkScripts: [
+            { id: 'forter', initArgs: { siteId: 'x' }, resultKey: 'token' },
+          ],
+        },
+      },
+    };
+    startMock.mockReturnValue(
+      generateSdkResponse({
+        screenState: {
+          clientScripts: [
+            {
+              id: 'grecaptcha',
+              initArgs: { enterprise: true },
+              resultKey: 'riskToken',
+            },
+          ],
+        },
+      }),
+    );
+    // clicking the social button opens an OAuth popup (redirect response)
+    nextMock.mockReturnValue({
+      ok: true,
+      data: {
+        stepId: 's2',
+        stepName: 'oauth',
+        action: RESPONSE_ACTIONS.redirect,
+        screen: { id: '', state: null },
+        redirect: { url: 'https://auth.example', isPopup: true },
+        executionId: EXECUTION_ID,
+        status: 'running',
+        webauthn: { options: '', transactionId: '' },
+        samlIdpResponse: { url: '', samlResponse: '', relayState: '' },
+        lastAuth: {},
+        nativeResponse: { type: '', payload: {} },
+      },
+      error: {},
+    });
+
+    fixtures.pageContent =
+      '<descope-button id="social">Continue with Google</descope-button><span>ready</span>';
+
+    document.body.innerHTML = `<descope-wc flow-id="sign-in" project-id="1"></descope-wc>`;
+    const wc: any = document.querySelector('descope-wc');
+
+    await waitFor(() => screen.getByShadowText('ready'), {
+      timeout: WAIT_TIMEOUT,
+    });
+
+    // click the social button -> flow.next returns a popup redirect
+    fireEvent.click(screen.getByShadowText('Continue with Google'));
+    await waitFor(() => expect(helpers.openCenteredPopup).toHaveBeenCalled(), {
+      timeout: WAIT_TIMEOUT,
+    });
+
+    // watch what gets reloaded when the popup closes
+    const loadSpy = jest.spyOn(wc, 'loadSdkScripts');
+
+    // user closes the popup without completing
+    popupObj.closed = true;
+    await jest.advanceTimersByTimeAsync(1100);
+    await jest.runAllTimersAsync();
+
+    await waitFor(() => expect(loadSpy).toHaveBeenCalled(), {
+      timeout: WAIT_TIMEOUT,
+    });
+    const reloadedIds = loadSpy.mock.calls
+      .flatMap(([scripts]) => (scripts as { id: string }[]) || [])
+      .map((s) => s.id);
+    expect(reloadedIds).toContain('grecaptcha');
+    expect(reloadedIds).not.toContain('forter');
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes the `DUPE` recaptcha error when a social-login (OAuth) popup is opened in popup mode, closed without finishing, and the user then submits again on the same screen (e.g. email/password).
- Root cause: the recaptcha token is single-use. A popup returns a *redirect* (not a screen), so the normal "reload the screen's clientScripts" step never runs, and the redirect response wipes `screenState`. The spent token stayed in context and was resent → backend `DUPE`.
- Fix: capture the screen's `clientScripts` at submit time, and on an *abandoned* popup close reload only those to mint a fresh token before the next submit. Non-captcha `sdkScripts` (forter, etc.) are not re-run.

## Linked
- Fixes: descope/etc#17057
- Related PRs: none (web-component only)

## Changes
- `DescopeWc.ts`
  - Popup-close detection now carries a per-popup `abandoned` flag on the `popupclosed` event (`receivedCode` in the popup closure).
  - `#handleComponentsLoadingState` captures `screenState.clientScripts` at click time (before the redirect wipes it).
  - `restoreComponentsState` reloads those captured scripts and gates the next submit on the fresh token (`#sdkScriptsLoading`) only when the popup was abandoned. Reload is reject-safe.
- New test `descope-wc.popupTokenRefresh.test.ts`.

## Manual test plan
- Elementor-style flow (social + email/password on one screen, OAuth in popup mode):
  1. Click the social button → popup opens.
  2. Close the popup without completing.
  3. Submit email/password on the same screen.
  - Expected: succeeds, no `DUPE`; the two `flow/next` calls send **different** `grecaptcha_riskToken` values.
- Verify a **successful** OAuth (popup completes) is unaffected — code exchange still runs, no extra delay.

## Risk / review focus
- Core flow code (`restoreComponentsState` / popup handling). Behavior change is scoped to the *abandoned* popup path; success, same-screen resubmit, and pageshow paths are unchanged.
- On abandoned popup, flow-level `sdkScripts` are intentionally **no longer** reloaded (only the screen's captcha script) — confirm no flow relies on that.
- Verified live against the real Elementor flow: two different tokens, no `DUPE`, flow advanced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)