### PR TITLE
fix(web-component): handle rejected credentials.store promise

### DIFF
--- a/packages/sdks/web-component/src/lib/mixins/passwordManagerMixin.ts
+++ b/packages/sdks/web-component/src/lib/mixins/passwordManagerMixin.ts
@@ -225,7 +225,7 @@ export const passwordManagerMixin = createSingletonMixin(
             // store() may be missing (optional chain -> undefined) or reject
             // async (e.g. NotSupportedError in headless Chromium). catch the
             // rejection so it doesn't surface as an unhandled rejection.
-            void navigator?.credentials?.store?.(cred)?.catch((err) => {
+            navigator?.credentials?.store?.(cred)?.catch((err) => {
               this.logger.error(
                 'Could not store credentials',
                 err?.message ?? err,

--- a/packages/sdks/web-component/src/lib/mixins/passwordManagerMixin.ts
+++ b/packages/sdks/web-component/src/lib/mixins/passwordManagerMixin.ts
@@ -222,7 +222,15 @@ export const passwordManagerMixin = createSingletonMixin(
             }
             const cred = new globalThis.PasswordCredential({ id, password });
 
-            navigator?.credentials?.store?.(cred);
+            // store() may be missing (optional chain -> undefined) or reject
+            // async (e.g. NotSupportedError in headless Chromium). catch the
+            // rejection so it doesn't surface as an unhandled rejection.
+            void navigator?.credentials?.store?.(cred)?.catch((err) => {
+              this.logger.error(
+                'Could not store credentials',
+                err?.message ?? err,
+              );
+            });
           } catch (e) {
             this.logger.error('Could not store credentials', e.message);
           }

--- a/packages/sdks/web-component/test/descope-wc.password-managers.test.ts
+++ b/packages/sdks/web-component/test/descope-wc.password-managers.test.ts
@@ -99,6 +99,8 @@ describe('web-component', () => {
       startMock.mockReturnValueOnce(generateSdkResponse());
       nextMock.mockReturnValueOnce(generateSdkResponse({ screenId: '1' }));
 
+      const errorSpy = jest.spyOn(console, 'error');
+
       // headless Chromium rejects store() with NotSupportedError; the rejection
       // must be caught, not surface as an unhandled rejection
       Object.assign(navigator, {
@@ -130,7 +132,7 @@ describe('web-component', () => {
 
       await waitFor(
         () =>
-          expect(console.error).toHaveBeenCalledWith(
+          expect(errorSpy).toHaveBeenCalledWith(
             '[Descope]',
             'Could not store credentials',
             'The user agent does not support public key credentials',

--- a/packages/sdks/web-component/test/descope-wc.password-managers.test.ts
+++ b/packages/sdks/web-component/test/descope-wc.password-managers.test.ts
@@ -95,6 +95,50 @@ describe('web-component', () => {
       );
     });
 
+    it('should log and not throw when storing credentials rejects asynchronously', async () => {
+      startMock.mockReturnValueOnce(generateSdkResponse());
+      nextMock.mockReturnValueOnce(generateSdkResponse({ screenId: '1' }));
+
+      // headless Chromium rejects store() with NotSupportedError; the rejection
+      // must be caught, not surface as an unhandled rejection
+      Object.assign(navigator, {
+        credentials: {
+          store: jest
+            .fn()
+            .mockRejectedValue(
+              new Error(
+                'The user agent does not support public key credentials',
+              ),
+            ),
+        },
+      });
+      globalThis.PasswordCredential = class {
+        constructor(obj) {
+          Object.assign(this, obj);
+        }
+      };
+      fixtures.pageContent =
+        '<descope-button id="submitterId">click</descope-button><input id="email" name="email" value="1@1.com"></input><input id="password" name="password" value="pass"></input><span>It works!</span>';
+
+      document.body.innerHTML = `<h1>Custom element test</h1> <descope-wc flow-id="otpSignInEmail" project-id="1"></descope-wc>`;
+
+      await waitFor(() => screen.getByShadowText('It works!'), {
+        timeout: WAIT_TIMEOUT,
+      });
+
+      fireEvent.click(screen.getByShadowText('click'));
+
+      await waitFor(
+        () =>
+          expect(console.error).toHaveBeenCalledWith(
+            '[Descope]',
+            'Could not store credentials',
+            'The user agent does not support public key credentials',
+          ),
+        { timeout: WAIT_TIMEOUT },
+      );
+    });
+
     describe('username anchor injection', () => {
       const newPasswordPage =
         '<descope-new-password external-input="true" id="new-password"><input slot="password" type="password"/></descope-new-password><span>It works!</span>';


### PR DESCRIPTION
## Summary
- `navigator.credentials.store()` returns a promise that can reject asynchronously. In headless Chromium it rejects with `NotSupportedError` ("The user agent does not support public key credentials").
- The surrounding sync `try/catch` never saw that rejection, so it surfaced as an uncaught error and broke consumers' Playwright tests (reported in #1456).
- Attach a `.catch` that logs via the existing logger, keeping the call fire-and-forget and preserving the optional-chaining guard (so it stays safe when `store` is unavailable).

## Linked
- Fixes #1456

## Changes
- `passwordManagerMixin.ts`: `void navigator?.credentials?.store?.(cred)?.catch(...)` logs the async failure through `this.logger.error`, matching the existing sync-branch message.
- Test: new case mocks `store` to reject and asserts the failure is caught and logged via the `console.error` spy.

## Manual test plan
- In a headless Chromium context (e.g. Playwright), run a password flow that triggers credential storage and confirm no uncaught `NotSupportedError` is thrown; the failure is logged instead.
- Existing password-manager tests still pass (store called with the right payload when supported).

## Risk / review focus
- Low risk; only adds rejection handling, no signature change, stays fire-and-forget.
- Worth a glance: the async catch uses `err?.message ?? err` (defensive, async rejection value may not be an `Error`) while the pre-existing sync catch uses `e.message` - intentional, sync branch is left untouched.