### PR TITLE
fix(debug-logs): correct types entry paths in package.json RELEASE

### DIFF
--- a/packages/libs/debug-logs/package.json
+++ b/packages/libs/debug-logs/package.json
@@ -5,14 +5,14 @@
   "description": "CloudWatch RUM-based telemetry collector for Descope SDK",
   "main": "dist/cjs/index.cjs.js",
   "module": "dist/index.esm.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "exports": {
     "require": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/cjs/types/index.d.ts",
       "default": "./dist/cjs/index.cjs.js"
     },
     "import": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/types/index.d.ts",
       "default": "./dist/index.esm.js"
     }
   },


### PR DESCRIPTION
## Summary
- `@descope/debug-logs` package.json pointed `types` and both `exports.*.types` at `dist/index.d.ts`, a file the build never produces.
- Corrected to the actual build output: `dist/types/index.d.ts` (ESM / top-level) and `dist/cjs/types/index.d.ts` (CJS).
- Metadata only. No runtime change; the web-component loads the runtime UMD from the CDN and is unaffected.

## Context
`@descope/debug-logs@0.1.0` was published manually - a first publish, since the CI automation token can't create a new package in the `@descope` org. That published `0.1.0` carries this defect. This PR fixes it so the next release (`0.1.1`) ships correct type paths.

## Before releasing 0.1.1
The CI automation token needs publish access granted to the now-existing `@descope/debug-logs` package in npm org settings, or the CI release will 404 the same way the first publish did. Do not add `RELEASE` to the squash-merge until that grant is in place.

## Test plan
- `npm run build` in `packages/libs/debug-logs`; confirm `dist/types/index.d.ts` and `dist/cjs/types/index.d.ts` exist and the package.json paths resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)