### PR TITLE
feat(debug-logs): capture initial DOM state + make package publishable RELEASE

### DIFF
--- a/packages/libs/debug-logs/README.md
+++ b/packages/libs/debug-logs/README.md
@@ -222,6 +222,27 @@ warning banner above the form and logs a `console.warn` to DevTools.
 - **Need to reuse after shutdown**: Instantiate a new `TelemetryManager`. A
   shutdown instance intentionally cannot be restarted.
 
+## Backward compatibility (important)
+
+The web-component SDK loads `@descope/debug-logs` from the CDN **at runtime**,
+pinned to `latest` (`config.version || 'latest'`). This is intentional - it lets
+us adapt telemetry logic without redeploying every SDK. The consequence: **a new
+release of this package is picked up immediately by already-deployed SDKs.**
+
+So the public API must stay backward compatible across releases:
+
+- Do not remove or rename the exported `TelemetryManager` methods
+  (`isReady`, `shutdown`, `enable`, `disable`, `updateContext`, `getRumClient`),
+  change the constructor shape `(config, context, logger?)`, or drop an exported
+  type.
+- Prefer additive changes (new optional config, new methods).
+- Recorded event shapes are additive too - adding fields is safe; removing or
+  renaming fields breaks consumers of the RUM data.
+
+`test/apiContract.test.ts` asserts this surface. If it fails, a deployed SDK
+loading `latest` will be affected - change it only as a deliberate, coordinated
+decision.
+
 ## License
 
 MIT License. See the root repository `LICENSE` file for details.

--- a/packages/libs/debug-logs/package.json
+++ b/packages/libs/debug-logs/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@descope/debug-logs",
   "version": "0.1.0",
-  "private": true,
   "author": "Descope Team <info@descope.com>",
   "description": "CloudWatch RUM-based telemetry collector for Descope SDK",
   "main": "dist/cjs/index.cjs.js",

--- a/packages/libs/debug-logs/project.json
+++ b/packages/libs/debug-logs/project.json
@@ -17,6 +17,22 @@
         "command": "pnpm run test",
         "cwd": "packages/libs/debug-logs"
       }
+    },
+    "version": {
+      "executor": "@jscutlery/semver:version",
+      "options": {
+        "trackDeps": true,
+        "push": false,
+        "preset": "conventional"
+      }
+    },
+    "licenseCheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": [
+          "tools/scripts/licenseValidation/thirdPartyLicenseCollector_linux_amd64 -npm-project {projectRoot}"
+        ]
+      }
     }
   },
   "tags": []

