### PR TITLE
fix(user-profile-widget): default empty custom attributes to avoid render crash RELEASE

### DIFF
--- a/packages/widgets/user-profile-widget/src/lib/widget/state/selectors.test.ts
+++ b/packages/widgets/user-profile-widget/src/lib/widget/state/selectors.test.ts
@@ -1,0 +1,20 @@
+import { getUserCustomAttrs } from './selectors';
+import { State } from './types';
+
+const makeState = (customAttributes?: Record<string, any>): State =>
+  ({
+    me: { data: { customAttributes } },
+  }) as unknown as State;
+
+describe('user-profile selectors', () => {
+  describe('getUserCustomAttrs', () => {
+    it('returns an empty object when the user has no custom attributes', () => {
+      expect(getUserCustomAttrs(makeState(undefined))).toEqual({});
+    });
+
+    it('returns the custom attributes when present', () => {
+      const attrs = { mailSubscription: true };
+      expect(getUserCustomAttrs(makeState(attrs))).toEqual(attrs);
+    });
+  });
+});

--- a/packages/widgets/user-profile-widget/src/lib/widget/state/selectors.ts
+++ b/packages/widgets/user-profile-widget/src/lib/widget/state/selectors.ts
@@ -61,11 +61,17 @@ export const getHasPasskey = createSelector(getMe, (me) => me.webauthn);
 export const getHasPassword = createSelector(getMe, (me) => me.password);
 export const getHasTotp = createSelector(getMe, (me) => me.TOTP);
 
+// Shared empty default so the no-attributes case keeps a stable reference
+// across recomputes (getMe is a plain extractor, so this selector re-runs on
+// every me.data replacement; a fresh {} each time would defeat downstream
+// shallow-compare / effect-dep checks).
+const EMPTY_ATTRS: Record<string, any> = {};
+
 export const getUserCustomAttrs = createSelector(
   getMe,
   // Default to an empty object: a user with no custom attributes has an
   // undefined `customAttributes`, and consumers index into the result.
-  (me) => (me.customAttributes ?? {}) as Record<string, any>,
+  (me) => (me.customAttributes ?? EMPTY_ATTRS) as Record<string, any>,
 );
 
 export const getUserBuiltinAttrs = createSelector(getMe, (me) => ({

--- a/packages/widgets/user-profile-widget/src/lib/widget/state/selectors.ts
+++ b/packages/widgets/user-profile-widget/src/lib/widget/state/selectors.ts
@@ -63,7 +63,9 @@ export const getHasTotp = createSelector(getMe, (me) => me.TOTP);
 
 export const getUserCustomAttrs = createSelector(
   getMe,
-  (me) => me.customAttributes as Record<string, any>,
+  // Default to an empty object: a user with no custom attributes has an
+  // undefined `customAttributes`, and consumers index into the result.
+  (me) => (me.customAttributes ?? {}) as Record<string, any>,
 );
 
 export const getUserBuiltinAttrs = createSelector(getMe, (me) => ({


### PR DESCRIPTION
## Problem
The user-profile widget crashes and fails to render for any user who has no custom attributes.

`getUserCustomAttrs` returns `me.customAttributes` as-is, which is `undefined` when the user has none. Consumers index into the result - e.g. `initUserCustomAttributesMixin` does `userCustomAttributes[customAttrName]` - so it throws:

```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading '<attr>')
    at initUserCustomAttributesMixin.ts:89
```

Because this runs during render init, the whole widget stops rendering.

## Fix
Default the selector to an empty object (`me.customAttributes ?? {}`). Fixing it at the selector protects every consumer, not just the one read site.

## Tests
Added `state/selectors.test.ts` (following the role/audit widget pattern):
- returns `{}` when the user has no custom attributes
- returns the attributes when present

## Non-goals
No behavior change for users who do have custom attributes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)