### PR TITLE
ci(readme): fail the build when a README JavaScript sample does not parse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,9 @@ jobs:
       - name: License validation
         run: pnpm run licenseCheck
 
+      - name: README code samples
+        run: pnpm run readmeCheck
+
       - name: Build
         run: pnpm run build
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "nx affected --target lint --fix=true",
     "lint:ci": "pnpm affected:ci --target lint",
     "licenseCheck": "nx affected --target licenseCheck",
+    "readmeCheck": "node ./tools/scripts/checkReadmeSamples.mjs",
     "test": "nx affected --target test",
     "test:e2e": "nx affected  --target test:e2e",
     "print-affected": "nx show projects --affected",

--- a/packages/sdks/web-js-sdk/README.md
+++ b/packages/sdks/web-js-sdk/README.md
@@ -113,6 +113,8 @@ const sessionToken = sdk.getSessionToken();
 
 Descope also supports OIDC login. To enable OIDC login, pass `oidcConfig` attribute to the SDK initialization. The `oidcConfig` attribute is either a boolean or a configuration object. If you pass `oidcConfig: true`, the SDK will use the Descope OIDC default application
 
+<!-- readme-check: skip two alternative initializations shown side by side, so `sdk` is declared twice -->
+
 ```js
 // Initialize the SDK with OIDC
 const sdk = descopeSdk({

--- a/tools/scripts/checkReadmeSamples.mjs
+++ b/tools/scripts/checkReadmeSamples.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+/**
+ * Fails the build when a fenced JavaScript sample in an SDK README does not parse.
+ *
+ * Every checked block is written to a temporary file with an `.mjs` extension and
+ * handed to `node --check`. The extension is load-bearing: with a `.js` extension
+ * Node parses the block as CommonJS first, and a top-level `import` makes that
+ * attempt fail for the *wrong* reason -- the ESM retry path then swallows the real
+ * error and `node --check` exits 0 on a block that is genuinely broken.
+ *
+ * (the `*\/` below is an unbalanced comment terminator, escaped so this comment survives)
+ *
+ *   $ printf "import x from 'y';\nconst a = 1;\n*\/\n" > g.js  && node --check g.js  # exit 0
+ *   $ printf "import x from 'y';\nconst a = 1;\n*\/\n" > g.mjs && node --check g.mjs # exit 1
+ *
+ * Usage:
+ *   node tools/scripts/checkReadmeSamples.mjs                 # the allowlist below
+ *   node tools/scripts/checkReadmeSamples.mjs path/to/README.md
+ *
+ * A block that is deliberately not standalone can be exempted by putting
+ * `<!-- readme-check: skip <reason> -->` on the last non-blank line above its
+ * opening fence. A reason is mandatory so every exemption stays reviewable.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = resolve(fileURLToPath(import.meta.url), '../../..');
+
+/**
+ * READMEs whose JavaScript samples must parse.
+ *
+ * Deliberately narrow for now. Deferred, because their `js`-tagged blocks are JSX
+ * or TypeScript and need a JSX/TS-aware parser rather than `node --check`:
+ * react-sdk, nextjs-sdk, angular-sdk, vue-sdk, web-component.
+ */
+const CHECKED_READMES = [
+  'packages/sdks/core-js-sdk/README.md',
+  'packages/sdks/web-js-sdk/README.md',
+];
+
+/** Fence info strings treated as plain JavaScript. `ts`/`tsx`/`jsx` are out of scope. */
+const JS_LANGUAGES = new Set(['js', 'javascript', 'mjs']);
+
+const SKIP_DIRECTIVE = /^<!--\s*readme-check:\s*skip\s*(.*?)\s*-->$/;
+
+/**
+ * A block that must be rejected. Guards the `.mjs` detail above: switch the
+ * temporary files back to `.js` and this snippet starts passing, which would
+ * turn the whole gate into a no-op without failing anything.
+ */
+const CANARY = "import x from 'y';\nconst a = 1;\n*/\n";
+
+const FENCE = /^([ \t]*)```([^\n`]*)\n([\s\S]*?)^\1```[ \t]*$/gm;
+
+/** @returns {{ lang: string, code: string, startLine: number, skipReason: string | null }[]} */
+const parseBlocks = (markdown) => {
+  const lines = markdown.split('\n');
+  const blocks = [];
+
+  for (let match = FENCE.exec(markdown); match; match = FENCE.exec(markdown)) {
+    const [, , info, code] = match;
+    // 1-based line of the opening fence.
+    const startLine = markdown.slice(0, match.index).split('\n').length;
+    // Walk back past blank lines to the nearest preceding content line.
+    let cursor = startLine - 2;
+    while (cursor >= 0 && !(lines[cursor] ?? '').trim()) cursor -= 1;
+    const directive = SKIP_DIRECTIVE.exec((lines[cursor] ?? '').trim());
+
+    if (directive && !directive[1]) {
+      throw new Error(
+        `line ${cursor + 1}: \`readme-check: skip\` needs a reason`,
+      );
+    }
+
+    blocks.push({
+      lang: info
+        .trim()
+        .split(/[\s{,:]/)[0]
+        .toLowerCase(),
+      code,
+      startLine,
+      skipReason: directive ? directive[1] : null,
+    });
+  }
+
+  return blocks;
+};
+
+/**
+ * @returns {string | null} the parse error, with block-relative line numbers
+ *   rewritten to README line numbers, or null when the block parses.
+ */
+const parseError = (block, readmePath, scratchDir) => {
+  const blockFile = join(scratchDir, `block-${block.startLine}.mjs`);
+  writeFileSync(blockFile, block.code);
+
+  try {
+    execFileSync(process.execPath, ['--check', blockFile], { stdio: 'pipe' });
+    return null;
+  } catch (error) {
+    return String(error.stderr)
+      .split('\n')
+      .filter((line) => !/^\s+at\s|^Node\.js v/.test(line))
+      .join('\n')
+      .trim()
+      .replace(
+        new RegExp(
+          `${blockFile.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}:(\\d+)`,
+          'g',
+        ),
+        // +1 for the opening fence, so the number points at the README line.
+        (_, line) => `${readmePath}:${block.startLine + Number(line)}`,
+      );
+  }
+};
+
+const checkReadme = (readmePath, scratchDir) => {
+  const failures = [];
+  const skipped = [];
+  let checked = 0;
+
+  for (const block of parseBlocks(
+    readFileSync(join(REPO_ROOT, readmePath), 'utf8'),
+  )) {
+    if (!JS_LANGUAGES.has(block.lang)) continue;
+
+    if (block.skipReason) {
+      skipped.push(`${readmePath}:${block.startLine} -- ${block.skipReason}`);
+      continue;
+    }
+
+    checked += 1;
+    const error = parseError(block, readmePath, scratchDir);
+    if (error) failures.push(error);
+  }
+
+  return { checked, failures, skipped };
+};
+
+const main = () => {
+  const targets = process.argv.slice(2);
+  const readmes = targets.length
+    ? targets.map((target) => relative(REPO_ROOT, resolve(target)))
+    : CHECKED_READMES;
+
+  const scratchDir = mkdtempSync(join(tmpdir(), 'readme-samples-'));
+  let checked = 0;
+  const failures = [];
+  const skipped = [];
+
+  try {
+    const canary = { code: CANARY, startLine: 0 };
+    if (!parseError(canary, '<canary>', scratchDir)) {
+      console.error(
+        'self-check failed: the canary block parsed, so this gate cannot fail.',
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    for (const readme of readmes) {
+      const result = checkReadme(readme, scratchDir);
+      checked += result.checked;
+      failures.push(...result.failures);
+      skipped.push(...result.skipped);
+    }
+  } finally {
+    rmSync(scratchDir, { recursive: true, force: true });
+  }
+
+  for (const skip of skipped) console.log(`skipped ${skip}`);
+
+  if (failures.length) {
+    console.error(
+      `\n${failures.length} of ${
+        checked + failures.length
+      } JavaScript README sample(s) do not parse:\n`,
+    );
+    for (const failure of failures) console.error(`${failure}\n`);
+    console.error(
+      'Fix the sample, or exempt the block with `<!-- readme-check: skip <reason> -->`.',
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    `${checked} JavaScript README sample(s) parse across ${readmes.length} file(s).`,
+  );
+};
+
+main();


### PR DESCRIPTION
> Stacked on #1470. Base branch is `fix/web-js-sdk-readme-quickstart-syntax`, so this PR shows only the gate. Merge #1470 first, then retarget this to `main`.

## Problem

Two hard syntax errors reached the `web-js-sdk` quickstart sample and nobody noticed (#1470), because nothing checks that README code samples parse. Fixing the sample without adding a gate means the next edit reintroduces the same class of defect.

## Change

`tools/scripts/checkReadmeSamples.mjs` pulls every `js` / `javascript` / `mjs` fenced block out of an allowlist of SDK READMEs and runs `node --check` over each one. Wired in as one step in the existing CI job, next to license validation:

```yaml
- name: README code samples
  run: pnpm run readmeCheck
```

### The extension is load-bearing

Blocks are written to temp files with an **`.mjs`** extension. With `.js`, Node parses the block as CommonJS first, a top-level `import` fails that attempt for the wrong reason, and the ESM retry path swallows the real error -- so `node --check block.js` exits **0** on the exact block that broke the quickstart:

```
$ printf "import x from 'y';\nconst a = 1;\n*/\n" > can.mjs
$ cp can.mjs can.js
$ for v in 18 20 22; do npx -y node@$v --check can.mjs; echo "mjs $v -> $?"; \
                        npx -y node@$v --check can.js;  echo "js  $v -> $?"; done
mjs 18 -> 1     js 18 -> 1
mjs 20 -> 1     js 20 -> 0      <-- broken sample passes
mjs 22 -> 1     js 22 -> 0      <-- broken sample passes
```

To stop that from being silently reintroduced, the script pushes a **canary** block (the snippet above, which must never parse) through the same code path on every run. Flip the extension back to `.js` and the self-check goes red instead of the gate going quiet:

```
$ sed 's/block-${block.startLine}.mjs/block-${block.startLine}.js/' \
    tools/scripts/checkReadmeSamples.mjs > /tmp/naive.mjs
$ node /tmp/naive.mjs packages/sdks/web-js-sdk/README.md
self-check failed: the canary block parsed, so this gate cannot fail.
exit=1
```

## Verification

Same command CI runs, `pnpm run readmeCheck`, in this worktree.

**Fails on the pre-fix README** (`git show origin/main:packages/sdks/web-js-sdk/README.md` restored over the working copy, gate unchanged):

```
2 of 14 JavaScript README sample(s) do not parse:

packages/sdks/web-js-sdk/README.md:43
  */
   ^

SyntaxError: Unexpected token '/'

packages/sdks/web-js-sdk/README.md:125
const sdk = descopeSdk({
      ^

SyntaxError: Identifier 'sdk' has already been declared

exit=1
```

Line 43 is the duplicated `*/` from #1470. Only one of that PR's two errors shows up per run because `node --check` stops at the first syntax error in a block; the missing-comma error surfaces once the first is fixed.

**Passes on this branch** (#1470's fix applied):

```
skipped packages/sdks/web-js-sdk/README.md:118 -- two alternative initializations shown side by side, so `sdk` is declared twice
11 JavaScript README sample(s) parse across 2 file(s).
exit=0
```

Also run under node 18 and 22 (both CI matrix entries) -- exit 0 on both.

## Scope: what is covered and what is deferred

Covered: `packages/sdks/core-js-sdk/README.md` and `packages/sdks/web-js-sdk/README.md`.

Deferred, because their `js`-tagged blocks are JSX or TypeScript and need a JSX/TS-aware parser rather than `node --check`. Measured counts of `js`/`javascript`/`jsx`/`ts`/`tsx` blocks that `node --check` rejects today:

| README | rejected blocks | why |
| --- | --- | --- |
| `react-sdk` | 24 | JSX in `js`-tagged blocks, plus `...` prop spread |
| `angular-sdk` | 15 | TypeScript decorators and type annotations |
| `nextjs-sdk` | 11 | JSX in `js`-tagged blocks |
| `web-component` | 2 | TypeScript in a `javascript`-tagged block |
| `vue-sdk` | 1 | JSX in a `js`-tagged block |

Also deferred: `ts` / `tsx` / `jsx` fence tags are skipped everywhere, including in the two covered READMEs (this drops one `ts` block in `web-js-sdk` at line 249).

One exemption is applied in this PR: the `web-js-sdk` OIDC block declares `const sdk` twice because it shows two alternative initializations side by side. It is marked with `<!-- readme-check: skip <reason> -->` rather than rewritten, since rewriting sample content is out of scope here. A reason is mandatory on the directive so every exemption stays reviewable.

## Not verified

No CI run yet -- the evidence above is local, using the exact command the new step invokes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
