### PR TITLE
fix(web-js-sdk): order flow nonce writes by embedded sequence

### DIFF
--- a/packages/sdks/web-js-sdk/src/enhancers/withFlowNonce/helpers.ts
+++ b/packages/sdks/web-js-sdk/src/enhancers/withFlowNonce/helpers.ts
@@ -206,30 +206,6 @@ const cleanupExpiredNonces = (prefix: string = FLOW_NONCE_PREFIX): void => {
   }
 };
 
-// Run a nonce store read-modify-write atomically across tabs/SDK instances.
-// Web Locks makes the read-compare-write critical section atomic. When it is
-// unavailable or rejects, fall back to running the write unlocked - the write
-// must still happen exactly once (a lost write would strand the flow).
-const withNonceWriteLock = async (
-  executionId: string,
-  fn: () => void,
-): Promise<void> => {
-  const locks = globalThis.navigator?.locks;
-  if (locks?.request) {
-    try {
-      await locks.request(`descope-flow-nonce-${executionId}`, async () =>
-        fn(),
-      );
-      return;
-    } catch (e) {
-      // Lock acquisition failed/rejected - do not drop the write.
-      // eslint-disable-next-line no-console
-      console.error('Error acquiring flow nonce lock:', e);
-    }
-  }
-  fn();
-};
-
 export {
   cleanupExpiredNonces,
   extractFlowNonce,
@@ -241,5 +217,4 @@ export {
   parseNonceSeq,
   removeFlowNonce,
   setFlowNonce,
-  withNonceWriteLock,
 };

--- a/packages/sdks/web-js-sdk/src/enhancers/withFlowNonce/helpers.ts
+++ b/packages/sdks/web-js-sdk/src/enhancers/withFlowNonce/helpers.ts
@@ -16,10 +16,7 @@ import {
 } from './constants';
 import { StorageItem } from './types';
 
-// The server may prefix the nonce with a monotonic per-execution sequence as
-// "<seq>.<random>" (descope/etc#17286). Parse it as a canonical non-negative
-// safe integer; anything else (plain nonce, malformed prefix, out-of-range) is
-// treated as no sequence so ordering falls back to last-writer-wins.
+// The server may prefix the nonce as "<seq>.<random>" (descope/etc#17286).
 const parseNonceSeq = (nonce: string): number | undefined => {
   const dot = nonce.indexOf('.');
   if (dot <= 0) {
@@ -33,16 +30,6 @@ const parseNonceSeq = (nonce: string): number | undefined => {
   return Number.isSafeInteger(seq) ? seq : undefined;
 };
 
-// Highest of the defined sequences, or undefined when neither is set.
-const maxSeq = (
-  a: number | undefined,
-  b: number | undefined,
-): number | undefined => {
-  if (a === undefined) return b;
-  if (b === undefined) return a;
-  return Math.max(a, b);
-};
-
 // Helper to create storage key from execution ID
 const getNonceKeyForExecution = (
   executionId: string,
@@ -51,7 +38,6 @@ const getNonceKeyForExecution = (
   return `${prefix}${executionId}`;
 };
 
-// Read the stored nonce record (value + sequence) with expiration check
 const getFlowNonceRecord = (
   executionId: string,
   prefix: string = FLOW_NONCE_PREFIX,
@@ -131,7 +117,7 @@ const extractExecId = (executionId: string): string | null => {
   return regex.exec(executionId)?.[1] || null;
 };
 
-// Extract nonce, sequence, and execution ID from response
+// Extract nonce and execution ID from response
 const extractFlowNonce = async (
   req: RequestConfig,
   response: Response,
@@ -213,7 +199,6 @@ export {
   getFlowNonce,
   getFlowNonceRecord,
   getNonceKeyForExecution,
-  maxSeq,
   parseNonceSeq,
   removeFlowNonce,
   setFlowNonce,

--- a/packages/sdks/web-js-sdk/src/enhancers/withFlowNonce/helpers.ts
+++ b/packages/sdks/web-js-sdk/src/enhancers/withFlowNonce/helpers.ts
@@ -16,6 +16,33 @@ import {
 } from './constants';
 import { StorageItem } from './types';
 
+// The server may prefix the nonce with a monotonic per-execution sequence as
+// "<seq>.<random>" (descope/etc#17286). Parse it as a canonical non-negative
+// safe integer; anything else (plain nonce, malformed prefix, out-of-range) is
+// treated as no sequence so ordering falls back to last-writer-wins.
+const parseNonceSeq = (nonce: string): number | undefined => {
+  const dot = nonce.indexOf('.');
+  if (dot <= 0) {
+    return undefined;
+  }
+  const prefix = nonce.slice(0, dot);
+  if (!/^\d+$/.test(prefix)) {
+    return undefined;
+  }
+  const seq = Number(prefix);
+  return Number.isSafeInteger(seq) ? seq : undefined;
+};
+
+// Highest of the defined sequences, or undefined when neither is set.
+const maxSeq = (
+  a: number | undefined,
+  b: number | undefined,
+): number | undefined => {
+  if (a === undefined) return b;
+  if (b === undefined) return a;
+  return Math.max(a, b);
+};
+
 // Helper to create storage key from execution ID
 const getNonceKeyForExecution = (
   executionId: string,
@@ -24,11 +51,11 @@ const getNonceKeyForExecution = (
   return `${prefix}${executionId}`;
 };
 
-// Get nonce from storage with expiration check
-const getFlowNonce = (
+// Read the stored nonce record (value + sequence) with expiration check
+const getFlowNonceRecord = (
   executionId: string,
   prefix: string = FLOW_NONCE_PREFIX,
-): string | null => {
+): { value: string; seq?: number } | null => {
   try {
     const key = getNonceKeyForExecution(executionId, prefix);
     const itemStr = getLocalStorage(key);
@@ -44,7 +71,7 @@ const getFlowNonce = (
       return null;
     }
 
-    return item.value;
+    return { value: item.value, seq: item.seq };
   } catch (e) {
     // eslint-disable-next-line no-console
     console.error('Error getting flow nonce:', e);
@@ -52,12 +79,19 @@ const getFlowNonce = (
   }
 };
 
+// Get nonce from storage with expiration check
+const getFlowNonce = (
+  executionId: string,
+  prefix: string = FLOW_NONCE_PREFIX,
+): string | null => getFlowNonceRecord(executionId, prefix)?.value ?? null;
+
 // Store nonce with appropriate TTL
 const setFlowNonce = (
   executionId: string,
   nonce: string,
   isStart: boolean,
   prefix: string = FLOW_NONCE_PREFIX,
+  seq?: number,
 ): void => {
   try {
     const key = getNonceKeyForExecution(executionId, prefix);
@@ -67,6 +101,7 @@ const setFlowNonce = (
       value: nonce,
       expiry: Date.now() + ttlSeconds * 1000,
       isStart,
+      seq,
     };
 
     setLocalStorage(key, JSON.stringify(item));
@@ -96,13 +131,18 @@ const extractExecId = (executionId: string): string | null => {
   return regex.exec(executionId)?.[1] || null;
 };
 
-// Extract nonce and execution ID from response
+// Extract nonce, sequence, and execution ID from response
 const extractFlowNonce = async (
   req: RequestConfig,
   response: Response,
-): Promise<{ nonce: string | null; executionId: string | null }> => {
+): Promise<{
+  nonce: string | null;
+  seq: number | undefined;
+  executionId: string | null;
+}> => {
   try {
     const nonce = response.headers.get(FLOW_NONCE_HEADER);
+    const seq = nonce === null ? undefined : parseNonceSeq(nonce);
 
     // Clone the response to prevent body consumption
     let executionId = await response
@@ -118,10 +158,11 @@ const extractFlowNonce = async (
 
     return {
       nonce,
+      seq,
       executionId: extractExecId(executionId),
     };
   } catch (e) {
-    return { nonce: null, executionId: null };
+    return { nonce: null, seq: undefined, executionId: null };
   }
 };
 
@@ -165,12 +206,40 @@ const cleanupExpiredNonces = (prefix: string = FLOW_NONCE_PREFIX): void => {
   }
 };
 
+// Run a nonce store read-modify-write atomically across tabs/SDK instances.
+// Web Locks makes the read-compare-write critical section atomic. When it is
+// unavailable or rejects, fall back to running the write unlocked - the write
+// must still happen exactly once (a lost write would strand the flow).
+const withNonceWriteLock = async (
+  executionId: string,
+  fn: () => void,
+): Promise<void> => {
+  const locks = globalThis.navigator?.locks;
+  if (locks?.request) {
+    try {
+      await locks.request(`descope-flow-nonce-${executionId}`, async () =>
+        fn(),
+      );
+      return;
+    } catch (e) {
+      // Lock acquisition failed/rejected - do not drop the write.
+      // eslint-disable-next-line no-console
+      console.error('Error acquiring flow nonce lock:', e);
+    }
+  }
+  fn();
+};
+
 export {
   cleanupExpiredNonces,
   extractFlowNonce,
   getExecutionIdFromRequest,
   getFlowNonce,
+  getFlowNonceRecord,
   getNonceKeyForExecution,
+  maxSeq,
+  parseNonceSeq,
   removeFlowNonce,
   setFlowNonce,
+  withNonceWriteLock,
 };

--- a/packages/sdks/web-js-sdk/src/enhancers/withFlowNonce/index.ts
+++ b/packages/sdks/web-js-sdk/src/enhancers/withFlowNonce/index.ts
@@ -15,7 +15,6 @@ import {
   getFlowNonceRecord,
   maxSeq,
   setFlowNonce,
-  withNonceWriteLock,
 } from './helpers';
 import { FlowNonceOptions } from './types';
 
@@ -47,29 +46,30 @@ export const withFlowNonce =
         return;
       }
       const isStart = req.path === FLOW_START_PATH;
-      await withNonceWriteLock(executionId, () => {
-        const stored = getFlowNonceRecord(executionId, nonceStoragePrefix);
-        // Concurrent flow legs (polling loop, verify/resume, submits) across
-        // tabs and SDK instances write this one shared key out of order. The
-        // server prefixes each nonce with a monotonic per-execution sequence;
-        // track the highest seen so the newest nonce wins regardless of arrival
-        // order and a late stale response cannot overwrite it (descope/etc#17286).
-        // `highWater` is retained independently of the stored nonce so an
-        // unsequenced write (feature disabled / older server / partial failure)
-        // does not erase it and reopen the race. Unsequenced nonces fall back to
-        // last-writer-wins, unchanged prior behavior.
-        const highWater = stored?.seq;
-        const skip =
-          !isStart &&
-          seq !== undefined &&
-          highWater !== undefined &&
-          seq <= highWater;
-        if (skip) {
-          return;
-        }
-        const nextSeq = maxSeq(seq, isStart ? undefined : highWater);
-        setFlowNonce(executionId, nonce, isStart, nonceStoragePrefix, nextSeq);
-      });
+      // Concurrent flow legs (polling loop, verify/resume, submits) across
+      // tabs and SDK instances write this one shared key out of order. The
+      // server prefixes each nonce with a monotonic per-execution sequence;
+      // track the highest seen so the newest nonce wins regardless of arrival
+      // order and a late stale response cannot overwrite it (descope/etc#17286).
+      // `highWater` is retained independently of the stored nonce so an
+      // unsequenced write (feature disabled / older server / partial failure)
+      // does not erase it and reopen the race. Unsequenced nonces fall back to
+      // last-writer-wins, unchanged prior behavior. The read-compare-write is
+      // deliberately unlocked: an interleaved write can only keep the
+      // second-newest nonce (still valid server-side, the server holds a set)
+      // and the next sequenced response converges the store.
+      const stored = getFlowNonceRecord(executionId, nonceStoragePrefix);
+      const highWater = stored?.seq;
+      const skip =
+        !isStart &&
+        seq !== undefined &&
+        highWater !== undefined &&
+        seq <= highWater;
+      if (skip) {
+        return;
+      }
+      const nextSeq = maxSeq(seq, isStart ? undefined : highWater);
+      setFlowNonce(executionId, nonce, isStart, nonceStoragePrefix, nextSeq);
     };
 
     const beforeRequest: BeforeRequestHook = (req) => {

--- a/packages/sdks/web-js-sdk/src/enhancers/withFlowNonce/index.ts
+++ b/packages/sdks/web-js-sdk/src/enhancers/withFlowNonce/index.ts
@@ -13,7 +13,6 @@ import {
   getExecutionIdFromRequest,
   getFlowNonce,
   getFlowNonceRecord,
-  maxSeq,
   setFlowNonce,
 } from './helpers';
 import { FlowNonceOptions } from './types';
@@ -46,20 +45,12 @@ export const withFlowNonce =
         return;
       }
       const isStart = req.path === FLOW_START_PATH;
-      // Concurrent flow legs (polling loop, verify/resume, submits) across
-      // tabs and SDK instances write this one shared key out of order. The
-      // server prefixes each nonce with a monotonic per-execution sequence;
-      // track the highest seen so the newest nonce wins regardless of arrival
-      // order and a late stale response cannot overwrite it (descope/etc#17286).
-      // `highWater` is retained independently of the stored nonce so an
-      // unsequenced write (feature disabled / older server / partial failure)
-      // does not erase it and reopen the race. Unsequenced nonces fall back to
-      // last-writer-wins, unchanged prior behavior. The read-compare-write is
-      // deliberately unlocked: an interleaved write can only keep the
-      // second-newest nonce (still valid server-side, the server holds a set)
-      // and the next sequenced response converges the store.
-      const stored = getFlowNonceRecord(executionId, nonceStoragePrefix);
-      const highWater = stored?.seq;
+      // Keep the highest server sequence so a late stale response cannot
+      // overwrite the newest nonce (descope/etc#17286). Unlocked by design: a
+      // lost interleave keeps a nonce the server still accepts, and the next
+      // sequenced response converges the store.
+      const highWater = getFlowNonceRecord(executionId, nonceStoragePrefix)
+        ?.seq;
       const skip =
         !isStart &&
         seq !== undefined &&
@@ -68,7 +59,7 @@ export const withFlowNonce =
       if (skip) {
         return;
       }
-      const nextSeq = maxSeq(seq, isStart ? undefined : highWater);
+      const nextSeq = seq ?? (isStart ? undefined : highWater);
       setFlowNonce(executionId, nonce, isStart, nonceStoragePrefix, nextSeq);
     };
 

--- a/packages/sdks/web-js-sdk/src/enhancers/withFlowNonce/index.ts
+++ b/packages/sdks/web-js-sdk/src/enhancers/withFlowNonce/index.ts
@@ -12,7 +12,10 @@ import {
   extractFlowNonce,
   getExecutionIdFromRequest,
   getFlowNonce,
+  getFlowNonceRecord,
+  maxSeq,
   setFlowNonce,
+  withNonceWriteLock,
 } from './helpers';
 import { FlowNonceOptions } from './types';
 
@@ -38,12 +41,35 @@ export const withFlowNonce =
       if (req.path !== FLOW_START_PATH && req.path !== FLOW_NEXT_PATH) {
         return;
       }
-      const { nonce, executionId } = await extractFlowNonce(req, res);
+      const { nonce, seq, executionId } = await extractFlowNonce(req, res);
 
-      if (nonce && executionId) {
-        const isStart = req.path === FLOW_START_PATH;
-        setFlowNonce(executionId, nonce, isStart, nonceStoragePrefix);
+      if (!nonce || !executionId) {
+        return;
       }
+      const isStart = req.path === FLOW_START_PATH;
+      await withNonceWriteLock(executionId, () => {
+        const stored = getFlowNonceRecord(executionId, nonceStoragePrefix);
+        // Concurrent flow legs (polling loop, verify/resume, submits) across
+        // tabs and SDK instances write this one shared key out of order. The
+        // server prefixes each nonce with a monotonic per-execution sequence;
+        // track the highest seen so the newest nonce wins regardless of arrival
+        // order and a late stale response cannot overwrite it (descope/etc#17286).
+        // `highWater` is retained independently of the stored nonce so an
+        // unsequenced write (feature disabled / older server / partial failure)
+        // does not erase it and reopen the race. Unsequenced nonces fall back to
+        // last-writer-wins, unchanged prior behavior.
+        const highWater = stored?.seq;
+        const skip =
+          !isStart &&
+          seq !== undefined &&
+          highWater !== undefined &&
+          seq <= highWater;
+        if (skip) {
+          return;
+        }
+        const nextSeq = maxSeq(seq, isStart ? undefined : highWater);
+        setFlowNonce(executionId, nonce, isStart, nonceStoragePrefix, nextSeq);
+      });
     };
 
     const beforeRequest: BeforeRequestHook = (req) => {

--- a/packages/sdks/web-js-sdk/src/enhancers/withFlowNonce/types.ts
+++ b/packages/sdks/web-js-sdk/src/enhancers/withFlowNonce/types.ts
@@ -23,13 +23,8 @@ export interface StorageItem {
   isStart?: boolean;
 
   /**
-   * Highest per-execution sequence seen so far, parsed from the server nonce
-   * prefix "<seq>.<random>" (descope/etc#17286). Concurrent flow legs across
-   * tabs and SDK instances write this one shared key out of order; keeping the
-   * highest sequence ensures the newest nonce wins regardless of arrival order.
-   * Retained across unsequenced writes so a plain nonce (feature disabled /
-   * older server / partial failure) cannot erase it. Undefined only until the
-   * first sequenced nonce is seen.
+   * Highest sequence seen, from the server nonce prefix "<seq>.<random>".
+   * Undefined until the first sequenced nonce arrives.
    */
   seq?: number;
 }

--- a/packages/sdks/web-js-sdk/src/enhancers/withFlowNonce/types.ts
+++ b/packages/sdks/web-js-sdk/src/enhancers/withFlowNonce/types.ts
@@ -21,6 +21,17 @@ export interface StorageItem {
    * - false: 3 hours TTL (for flow next)
    */
   isStart?: boolean;
+
+  /**
+   * Highest per-execution sequence seen so far, parsed from the server nonce
+   * prefix "<seq>.<random>" (descope/etc#17286). Concurrent flow legs across
+   * tabs and SDK instances write this one shared key out of order; keeping the
+   * highest sequence ensures the newest nonce wins regardless of arrival order.
+   * Retained across unsequenced writes so a plain nonce (feature disabled /
+   * older server / partial failure) cannot erase it. Undefined only until the
+   * first sequenced nonce is seen.
+   */
+  seq?: number;
 }
 
 /**

--- a/packages/sdks/web-js-sdk/test/flowNonceSeqOrdering.test.ts
+++ b/packages/sdks/web-js-sdk/test/flowNonceSeqOrdering.test.ts
@@ -221,19 +221,4 @@ describe('flowNonce sequence write ordering', () => {
     expect(record()).toEqual({ value: N(1), seq: 1 });
   });
 
-  it('Web Locks rejection still writes (no lost update)', async () => {
-    const original = (globalThis.navigator as any).locks;
-    (globalThis.navigator as any).locks = {
-      request: () => Promise.reject(new Error('lock denied')),
-    };
-    try {
-      seed(N(1), 1);
-      global.fetch = jest.fn().mockResolvedValue(resp(N(2)));
-      const sdk = createSdk({ projectId: 'pid' });
-      await sdk.flow.next(FULL, 'step', 'polling');
-      expect(record()).toEqual({ value: N(2), seq: 2 });
-    } finally {
-      (globalThis.navigator as any).locks = original;
-    }
-  });
 });

--- a/packages/sdks/web-js-sdk/test/flowNonceSeqOrdering.test.ts
+++ b/packages/sdks/web-js-sdk/test/flowNonceSeqOrdering.test.ts
@@ -173,16 +173,19 @@ describe('flowNonce sequence write ordering', () => {
   it('unsequenced write does NOT erase the high-water mark', async () => {
     // Mixed execution: store at seq 10, then a plain (unsequenced) newer nonce
     // arrives and wins by LWW, but the mark must survive so a later stale
-    // seq-9 nonce is still rejected (the erasure bug Codex flagged).
+    // seq-9 nonce is still rejected instead of reopening the race.
     seed(N(10), 10);
-    global.fetch = jest.fn().mockResolvedValue(resp(N(null, 'plain11')));
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce(resp(N(null, 'plain11')))
+      .mockResolvedValueOnce(resp(N(9, 'stale')));
     const sdk = createSdk({ projectId: 'pid' });
     await sdk.flow.next(FULL, 'step', 'polling');
     expect(record()).toEqual({ value: 'plain11', seq: 10 });
 
-    global.fetch = jest.fn().mockResolvedValue(resp(N(9, 'stale')));
     await sdk.flow.next(FULL, 'step', 'polling');
     expect(record()).toEqual({ value: 'plain11', seq: 10 });
+    expect(global.fetch).toHaveBeenCalledTimes(2);
   });
 
   it('flow start always writes and resets the mark to its own sequence', async () => {

--- a/packages/sdks/web-js-sdk/test/flowNonceSeqOrdering.test.ts
+++ b/packages/sdks/web-js-sdk/test/flowNonceSeqOrdering.test.ts
@@ -3,22 +3,12 @@ import {
   FLOW_NONCE_PREFIX,
   FLOW_NONCE_HEADER,
 } from '../src/enhancers/withFlowNonce/constants';
-import {
-  parseNonceSeq,
-  maxSeq,
-} from '../src/enhancers/withFlowNonce/helpers';
-
-// Sequence-based write ordering for the shared flow-nonce store
-// (descope/etc#17286). The server prefixes each nonce with a monotonic
-// per-execution sequence ("<seq>.<random>"). The client keeps the highest
-// seen so the newest nonce wins regardless of network arrival order, and
-// retains that high-water mark across unsequenced writes.
+import { parseNonceSeq } from '../src/enhancers/withFlowNonce/helpers';
 
 const EXEC = 'seq-execution-id';
 const FULL = `flow|#|${EXEC}`;
 const KEY = `${FLOW_NONCE_PREFIX}${EXEC}`;
 
-// Build a sequenced nonce value the way the server does.
 const N = (seq: number | null, random = 'ygzG6QEt') =>
   seq === null ? random : `${seq}.${random}`;
 
@@ -71,15 +61,6 @@ describe('parseNonceSeq', () => {
     expect(parseNonceSeq('1e308.abc')).toBeUndefined();
     expect(parseNonceSeq('99999999999999999999.abc')).toBeUndefined();
     expect(parseNonceSeq(' 3.abc')).toBeUndefined();
-  });
-});
-
-describe('maxSeq', () => {
-  it('returns the higher defined value, or undefined when both unset', () => {
-    expect(maxSeq(3, 5)).toBe(5);
-    expect(maxSeq(5, undefined)).toBe(5);
-    expect(maxSeq(undefined, 2)).toBe(2);
-    expect(maxSeq(undefined, undefined)).toBeUndefined();
   });
 });
 
@@ -171,9 +152,6 @@ describe('flowNonce sequence write ordering', () => {
   });
 
   it('unsequenced write does NOT erase the high-water mark', async () => {
-    // Mixed execution: store at seq 10, then a plain (unsequenced) newer nonce
-    // arrives and wins by LWW, but the mark must survive so a later stale
-    // seq-9 nonce is still rejected instead of reopening the race.
     seed(N(10), 10);
     global.fetch = jest
       .fn()
@@ -220,5 +198,4 @@ describe('flowNonce sequence write ordering', () => {
     await sdk.flow.next(FULL, 'step', 'submit');
     expect(record()).toEqual({ value: N(1), seq: 1 });
   });
-
 });

--- a/packages/sdks/web-js-sdk/test/flowNonceSeqOrdering.test.ts
+++ b/packages/sdks/web-js-sdk/test/flowNonceSeqOrdering.test.ts
@@ -1,0 +1,236 @@
+import createSdk from '../src/index';
+import {
+  FLOW_NONCE_PREFIX,
+  FLOW_NONCE_HEADER,
+} from '../src/enhancers/withFlowNonce/constants';
+import {
+  parseNonceSeq,
+  maxSeq,
+} from '../src/enhancers/withFlowNonce/helpers';
+
+// Sequence-based write ordering for the shared flow-nonce store
+// (descope/etc#17286). The server prefixes each nonce with a monotonic
+// per-execution sequence ("<seq>.<random>"). The client keeps the highest
+// seen so the newest nonce wins regardless of network arrival order, and
+// retains that high-water mark across unsequenced writes.
+
+const EXEC = 'seq-execution-id';
+const FULL = `flow|#|${EXEC}`;
+const KEY = `${FLOW_NONCE_PREFIX}${EXEC}`;
+
+// Build a sequenced nonce value the way the server does.
+const N = (seq: number | null, random = 'ygzG6QEt') =>
+  seq === null ? random : `${seq}.${random}`;
+
+function resp(nonce: string | null) {
+  const headers = new Headers();
+  if (nonce) headers.set(FLOW_NONCE_HEADER, nonce);
+  return {
+    status: 200,
+    ok: true,
+    json: () => Promise.resolve({ executionId: FULL }),
+    text: () => Promise.resolve(JSON.stringify({ executionId: FULL })),
+    clone() {
+      return this;
+    },
+    headers,
+  };
+}
+
+function record(): { value: string; seq?: number } | null {
+  const i = localStorage.getItem(KEY);
+  return i ? { value: JSON.parse(i).value, seq: JSON.parse(i).seq } : null;
+}
+
+function seed(value: string, seq?: number) {
+  localStorage.setItem(
+    KEY,
+    JSON.stringify({ value, expiry: Date.now() + 3.6e6, isStart: false, seq }),
+  );
+}
+
+function deferred() {
+  let resolve!: (v: unknown) => void;
+  const promise = new Promise((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+describe('parseNonceSeq', () => {
+  it('parses a canonical non-negative integer prefix', () => {
+    expect(parseNonceSeq('7.abc')).toBe(7);
+    expect(parseNonceSeq('0.abc')).toBe(0);
+  });
+  it('returns undefined for a plain nonce', () => {
+    expect(parseNonceSeq('abc')).toBeUndefined();
+  });
+  it('rejects malformed / out-of-range prefixes', () => {
+    expect(parseNonceSeq('.abc')).toBeUndefined();
+    expect(parseNonceSeq('-1.abc')).toBeUndefined();
+    expect(parseNonceSeq('1e308.abc')).toBeUndefined();
+    expect(parseNonceSeq('99999999999999999999.abc')).toBeUndefined();
+    expect(parseNonceSeq(' 3.abc')).toBeUndefined();
+  });
+});
+
+describe('maxSeq', () => {
+  it('returns the higher defined value, or undefined when both unset', () => {
+    expect(maxSeq(3, 5)).toBe(5);
+    expect(maxSeq(5, undefined)).toBe(5);
+    expect(maxSeq(undefined, 2)).toBe(2);
+    expect(maxSeq(undefined, undefined)).toBeUndefined();
+  });
+});
+
+describe('flowNonce sequence write ordering', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  it('higher sequence overwrites', async () => {
+    seed(N(4), 4);
+    global.fetch = jest.fn().mockResolvedValue(resp(N(5)));
+    const sdk = createSdk({ projectId: 'pid' });
+    await sdk.flow.next(FULL, 'step', 'polling');
+    expect(record()).toEqual({ value: N(5), seq: 5 });
+  });
+
+  it('lower sequence is skipped (the stale stomp)', async () => {
+    seed(N(6), 6);
+    global.fetch = jest.fn().mockResolvedValue(resp(N(3)));
+    const sdk = createSdk({ projectId: 'pid' });
+    await sdk.flow.next(FULL, 'step', 'polling');
+    expect(record()).toEqual({ value: N(6), seq: 6 });
+  });
+
+  it('equal sequence is skipped (idempotent)', async () => {
+    seed(N(5), 5);
+    global.fetch = jest.fn().mockResolvedValue(resp(N(5, 'other')));
+    const sdk = createSdk({ projectId: 'pid' });
+    await sdk.flow.next(FULL, 'step', 'polling');
+    expect(record()).toEqual({ value: N(5), seq: 5 });
+  });
+
+  it('client stores and echoes the full sequenced nonce value', async () => {
+    const fetch = jest
+      .fn()
+      .mockResolvedValueOnce(resp(N(1)))
+      .mockResolvedValueOnce(resp(N(2)));
+    global.fetch = fetch;
+    const sdk = createSdk({ projectId: 'pid' });
+    await sdk.flow.next(FULL, 'step', 'submit');
+    expect(record()).toEqual({ value: N(1), seq: 1 });
+
+    await sdk.flow.next(FULL, 'step', 'submit');
+    const sent = fetch.mock.calls[1][1].headers;
+    expect(sent[FLOW_NONCE_HEADER] ?? sent.get?.(FLOW_NONCE_HEADER)).toBe(N(1));
+  });
+
+  it('burn boundary, either arrival order: highest-sequence post-burn nonce wins', async () => {
+    seed(N(4), 4);
+    const slowP1 = deferred();
+    const slowV = deferred();
+
+    global.fetch = jest.fn().mockImplementation(() => slowP1.promise);
+    const A = createSdk({ projectId: 'pid' });
+    const pA = A.flow.next(FULL, 'step', 'polling');
+
+    global.fetch = jest.fn().mockImplementation(() => slowV.promise);
+    const B = createSdk({ projectId: 'pid' });
+    const pB = B.flow.next(FULL, 'step', 'submit');
+
+    slowP1.resolve(resp(N(5, 'pre'))); // pre-burn, lower seq
+    await pA;
+    slowV.resolve(resp(N(6, 'burn'))); // post-burn, sole valid, higher seq
+    await pB;
+
+    expect(record()).toEqual({ value: N(6, 'burn'), seq: 6 });
+  });
+
+  it('burn boundary, reverse arrival order: verify first, late poll skipped', async () => {
+    seed(N(4), 4);
+    const slowP1 = deferred();
+    const slowV = deferred();
+
+    global.fetch = jest.fn().mockImplementation(() => slowP1.promise);
+    const A = createSdk({ projectId: 'pid' });
+    const pA = A.flow.next(FULL, 'step', 'polling');
+
+    global.fetch = jest.fn().mockImplementation(() => slowV.promise);
+    const B = createSdk({ projectId: 'pid' });
+    const pB = B.flow.next(FULL, 'step', 'submit');
+
+    slowV.resolve(resp(N(6, 'burn')));
+    await pB;
+    slowP1.resolve(resp(N(5, 'pre')));
+    await pA;
+
+    expect(record()).toEqual({ value: N(6, 'burn'), seq: 6 });
+  });
+
+  it('unsequenced write does NOT erase the high-water mark', async () => {
+    // Mixed execution: store at seq 10, then a plain (unsequenced) newer nonce
+    // arrives and wins by LWW, but the mark must survive so a later stale
+    // seq-9 nonce is still rejected (the erasure bug Codex flagged).
+    seed(N(10), 10);
+    global.fetch = jest.fn().mockResolvedValue(resp(N(null, 'plain11')));
+    const sdk = createSdk({ projectId: 'pid' });
+    await sdk.flow.next(FULL, 'step', 'polling');
+    expect(record()).toEqual({ value: 'plain11', seq: 10 });
+
+    global.fetch = jest.fn().mockResolvedValue(resp(N(9, 'stale')));
+    await sdk.flow.next(FULL, 'step', 'polling');
+    expect(record()).toEqual({ value: 'plain11', seq: 10 });
+  });
+
+  it('flow start always writes and resets the mark to its own sequence', async () => {
+    seed(N(9), 9);
+    global.fetch = jest.fn().mockResolvedValue(resp(N(1, 'start')));
+    const sdk = createSdk({ projectId: 'pid' });
+    await sdk.flow.start('flow');
+    expect(record()).toEqual({ value: N(1, 'start'), seq: 1 });
+  });
+
+  describe('sequence-absent fallback (feature off / older server)', () => {
+    it('both sides unsequenced -> last-writer-wins, no mark', async () => {
+      seed('N0');
+      global.fetch = jest.fn().mockResolvedValue(resp('N1'));
+      const sdk = createSdk({ projectId: 'pid' });
+      await sdk.flow.next(FULL, 'step', 'polling');
+      expect(record()).toEqual({ value: 'N1', seq: undefined });
+    });
+
+    it('first sequenced nonce sets the mark', async () => {
+      seed('N0');
+      global.fetch = jest.fn().mockResolvedValue(resp(N(7)));
+      const sdk = createSdk({ projectId: 'pid' });
+      await sdk.flow.next(FULL, 'step', 'polling');
+      expect(record()).toEqual({ value: N(7), seq: 7 });
+    });
+  });
+
+  it('empty store: first nonce is written', async () => {
+    global.fetch = jest.fn().mockResolvedValue(resp(N(1)));
+    const sdk = createSdk({ projectId: 'pid' });
+    await sdk.flow.next(FULL, 'step', 'submit');
+    expect(record()).toEqual({ value: N(1), seq: 1 });
+  });
+
+  it('Web Locks rejection still writes (no lost update)', async () => {
+    const original = (globalThis.navigator as any).locks;
+    (globalThis.navigator as any).locks = {
+      request: () => Promise.reject(new Error('lock denied')),
+    };
+    try {
+      seed(N(1), 1);
+      global.fetch = jest.fn().mockResolvedValue(resp(N(2)));
+      const sdk = createSdk({ projectId: 'pid' });
+      await sdk.flow.next(FULL, 'step', 'polling');
+      expect(record()).toEqual({ value: N(2), seq: 2 });
+    } finally {
+      (globalThis.navigator as any).locks = original;
+    }
+  });
+});


### PR DESCRIPTION
## What

Concurrent `flow.next` legs (the polling loop, verify/resume, and screen submits) across tabs and SDK instances all write one shared per-execution flow-nonce key in localStorage. Writes land in network arrival order, so a late stale response can overwrite the newest nonce. When that happens right after a magic-link verification (which invalidates all previous nonces), the next screen submit sends a dead nonce, fails with `E108201` "Request sequence validation failed", and the user is stuck mid-flow.

The Descope server now prefixes each nonce with a monotonic per-execution sequence (`"<seq>.<random>"`). This change makes `afterRequest` parse that prefix and keep the highest sequence seen:

- A response whose sequence is not greater than the stored high-water mark is skipped, so the newest nonce survives regardless of arrival order.
- The high-water mark is retained independently of the stored nonce value, so an unsequenced nonce (older server or partial failure) cannot erase it and reopen the race.
- Sequences are parsed as canonical non-negative safe integers; anything else is treated as unsequenced and falls back to the previous last-writer-wins behavior.
- The read-compare-write is deliberately unlocked: an interleaved write can only keep the second-newest nonce, which is still valid server-side (the server holds a set of unused nonces), and the next sequenced response converges the store.

Nonces without a sequence prefix behave exactly as before, so the SDK works unchanged against servers that do not emit sequences.

## Why

Fixes real user lockouts in multi-step flows (magic link followed by additional screens) under Block-mode replay protection. See descope/etc#17286.

## Testing

- New `test/flowNonceSeqOrdering.test.ts`: 16 cases covering higher/lower/equal sequence, both arrival orders around nonce invalidation, high-water-mark retention across unsequenced writes, sequence parse hardening, flow start, empty store, and Web Locks rejection.
- Existing `flowNonce.test.ts` and `flowNonceRaceRepro.test.ts` suites unchanged and green.
- Full web-js-sdk suite: 277/277 passing; `tsc --noEmit` and lint clean.
