### PR TITLE
feat(sdks)!: onScreenUpdate screen data moved under context.data

### DIFF
--- a/packages/sdks/react-sdk/README.md
+++ b/packages/sdks/react-sdk/README.md
@@ -213,7 +213,7 @@ The function can be sync or async, and should return a boolean indicating whethe
 - `true`: Render a custom screen
 - `false`: Render the default flow screen
 
-> **Breaking change (v-next):** server-produced screen data that used to sit directly on
+> **Breaking change (v3.0.0):** server-produced screen data that used to sit directly on
 > `context` now lives under **`context.data`** — e.g. `context.totp` → `context.data.totp`,
 > `context.inboundAppApproveScopes` → `context.data.inboundAppApproveScopes`. Status,
 > `form`, and identity fields (`user` / `project` / `lastAuth`) stay at the top level.

--- a/packages/sdks/vue-sdk/README.md
+++ b/packages/sdks/vue-sdk/README.md
@@ -104,7 +104,7 @@ The function can be sync or async, and should return a boolean indicating whethe
 - `true`: Render a custom screen
 - `false`: Render the default flow screen
 
-> **Breaking change (v-next):** server-produced screen data that used to sit directly on
+> **Breaking change (v3.0.0):** server-produced screen data that used to sit directly on
 > `context` now lives under **`context.data`** — e.g. `context.totp` → `context.data.totp`,
 > `context.inboundAppApproveScopes` → `context.data.inboundAppApproveScopes`. Status,
 > `form`, and identity fields (`user` / `project` / `lastAuth`) stay at the top level.

--- a/packages/sdks/web-component/README.md
+++ b/packages/sdks/web-component/README.md
@@ -281,7 +281,7 @@ by the flow). Their keys are the flow's own field names, so they don't fit the f
 above; they are omitted for now and reserved for a future `context.data.selects` map. This
 data was not available to custom screens before, so nothing changes for existing code.
 
-> **Breaking change (v-next):** screen-data fields that used to sit directly on `context`
+> **Breaking change (v4.0.0):** screen-data fields that used to sit directly on `context`
 > now live under `context.data`. Migrate reads accordingly, e.g.
 > `context.inboundAppApproveScopes` → `context.data.inboundAppApproveScopes`,
 > `context.totp` → `context.data.totp`. Status, `form`, and identity fields

--- a/packages/sdks/web-component/README.md
+++ b/packages/sdks/web-component/README.md
@@ -189,6 +189,12 @@ The function can be sync or async, and should return a boolean indicating whethe
 - `true`: Render a custom screen
 - `false`: Render the default flow screen
 
+> **Breaking change (v4.0.0):** server-produced screen data that used to sit directly on
+> `context` now lives under **`context.data`** — e.g. `context.totp` → `context.data.totp`,
+> `context.inboundAppApproveScopes` → `context.data.inboundAppApproveScopes`. Status,
+> `form`, and identity fields (`user` / `project` / `lastAuth`) stay at the top level.
+> See [The `context` object](#the-context-object) below for the full list of `context.data` fields.
+
 This function allows rendering custom screens instead of the default flow screens.
 It can be useful for highly customized UIs or specific logic not covered by the default screens
 


### PR DESCRIPTION
## Why

The `onScreenUpdate` breaking change (screen data moved under `context.data`) was released in [#1444](https://github.com/descope/descope-js/pull/1444) under **patch** versions by mistake — the squash commit message had a malformed breaking marker (`feat!(web-component):` instead of `feat(web-component)!:`), so `@jscutlery/semver` never saw it as breaking.

Result: the breaking change shipped as `react-sdk@2.30.11`, `vue-sdk@2.17.15`, `web-component@3.70.7` — consumers on `^2` / `^3` auto-pull a breaking change under a patch.

## What

Re-release the affected packages under correct versions via a properly-formatted breaking commit. Verified with `nx run <pkg>:version --dryRun`:

| package | current | → |
|---|---|---|
| `@descope/web-component` | 3.70.7 | **4.0.0** |
| `@descope/react-sdk` | 2.30.11 | **3.0.0** |
| `@descope/vue-sdk` | 2.17.15 | **3.0.0** |
| `@descope/nextjs-sdk` | 0.15.62 | 0.15.63 (auto dep-sync patch) |
| `@descope/angular-sdk` | 0.27.10 | 0.27.11 (auto dep-sync patch) |

The change itself only finalizes the `(v-next)` placeholder in the migration notes to the real version numbers (and adds the note to the web-component README, which was missing it) — enough to trigger the corrected bump.

## ⚠️ Merge instructions

Squash-merge with a message that keeps the breaking marker **and** `RELEASE`, e.g.:

```
feat(sdks)!: onScreenUpdate screen data moved under context.data (#PR) RELEASE

BREAKING CHANGE: server-produced screen data in onScreenUpdate now lives under context.data instead of directly on context.
```

If the `!` / `BREAKING CHANGE:` / `RELEASE` are dropped from the squash message, this repeats the original bug.

## Related PR
- #1444 — the original release that shipped the break under patch versions