--- a/packages/libs/debug-logs/src/plugins/domMutationPlugin.ts
+++ b/packages/libs/debug-logs/src/plugins/domMutationPlugin.ts
@@ -120,14 +120,7 @@ export class DomMutationPlugin implements Plugin {
       // current (post-render) HTML so the DOM state is captured. Same
       // text-stripping privacy rule as the mutation path (includeText=false
       // strips rendered copy - OTP codes, emails, error messages).
-      const source = this.includeText
-        ? this.rootElement
-        : stripTextNodes(this.rootElement);
-      const raw = source.innerHTML;
-      const rootElementHTML =
-        raw.length > this.maxHtmlLength
-          ? raw.substring(0, this.maxHtmlLength - 20) + '... [truncated]'
-          : raw;
+      const rootElementHTML = this.snapshotHTML();
       // Only emit when there is actually content to snapshot - an empty root
       // carries no signal.
       if (rootElementHTML) {
@@ -145,6 +138,22 @@ export class DomMutationPlugin implements Plugin {
       // Fail silently if MutationObserver fails
       console.debug('DOM mutation plugin failed to start:', error);
     }
+  }
+
+  /**
+   * Serialize the observed root's HTML for a snapshot: strips text nodes unless
+   * includeText is set, then truncates to maxHtmlLength. Shared by the initial
+   * baseline snapshot and the structural-mutation path so the truncation math
+   * can't drift between the two.
+   */
+  private snapshotHTML(): string {
+    const source = this.includeText
+      ? this.rootElement
+      : stripTextNodes(this.rootElement);
+    const raw = source.innerHTML;
+    return raw.length > this.maxHtmlLength
+      ? raw.substring(0, this.maxHtmlLength - 20) + '... [truncated]'
+      : raw;
   }
 
   disable(): void {
@@ -239,17 +248,7 @@ export class DomMutationPlugin implements Plugin {
       // codes, error messages) never reaches RUM. Set config.includeText =
       // true only during a controlled support session.
       const hasStructuralChange = addedNodes > 0 || removedNodes > 0;
-      let rootElementHTML = '';
-      if (hasStructuralChange) {
-        const source = this.includeText
-          ? this.rootElement
-          : stripTextNodes(this.rootElement);
-        const raw = source.innerHTML;
-        rootElementHTML =
-          raw.length > this.maxHtmlLength
-            ? raw.substring(0, this.maxHtmlLength - 20) + '... [truncated]'
-            : raw;
-      }
+      const rootElementHTML = hasStructuralChange ? this.snapshotHTML() : '';
 
       this.context.record('dom_mutation', {
         addedNodes,

--- a/packages/libs/debug-logs/src/plugins/domMutationPlugin.ts
+++ b/packages/libs/debug-logs/src/plugins/domMutationPlugin.ts
@@ -110,6 +110,33 @@ export class DomMutationPlugin implements Plugin {
         attributeOldValue: false,
         characterDataOldValue: false,
       });
+
+      // The observer attaches after first paint, so the initial render's node
+      // additions never arrive as mutations. Emit one baseline snapshot of the
+      // current (post-render) HTML so the DOM state is captured. Same
+      // text-stripping privacy rule as the mutation path (includeText=false
+      // strips rendered copy - OTP codes, emails, error messages).
+      const source = this.includeText
+        ? this.rootElement
+        : stripTextNodes(this.rootElement);
+      const raw = source.innerHTML;
+      const rootElementHTML =
+        raw.length > this.maxHtmlLength
+          ? raw.substring(0, this.maxHtmlLength - 20) + '... [truncated]'
+          : raw;
+      // Only emit when there is actually content to snapshot - an empty root
+      // carries no signal.
+      if (rootElementHTML) {
+        this.context.record('dom_mutation', {
+          addedNodes: 0,
+          removedNodes: 0,
+          attributeChanges: 0,
+          characterDataChanges: 0,
+          timestamp: Date.now(),
+          rootElementHTML,
+          initial: true,
+        });
+      }
     } catch (error) {
       // Fail silently if MutationObserver fails
       console.debug('DOM mutation plugin failed to start:', error);

--- a/packages/libs/debug-logs/src/plugins/domMutationPlugin.ts
+++ b/packages/libs/debug-logs/src/plugins/domMutationPlugin.ts
@@ -23,9 +23,13 @@ export interface DomMutationPluginConfig {
  * false (the default) so error messages, one-time codes, and displayed
  * emails don't reach RUM.
  */
-function stripTextNodes(root: HTMLElement): HTMLElement {
-  const clone = root.cloneNode(true) as HTMLElement;
-  const walker = document.createTreeWalker(clone, NodeFilter.SHOW_TEXT);
+function stripTextNodes(root: HTMLElement | ShadowRoot): HTMLElement {
+  // root may be a ShadowRoot (the web-component observes its shadow root),
+  // which does not support cloneNode. Re-parse its markup into a detached
+  // container so this works for both elements and shadow roots.
+  const container = document.createElement('div');
+  container.innerHTML = root.innerHTML;
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
   const toRemove: Node[] = [];
   let node = walker.nextNode();
   while (node) {
@@ -33,7 +37,7 @@ function stripTextNodes(root: HTMLElement): HTMLElement {
     node = walker.nextNode();
   }
   toRemove.forEach((n) => n.parentNode?.removeChild(n));
-  return clone;
+  return container;
 }
 
 // AWS RUM has a 256KB limit for the entire event payload

--- a/packages/libs/debug-logs/test/apiContract.test.ts
+++ b/packages/libs/debug-logs/test/apiContract.test.ts
@@ -1,0 +1,64 @@
+import TelemetryManager from '../src';
+import type {
+  Logger,
+  TelemetryConfig,
+  TelemetryContext,
+} from '../src';
+
+/**
+ * Public API contract.
+ *
+ * The web-component SDK loads `@descope/debug-logs` from the CDN at RUNTIME,
+ * pinned to `latest` (`config.version || 'latest'`). We keep `latest` on
+ * purpose so telemetry logic can be adapted without redeploying every SDK -
+ * which means a new release of this package is picked up by ALREADY-DEPLOYED
+ * SDKs immediately.
+ *
+ * Therefore the public surface asserted here MUST stay backward compatible:
+ * do not remove/rename these members, change the constructor shape, or drop an
+ * exported type without a deliberate, coordinated change. If a break is
+ * intended, updating this test is the explicit signal that consumers loading
+ * `latest` will be affected.
+ *
+ * Also exported and part of the contract (verified by these imports compiling):
+ * `NetworkCaptureConfig`, `ConsoleLevel`.
+ */
+describe('public API contract (deployed SDKs load @latest)', () => {
+  const config: TelemetryConfig = {
+    enabled: false, // false -> constructor does not build a RUM client
+    rumConfig: {
+      sessionSampleRate: 1,
+      applicationId: 'app',
+      identityPoolId: 'pool',
+      region: 'eu-west-1',
+    },
+  };
+  const context: TelemetryContext = { projectId: 'P1', flowId: 'sign-in' };
+
+  it('default export is the TelemetryManager class', () => {
+    expect(typeof TelemetryManager).toBe('function');
+    expect(new TelemetryManager(config, context)).toBeInstanceOf(TelemetryManager);
+  });
+
+  it('constructor accepts (config, context, logger?)', () => {
+    const logger: Logger = console;
+    expect(() => new TelemetryManager(config, context, logger)).not.toThrow();
+    expect(() => new TelemetryManager(config, context)).not.toThrow();
+  });
+
+  it('exposes the methods consumers depend on', () => {
+    const tm = new TelemetryManager(config, context);
+    for (const method of [
+      'isReady',
+      'shutdown',
+      'enable',
+      'disable',
+      'updateContext',
+      'getRumClient',
+    ]) {
+      expect(typeof (tm as unknown as Record<string, unknown>)[method]).toBe(
+        'function',
+      );
+    }
+  });
+});

--- a/packages/libs/debug-logs/test/apiContract.test.ts
+++ b/packages/libs/debug-logs/test/apiContract.test.ts
@@ -3,6 +3,8 @@ import type {
   Logger,
   TelemetryConfig,
   TelemetryContext,
+  NetworkCaptureConfig,
+  ConsoleLevel,
 } from '../src';
 
 /**
@@ -20,10 +22,13 @@ import type {
  * intended, updating this test is the explicit signal that consumers loading
  * `latest` will be affected.
  *
- * Also exported and part of the contract (verified by these imports compiling):
- * `NetworkCaptureConfig`, `ConsoleLevel`.
+ * `NetworkCaptureConfig` and `ConsoleLevel` are also part of the exported
+ * contract; they are referenced in the config below, so this file fails to
+ * compile if either is removed or renamed.
  */
 describe('public API contract (deployed SDKs load @latest)', () => {
+  const consoleLevels: ConsoleLevel[] = ['error', 'warn'];
+  const network: NetworkCaptureConfig = { maxHeaderLength: 2048 };
   const config: TelemetryConfig = {
     enabled: false, // false -> constructor does not build a RUM client
     rumConfig: {
@@ -31,6 +36,10 @@ describe('public API contract (deployed SDKs load @latest)', () => {
       applicationId: 'app',
       identityPoolId: 'pool',
       region: 'eu-west-1',
+    },
+    capture: {
+      console: { levels: consoleLevels },
+      network,
     },
   };
   const context: TelemetryContext = { projectId: 'P1', flowId: 'sign-in' };

--- a/packages/libs/debug-logs/test/domMutationPlugin.test.ts
+++ b/packages/libs/debug-logs/test/domMutationPlugin.test.ts
@@ -371,6 +371,7 @@ describe('DomMutationPlugin', () => {
         includeText: true,
       });
       plugin.load(mockContext);
+      mockRecord.mockClear(); // discard the initial baseline snapshot
 
       const container = document.getElementById('state-target')!;
       container.innerHTML = '<span>Modified</span>';
@@ -382,6 +383,37 @@ describe('DomMutationPlugin', () => {
       expect(call.rootElementHTML).not.toContain('Original');
     });
 
+    it('emits a baseline snapshot on start when the root already has content', () => {
+      createTestElement('initial-target', '<p>Rendered before observe</p>');
+      plugin = new DomMutationPlugin({
+        rootElement: '#initial-target',
+        throttleMs: 50,
+        includeText: true,
+      });
+      plugin.load(mockContext);
+      // No mutation triggered - the snapshot is emitted synchronously on start,
+      // because the observer attaches after first paint and would otherwise miss
+      // the initial render.
+      const call = mockRecord.mock.calls[0];
+      expect(call[0]).toBe('dom_mutation');
+      expect(call[1]).toMatchObject({
+        initial: true,
+        addedNodes: 0,
+        removedNodes: 0,
+      });
+      expect(call[1].rootElementHTML).toContain('Rendered before observe');
+    });
+
+    it('does not emit a baseline snapshot when the root is empty', () => {
+      createTestElement('empty-initial-target');
+      plugin = new DomMutationPlugin({
+        rootElement: '#empty-initial-target',
+        throttleMs: 50,
+      });
+      plugin.load(mockContext);
+      expect(mockRecord).not.toHaveBeenCalled();
+    });
+
     it('should strip text nodes by default (structure-only snapshot)', async () => {
       createTestElement('strip-target', '<p>Existing text</p>');
       plugin = new DomMutationPlugin({
@@ -389,6 +421,7 @@ describe('DomMutationPlugin', () => {
         throttleMs: 50,
       });
       plugin.load(mockContext);
+      mockRecord.mockClear(); // discard the initial baseline snapshot
 
       const container = document.getElementById('strip-target')!;
       const div = document.createElement('div');
@@ -411,6 +444,7 @@ describe('DomMutationPlugin', () => {
         throttleMs: 50,
       });
       plugin.load(mockContext);
+      mockRecord.mockClear(); // discard the initial baseline snapshot
 
       document
         .getElementById('attr-only-target')!
@@ -654,6 +688,7 @@ describe('DomMutationPlugin', () => {
 
       // Enable again
       plugin.enable();
+      mockRecord.mockClear(); // discard the initial baseline snapshot on re-enable
       container.appendChild(document.createElement('div'));
       await waitFor(100);
       expect(mockRecord).toHaveBeenCalledTimes(1);

--- a/packages/libs/debug-logs/test/domMutationPlugin.test.ts
+++ b/packages/libs/debug-logs/test/domMutationPlugin.test.ts
@@ -414,6 +414,46 @@ describe('DomMutationPlugin', () => {
       expect(mockRecord).not.toHaveBeenCalled();
     });
 
+    // Regression: the web-component observes its shadow ROOT (a ShadowRoot,
+    // not an HTMLElement). cloneNode() throws on a ShadowRoot, which used to
+    // make every HTML snapshot fail silently so rootElementHTML was always ''.
+    it('serializes HTML from a shadow root (includeText: true)', () => {
+      const host = document.createElement('div');
+      document.body.appendChild(host);
+      const shadow = host.attachShadow({ mode: 'open' });
+      shadow.innerHTML = '<div class="screen"><p>hello</p></div>';
+      plugin = new DomMutationPlugin({
+        rootElement: shadow as unknown as HTMLElement,
+        throttleMs: 50,
+        includeText: true,
+      });
+      plugin.load(mockContext);
+
+      const call = mockRecord.mock.calls[0];
+      expect(call[0]).toBe('dom_mutation');
+      expect(call[1].initial).toBe(true);
+      expect(call[1].rootElementHTML).toContain('class="screen"');
+      expect(call[1].rootElementHTML).toContain('hello');
+    });
+
+    it('strips text but keeps structure when snapshotting a shadow root', () => {
+      const host = document.createElement('div');
+      document.body.appendChild(host);
+      const shadow = host.attachShadow({ mode: 'open' });
+      shadow.innerHTML = '<div class="screen"><span>one-time-code-123</span></div>';
+      plugin = new DomMutationPlugin({
+        rootElement: shadow as unknown as HTMLElement,
+        throttleMs: 50,
+      }); // includeText defaults to false
+
+      plugin.load(mockContext);
+
+      const html = mockRecord.mock.calls[0][1].rootElementHTML;
+      expect(html).toContain('class="screen"');
+      expect(html).toContain('<span>');
+      expect(html).not.toContain('one-time-code-123');
+    });
+
     it('should strip text nodes by default (structure-only snapshot)', async () => {
       createTestElement('strip-target', '<p>Existing text</p>');
       plugin = new DomMutationPlugin({

--- a/packages/libs/debug-logs/test/integration.test.ts
+++ b/packages/libs/debug-logs/test/integration.test.ts
@@ -197,6 +197,7 @@ describe('TelemetryManager Integration', () => {
 
       // Re-enable
       manager.enable();
+      mockRecord.mockClear(); // discard the DOM plugin's initial baseline snapshot
       console.log('Re-enabled');
       expect(mockRecord).toHaveBeenCalledTimes(1);
     });


### PR DESCRIPTION
## Summary
Makes `@descope/debug-logs` publishable and fixes DOM capture in the web-component (shadow DOM). Grew from a one-line publish enablement into a small set of related fixes.

## Changes

### Publish the package
- Remove `private: true` so the release pipeline publishes it to npm -> the Descope CDN (matching sdk-mixins/web-component, which ship with no `private` field).
- Add `version` + `licenseCheck` targets to `project.json` (mirroring sdk-mixins). Without a `version` target, `nx affected --target version` silently skips the project, so after the first `0.1.0` publish it would never bump again and `pnpm -r publish` would no-op forever - freezing the package the web-component fetches at runtime.

**Why publish matters:** the web-component telemetry mixin loads `@descope/debug-logs` from the CDN **at runtime**. While private it never reached npm/CDN, so that fetch 404s and telemetry can't start in production even when support enables it.

### Fix DOM capture (shadow DOM)
- **`stripTextNodes` threw on a `ShadowRoot`.** It cloned the root via `cloneNode`, which throws on a shadow root - and the web-component observes its shadow root. So every HTML snapshot silently failed (caught by the try/catch) and `rootElementHTML` was always empty. Re-parse the root's `innerHTML` into a detached container instead, which works for both elements and shadow roots.
- **Capture an initial DOM snapshot on start.** The observer attaches only after telemetry finishes init (after the debug-logs CDN load), so the initial render's node additions are never seen as mutations. Emit one baseline `dom_mutation` (`initial: true`) with the post-render HTML when the observer starts; skipped when the root is empty; same text-stripping privacy rule (`includeText=false` strips OTP codes / emails / errors).
- Extract a `snapshotHTML()` helper so the initial snapshot and the mutation path share one truncation formula.

Verified live: RUM now receives `dom_mutation` events carrying the actual rendered DOM (`rootElementHTML`).

### Tests + docs
- Regression tests: serialize HTML from a real `ShadowRoot` (both `includeText` modes) so the `cloneNode` bug can't come back.
- `apiContract.test.ts`: asserts the public surface (`TelemetryManager` + `isReady/shutdown/enable/disable/updateContext/getRumClient`, the `(config, context, logger?)` constructor, and the exported types).
- README "Backward compatibility" section: the web-component loads this package as `latest` at runtime (kept on purpose, so telemetry logic can adapt without redeploying SDKs), so the public API must stay backward compatible; the contract test is the guard.

## Related
- Backend telemetry gate (merged): descope/backend#2045
- Support permission (`debug-telemetry-w`): descope/backend#2278
- SDK telemetry (merged): descope/descope-js#1461

## Notes
- Actual publish happens on the next `RELEASE`-tagged commit (`pnpm -r publish`). Once on npm -> CDN, the runtime `@descope/debug-logs` fetch works in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)