### PR TITLE
Revert "fix(react-sdk): clear isSessionLoading via setTimeout so it also fires in backgrounded tabs"

### DIFF
--- a/packages/sdks/react-sdk/src/components/AuthProvider/AuthProvider.tsx
+++ b/packages/sdks/react-sdk/src/components/AuthProvider/AuthProvider.tsx
@@ -150,17 +150,15 @@ const AuthProvider: FC<IAuthProviderProps> = ({
 
     setIsSessionLoading(true);
     const stopSessionLoading = () => {
-      // Defer to a separate macrotask so React doesn't batch this with
+      // Defer to a separate render pass so React doesn't batch this with
       // the setIsSessionLoading(true) above when refresh() short-circuits
       // synchronously - downstream consumers (e.g. useSession) need to
-      // observe the false→true→false loading transition (#1393).
-      // Deliberately not requestAnimationFrame: rAF callbacks don't run
-      // while the tab is backgrounded (e.g. a login page opened from an
-      // email magic link), which left isSessionLoading stuck true (#1433).
-      // setTimeout always fires, visible tab or not.
-      setTimeout(() => {
-        setIsSessionLoading(false);
-      }, 0);
+      // observe the false→true→false loading transition (#1393)
+      requestAnimationFrame(() => {
+        setTimeout(() => {
+          setIsSessionLoading(false);
+        }, 0);
+      });
     };
     // Clear the loading state on both fulfilment and rejection. A rejected
     // refresh (e.g. a transient network failure on the proactive refresh) must

--- a/packages/sdks/react-sdk/test/components/AuthProviderSessionLoading.test.tsx
+++ b/packages/sdks/react-sdk/test/components/AuthProviderSessionLoading.test.tsx
@@ -1,6 +1,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { createSdk } from '@descope/web-js-sdk';
-import { act, render, waitFor } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import React from 'react';
 import { AuthProvider, useSession, useUser } from '../../src';
 
@@ -50,61 +50,6 @@ describe('AuthProvider loading state on a rejected refresh / me', () => {
     await waitFor(() =>
       expect(getByTestId('session-loading').textContent).toBe('false'),
     );
-  });
-
-  // Regression for #1393 - when refresh() short-circuits synchronously the
-  // isSessionLoading clear must land in a separate macrotask, so consumers
-  // always observe the true→false transition instead of both updates being
-  // batched into a single render
-  it('defers the isSessionLoading clear to a separate macrotask', async () => {
-    jest.useFakeTimers();
-    try {
-      const { getByTestId } = render(
-        <AuthProvider projectId="p1">
-          <SessionProbe />
-        </AuthProvider>,
-      );
-
-      // let refresh() resolve and its microtask handlers run - the clear must
-      // not have landed yet, consumers still see the loading state
-      await act(async () => {
-        await Promise.resolve();
-      });
-      expect(refresh).toHaveBeenCalled();
-      expect(getByTestId('session-loading').textContent).toBe('true');
-
-      // the deferred clear fires from a timer
-      await act(async () => {
-        jest.runAllTimers();
-      });
-      expect(getByTestId('session-loading').textContent).toBe('false');
-    } finally {
-      jest.useRealTimers();
-    }
-  });
-
-  // Regression for #1433 - the loading clear must not depend on
-  // requestAnimationFrame, which never fires while the tab is backgrounded
-  // (e.g. a login page opened from an email magic link)
-  it('clears isSessionLoading even when requestAnimationFrame never fires', async () => {
-    const rafSpy = jest
-      .spyOn(window, 'requestAnimationFrame')
-      .mockImplementation(() => 1); // backgrounded tab: callback never runs
-
-    try {
-      const { getByTestId } = render(
-        <AuthProvider projectId="p1">
-          <SessionProbe />
-        </AuthProvider>,
-      );
-
-      await waitFor(() => expect(refresh).toHaveBeenCalled());
-      await waitFor(() =>
-        expect(getByTestId('session-loading').textContent).toBe('false'),
-      );
-    } finally {
-      rafSpy.mockRestore();
-    }
   });
 
   it('clears isUserLoading when me rejects', async () => {


### PR DESCRIPTION
Reverts descope/descope-js#1436

reverting until later conclusion 