### PR TITLE
fix(user-mgmt-widget): keep custom-attribute filter columns while schema loads RELEASE

### DIFF
--- a/packages/widgets/user-management-widget/src/lib/widget/helpers/filterColumns.ts
+++ b/packages/widgets/user-management-widget/src/lib/widget/helpers/filterColumns.ts
@@ -48,12 +48,9 @@ export const enrichFilterCustomAttributeColumns = (
   customAttrs: CustomAttr[] | undefined,
 ): FilterColumn[] =>
   cols
-    // Drop a custom-attribute column whose attribute no longer exists, so users
-    // cannot filter on a deleted attribute (which always returns zero results).
-    // Only drop when the schema is loaded AND non-empty: an empty read is the
-    // initial/loading state (data starts as []), and cannot be told apart from a
-    // real deletion - dropping then would hide every CA column until the schema
-    // arrives.
+    // Empty schema ([], the initial state before getCustomAttributes resolves):
+    // keep every column. Loaded schema missing this attribute: it was deleted,
+    // so drop the column.
     .filter((col) => {
       if (!col?.id?.startsWith(CA_COL_PREFIX) || !customAttrs?.length) {
         return true;

--- a/packages/widgets/user-management-widget/src/lib/widget/helpers/filterColumns.ts
+++ b/packages/widgets/user-management-widget/src/lib/widget/helpers/filterColumns.ts
@@ -50,9 +50,12 @@ export const enrichFilterCustomAttributeColumns = (
   cols
     // Drop a custom-attribute column whose attribute no longer exists, so users
     // cannot filter on a deleted attribute (which always returns zero results).
-    // Keep everything while the schema is still loading (customAttrs undefined).
+    // Only drop when the schema is loaded AND non-empty: an empty read is the
+    // initial/loading state (data starts as []), and cannot be told apart from a
+    // real deletion - dropping then would hide every CA column until the schema
+    // arrives.
     .filter((col) => {
-      if (!col?.id?.startsWith(CA_COL_PREFIX) || customAttrs === undefined) {
+      if (!col?.id?.startsWith(CA_COL_PREFIX) || !customAttrs?.length) {
         return true;
       }
       const name = col.id.slice(CA_COL_PREFIX.length);

--- a/packages/widgets/user-management-widget/test/filterColumns.test.ts
+++ b/packages/widgets/user-management-widget/test/filterColumns.test.ts
@@ -19,10 +19,16 @@ describe('enrichFilterCustomAttributeColumns', () => {
     expect(enrichOne(input, undefined)).toBe(input);
   });
 
+  it('keeps a custom-attribute column while the schema is empty (loading, not a deletion)', () => {
+    // data starts as [] before the CA schema loads; an empty read must not be
+    // mistaken for a deleted attribute, or every CA column vanishes.
+    const input = col({ id: 'customAttributes.dept', inputType: 'text' });
+    expect(enrichFilterCustomAttributeColumns([input], [])).toEqual([input]);
+  });
+
   it('drops a custom-attribute column whose attribute no longer exists', () => {
     const input = col({ id: 'customAttributes.dept', inputType: 'text' });
-    // schema loaded (array) but dept is gone -> column removed
-    expect(enrichFilterCustomAttributeColumns([input], [])).toEqual([]);
+    // schema loaded and non-empty, but dept is gone -> column removed
     expect(
       enrichFilterCustomAttributeColumns(
         [input],


### PR DESCRIPTION
## Problem
Custom-attribute columns disappear from the user-management widget's filter column picker.

The drop-guard in `enrichFilterCustomAttributeColumns` used `customAttrs === undefined` to mean "schema still loading". But the widget's `customAttributes.data` is initialised to `[]` (see `initialState.ts`) and is **never** `undefined`. So the guard is dead: on every load it runs `[].some(...) === false` and drops every CA column until `getCustomAttributes` resolves.

Outcomes:
- Best case: the memo re-runs when the schema loads and restores the columns -> visible flicker.
- Worst case: the `descope-filter` component re-emits its `data` attribute, `#captureAndSync` re-snapshots `#originalCols` from the already-trimmed (no-CA) set, and the CA columns are dropped **permanently**.

## Fix
Only drop a CA column when the schema is **loaded and non-empty** but the attribute is absent (a real deletion). An empty/undefined read is indistinguishable from a loading state, so keep the column.

```diff
- if (!col?.id?.startsWith(CA_COL_PREFIX) || customAttrs === undefined) {
+ if (!col?.id?.startsWith(CA_COL_PREFIX) || !customAttrs?.length) {
```

## Test
`test/filterColumns.test.ts`: added a case asserting an empty schema **keeps** the CA column (loading, not a deletion); the deletion case now uses a non-empty schema missing the name. Suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)