### PR TITLE
fix(react-sdk): don't strand isSessionLoading when the loading toggle is batched away

### DIFF
--- a/packages/sdks/react-sdk/src/components/AuthProvider/AuthProvider.tsx
+++ b/packages/sdks/react-sdk/src/components/AuthProvider/AuthProvider.tsx
@@ -127,6 +127,13 @@ const AuthProvider: FC<IAuthProviderProps> = ({
   const isSessionFetched = useRef(false);
   const isUserFetched = useRef(false);
 
+  // Observable mirror of `isSessionFetched.current`. Completing the one-shot
+  // session fetch must always trigger a re-render: consumers (useSession)
+  // derive their loading flag from this, and without a state change React can
+  // bail out of the re-render when isSessionLoading nets false→false (the
+  // synchronous-refresh batch), stranding the loading flag `true` (#1393/#1436).
+  const [isSessionFetchedState, setIsSessionFetchedState] = useState(false);
+
   // if oidc config is enabled, and we have oidc params in the url
   // we will finish the login (this should run only once)
   useEffect(() => {
@@ -136,6 +143,7 @@ const AuthProvider: FC<IAuthProviderProps> = ({
         setIsOidcLoading(false);
         // We want that the session will fetched only once
         isSessionFetched.current = true;
+        setIsSessionFetchedState(true);
       });
     }
   }, []);
@@ -147,6 +155,7 @@ const AuthProvider: FC<IAuthProviderProps> = ({
     // We want that the session will fetched only once
     if (isSessionFetched.current) return;
     isSessionFetched.current = true;
+    setIsSessionFetchedState(true);
 
     setIsSessionLoading(true);
     const stopSessionLoading = () => {
@@ -196,7 +205,7 @@ const AuthProvider: FC<IAuthProviderProps> = ({
       isAuthenticated,
       isSessionLoading,
       isOidcLoading,
-      isSessionFetched: isSessionFetched.current,
+      isSessionFetched: isSessionFetchedState,
       projectId,
       baseUrl,
       baseStaticUrl,
@@ -221,7 +230,7 @@ const AuthProvider: FC<IAuthProviderProps> = ({
       isAuthenticated,
       isSessionLoading,
       isOidcLoading,
-      isSessionFetched.current,
+      isSessionFetchedState,
       projectId,
       baseUrl,
       baseStaticUrl,

--- a/packages/sdks/react-sdk/src/hooks/useSession.ts
+++ b/packages/sdks/react-sdk/src/hooks/useSession.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect } from 'react';
 import useContext from './useContext';
 import { isDescopeBridge } from '../utils';
 
@@ -13,24 +13,24 @@ const useSession = () => {
     isAuthenticated,
   } = useContext();
 
-  // when session should be received, we want the return value of "isSessionLoading" to be true starting from the first call
-  // (and not only when receiving an update from the context)
-  const isLoading = useRef(isSessionLoading || isOidcLoading);
-
-  // we want this to happen before returning a value so we are using "useMemo" and not "useEffect"
-  useMemo(() => {
-    isLoading.current = isSessionLoading || isOidcLoading;
-  }, [isSessionLoading, isOidcLoading]);
-
   // In case we're in a native flow, we won't refresh the session anyway, so no point in marking the state as loading
-  const shouldFetchSession = !isAuthenticated && !isSessionLoading && !isDescopeBridge();
+  const shouldFetchSession =
+    !isAuthenticated && !isSessionLoading && !isDescopeBridge();
 
-  // we want this to happen before returning a value so we are using "useMemo" and not "useEffect"
-  useMemo(() => {
-    if (shouldFetchSession && !isSessionFetched) {
-      isLoading.current = true;
-    }
-  }, [isSessionFetched]);
+  // Derive the loading state directly on every render instead of caching it in
+  // a ref that only updates when the context value *changes*. When refresh()
+  // short-circuits synchronously the AuthProvider's setIsSessionLoading(true)
+  // and (false) can be batched into a single commit (or React can bail out of
+  // the re-render entirely, since the value nets false→false) - the context
+  // value then never observably toggles, a change-keyed memo never re-runs, and
+  // a cached ref stays stuck `true` forever (#1393, and its resurfacing via the
+  // #1436 setTimeout race). Computing inline removes the dependency on observing
+  // the transition: we're loading while the SDK is actively refreshing, or
+  // before the one-shot fetch has completed for a session we expect to receive.
+  const isSessionLoadingResolved =
+    isSessionLoading ||
+    isOidcLoading ||
+    (shouldFetchSession && !isSessionFetched);
 
   // Fetch session if it's not already fetched
   // We want this to happen only once, so the dependency array should not contain shouldFetchSession
@@ -39,8 +39,9 @@ const useSession = () => {
       fetchSession();
     }
   }, [fetchSession]);
+
   return {
-    isSessionLoading: isLoading.current,
+    isSessionLoading: isSessionLoadingResolved,
     sessionToken: session,
     claims,
     isAuthenticated,

--- a/packages/sdks/react-sdk/test/components/AuthProviderSessionLoading.test.tsx
+++ b/packages/sdks/react-sdk/test/components/AuthProviderSessionLoading.test.tsx
@@ -3,6 +3,7 @@ import { createSdk } from '@descope/web-js-sdk';
 import { act, render, waitFor } from '@testing-library/react';
 import React from 'react';
 import { AuthProvider, useSession, useUser } from '../../src';
+import Context from '../../src/hooks/Context';
 
 jest.mock('@descope/web-js-sdk', () => {
   const sdk = {
@@ -105,6 +106,43 @@ describe('AuthProvider loading state on a rejected refresh / me', () => {
     } finally {
       rafSpy.mockRestore();
     }
+  });
+
+  // Regression for the #1436 stuck-loading race (admin-portal blank flow on
+  // loaded CI runners): useSession must not depend on *observing* an
+  // isSessionLoading true→false toggle. When refresh() short-circuits
+  // synchronously that transition can collapse into a single batched commit, so
+  // loading has to resolve off isSessionFetched instead of stranding `true`.
+  // This drives useSession directly: isSessionFetched flips false→true while
+  // isSessionLoading never toggles. Before the fix (ref cached on the toggle)
+  // this stayed 'true'.
+  it('resolves loading from isSessionFetched without an observed isSessionLoading toggle', () => {
+    const base = {
+      session: undefined,
+      claims: undefined,
+      isSessionLoading: false,
+      isOidcLoading: false,
+      isAuthenticated: false,
+      fetchSession: jest.fn(),
+    };
+
+    const { getByTestId, rerender } = render(
+      <Context.Provider value={{ ...base, isSessionFetched: false } as any}>
+        <SessionProbe />
+      </Context.Provider>,
+    );
+    // before the one-shot fetch completes we are loading, even though the
+    // context's isSessionLoading is false
+    expect(getByTestId('session-loading').textContent).toBe('true');
+
+    // fetch completes (isSessionFetched → true) WITHOUT isSessionLoading ever
+    // toggling to true and back
+    rerender(
+      <Context.Provider value={{ ...base, isSessionFetched: true } as any}>
+        <SessionProbe />
+      </Context.Provider>,
+    );
+    expect(getByTestId('session-loading').textContent).toBe('false');
   });
 
   it('clears isUserLoading when me rejects', async () => {


### PR DESCRIPTION
## Related Issues
Fixes: https://github.com/descope/etc/issues/17405

## Description
`useSession().isSessionLoading` could get stuck `true` forever for a fresh, unauthenticated user, leaving any UI that gates rendering on it permanently blank. It surfaced as a Sanitarium failure in the Admin Portal (the login flow never rendered) and reproduces on slow/loaded machines (CI runners) but not on fast dev boxes.

**Root cause.** `useSession` cached its loading flag in a ref that only cleared when the `useMemo` keyed on `[isSessionLoading]` re-ran — i.e. only when the context value actually *toggled*. For a fresh user `refresh()` short-circuits synchronously, so `setIsSessionLoading(true)` and `(false)` can batch into a single commit that nets `false → false` (or React bails out of the re-render entirely). The value never toggles, the memo never re-runs, and the ref is stranded `true` (original #1393). #1436 replaced the `requestAnimationFrame` deferral with a plain `setTimeout(0)`, which can fire before React commits the `true` render under load, re-coalescing the two updates — so the stuck state came back on loaded runners.

**Fix.**
- `useSession` now derives the loading flag directly each render (`isSessionLoading || isOidcLoading || (shouldFetchSession && !isSessionFetched)`) instead of a change-keyed ref, so correctness no longer depends on observing the toggle.
- `AuthProvider` exposes `isSessionFetched` as observable state (mirroring the existing one-shot ref) so completing the fetch always forces a re-render — otherwise React can bail out of the `false → false` commit and never propagate the resolved state.
- The `setTimeout` deferral is kept (still fixes #1433); existing regression tests are unchanged and green.

`useUser` uses the identical ref-cached-on-toggle pattern (`isUserLoading`) and has the same latent bug; not fixed here since it isn't in the reproduced path (it only fetches when authenticated).

## Verification
- react-sdk suite: **82/82 pass** (added 1 regression test; the #1393 and #1433 guards are unchanged). The new test fails on `origin/main` (`Received: "true"`) and passes with the fix.
- End-to-end: built this react-sdk, bundled it into a production admin-portal build, and drove it headless with CDP CPU throttling (which reproduces the CI race). Fixed renders the login flow and clears `isSessionLoading` at 1× / 4× / 10× / 20×; unpatched `2.30.9` was blank at ≥ 4×.

## Must
- [x] Tests
- [ ] Documentation (if applicable)
