### PR TITLE
docs(web-js-sdk): fix syntax errors in the quickstart code sample

### DIFF
--- a/packages/sdks/web-js-sdk/README.md
+++ b/packages/sdks/web-js-sdk/README.md
@@ -39,7 +39,6 @@ const sdk = descopeSdk({
     - If the cookie domain set on Descope configuration doesn't match, or is not a parent domain of the current domain, The cookie will be stored on the current domain that runs the code. Examples:
      - Project cookie domain is acme.com, current domain is app.acme.com - the domain will be set to app.acme.com
      - Project cookie domain is acme.com, current domain is my-app.com - the domain will be set to my-app.com
-     */
   */
   sessionTokenViaCookie: false,
   /* Automatically schedule a call refresh session call after a successful authentication:
@@ -57,7 +56,7 @@ const sdk = descopeSdk({
 
   /*  When managing multiple Descope projects on the same domain, you can prevent refresh cookie conflicts by assigning a custom name to your refresh token cookie during the login process (for example, using Descope Flows). However, you must also configure the SDK to recognize this unique name by passing the `refreshCookieName` option.
   */
-  refreshCookieName: "cookie-1"
+  refreshCookieName: 'cookie-1',
 
   // Pass this function to the SDK if you want to seamlessly migrate session from an external authentication provider to Descope.
   getExternalToken: async () => {


### PR DESCRIPTION
## Problem

The first code block in `packages/sdks/web-js-sdk/README.md` -- the sample a new developer copies to get their first login working -- is not valid JavaScript. Copy-pasting it fails before it reaches the SDK at all:

1. Line 42/43: a duplicated `*/` closes the `sessionTokenViaCookie` comment twice.
   ```
   SyntaxError: Unexpected token '/'
   ```
2. Line 60: `refreshCookieName: "cookie-1"` is missing its trailing comma, so the next property is parsed as a statement.
   ```
   SyntaxError: Unexpected identifier 'getExternalToken'
   ```

Found while measuring time-to-first-login for the browser SDK from a clean directory. It took 15 seconds from `npm init` to a hard stall, and the stall is 100% reproducible for every developer who follows the README.

## Change

Three lines, docs only. No public surface change.

- Remove the duplicated `*/`.
- Add the missing trailing comma after `refreshCookieName`.
- Normalise that line to single quotes to match the rest of the sample.

## How it was verified

Against the **published** `@descope/web-js-sdk@1.52.0` in a clean directory, extracting the first ` ```js ` block (README lines 15-111) straight out of the README.

**The extension matters.** The block starts with a top-level `import`, so it must be parsed as ESM. Write it to `block.mjs`, or pass `--input-type=module`. Written to `block.js`, node v20.19.2 exits **0** on the broken block -- the CommonJS parse fails on the `import` and the ESM retry path never surfaces the `*/`:

```
$ node -v
v20.19.2

# broken block, from origin/main
$ node --check block.js    ; echo $?
0                                        # <- silent false pass
$ node --check block.mjs   ; echo $?
SyntaxError: Unexpected token '/'
1

# fixed block, from this branch
$ node --check block.js    ; echo $?
0
$ node --check block.mjs   ; echo $?
0
```

So: broken -> exit 1, fixed -> exit 0, both as `.mjs`. The fix clears the whole block, not just the first defect.

Then executed the fixed block with only `myProjectId` filled in and `baseUrl` pointed at a local protocol stub (no Descope environment was contacted). It now runs past `otp.signIn.email` and sets the auto-refresh timer, instead of dying at parse time.

Note: the sample's final `sdk.getSessionToken()` line is correct -- it resolves in a browser. It is only absent under Node because `withPersistTokens` returns early on `!IS_BROWSER` (`src/enhancers/withPersistTokens/index.ts:44`). Out of scope here.

## Follow-ups not in this PR

- The same block has a "see usage bellow bellow" typo at line 25.
- Nothing checks that README code samples parse, which is how this survived. A CI step over fenced `js` blocks would catch it, but it must write ESM samples to `.mjs` (or pass `--input-type=module`) or it will pass every broken sample silently, exactly as shown above. It also needs a JSX/TS-aware parser to avoid false positives on the react/nextjs READMEs. Tracked internally as DES-11, with a requirement that the gate be proven to fail on this pre-fix block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
