### PR TITLE
fix(sdk-mixins): guard process.env telemetry reads for the browser RELEASE

### DIFF
--- a/packages/libs/sdk-mixins/src/mixins/telemetryMixin/telemetryMixin.ts
+++ b/packages/libs/sdk-mixins/src/mixins/telemetryMixin/telemetryMixin.ts
@@ -217,26 +217,51 @@ export const telemetryMixin = createSingletonMixin(
         const resolvedConfig = await this.config;
         const beTelemetry = resolvedConfig?.projectConfig?.telemetry;
 
-        const sampleRate = Number(
-          process.env.DESCOPE_TELEMETRY_SESSION_SAMPLE_RATE,
-        );
+        // The DESCOPE_TELEMETRY_* reads below are build-time env tokens: the WC
+        // app build substitutes them from .env (rollup.config.app.mjs) and the
+        // WC lib build strips them to "" (stubEnvInProd). But @descope/sdk-mixins
+        // ships its own dist with these tokens RAW, so a non-WC consumer that
+        // bundles this file for the browser hits a bare `process`, which is
+        // undefined there -> "ReferenceError: process is not defined".
+        // Wrap the reads in try/catch: this keeps the literal `process.env.*`
+        // tokens intact (so the WC build-time replace/strip still match them),
+        // while falling back to an empty config wherever `process` doesn't
+        // exist. Real config comes from the backend (projectConfig.telemetry).
+        let fallback: NonNullable<TelemetryConfig>;
+        try {
+          const sampleRate = Number(
+            process.env.DESCOPE_TELEMETRY_SESSION_SAMPLE_RATE,
+          );
 
-        const fallback: NonNullable<TelemetryConfig> = {
-          enabled:
-            (process.env.DESCOPE_TELEMETRY_ENABLED || '').toLowerCase() ===
-            'true',
-          rumConfig: {
-            applicationId: process.env.DESCOPE_TELEMETRY_APPLICATION_ID || '',
-            identityPoolId:
-              process.env.DESCOPE_TELEMETRY_IDENTITY_POOL_ID || '',
-            region: process.env.DESCOPE_TELEMETRY_REGION || '',
-            sessionSampleRate:
-              Number.isFinite(sampleRate) && sampleRate > 0 ? sampleRate : 1,
-            ...(process.env.DESCOPE_TELEMETRY_GUEST_ROLE_ARN && {
-              guestRoleArn: process.env.DESCOPE_TELEMETRY_GUEST_ROLE_ARN,
-            }),
-          },
-        };
+          fallback = {
+            enabled:
+              (process.env.DESCOPE_TELEMETRY_ENABLED || '').toLowerCase() ===
+              'true',
+            rumConfig: {
+              applicationId: process.env.DESCOPE_TELEMETRY_APPLICATION_ID || '',
+              identityPoolId:
+                process.env.DESCOPE_TELEMETRY_IDENTITY_POOL_ID || '',
+              region: process.env.DESCOPE_TELEMETRY_REGION || '',
+              sessionSampleRate:
+                Number.isFinite(sampleRate) && sampleRate > 0 ? sampleRate : 1,
+              ...(process.env.DESCOPE_TELEMETRY_GUEST_ROLE_ARN && {
+                guestRoleArn: process.env.DESCOPE_TELEMETRY_GUEST_ROLE_ARN,
+              }),
+            },
+          };
+        } catch {
+          // `process` is not defined (browser, no build-time replacement).
+          // No .env fallback here - rely on the backend telemetry config.
+          fallback = {
+            enabled: false,
+            rumConfig: {
+              applicationId: '',
+              identityPoolId: '',
+              region: '',
+              sessionSampleRate: 1,
+            },
+          };
+        }
 
         const cfg: NonNullable<TelemetryConfig> = {
           ...fallback,


### PR DESCRIPTION
## Summary
- `telemetryMixin#getTelemetryConfig` read `process.env.DESCOPE_TELEMETRY_*` directly. `process` is a Node global and is undefined in the browser, so any consumer that bundles `@descope/sdk-mixins` without replacing/stripping those tokens threw `ReferenceError: process is not defined` on `init()` (surfaced via `.catch()` as "Failed to start telemetry"; non-fatal, but telemetry never starts).
- Wrapped the reads in try/catch. This keeps the literal `process.env.*` tokens intact so the web-component build-time replace/strip still match them, while falling back to an empty config wherever `process` is undefined. Real config comes from the backend (`projectConfig.telemetry`).

## Why try/catch (and not aliasing / a strip step)
The plugins that make this work in the WC are textual: the app build injects `.env` values via `rollup-plugin-define` matching the literal `process.env.DESCOPE_TELEMETRY_*` tokens, and the lib build strips those same tokens via `stubEnvInProd`. Aliasing (`const env = process.env`) or stripping in the sdk-mixins build would break the demo injection and/or the strip. try/catch is the only change that keeps the tokens for those plugins AND is safe when `process` is genuinely undefined.

## Verified across all builds
- **sdk-mixins dist**: tokens stay raw but now inside try/catch -> external browser consumers no longer crash.
- **WC lib IIFE (CDN UMD)**: `stubEnvInProd` still strips `process.env.DESCOPE_TELEMETRY_*` -> 0 survivors in the bundle.
- **WC demo app build**: `define` still injects the `.env` values into the shipped `.js`.
- **Tests**: sdk-mixins telemetry suite 16/16 pass, including the env-driven fallback path.

## Test plan
- `nx test sdk-mixins --testPathPattern=telemetryMixin`
- Build WC lib + app; confirm the CDN bundle has no raw `process.env.*` and the demo bundle has the values injected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)