### PR TITLE
docs(web-js-sdk): split the OIDC init sample into two copyable blocks

### DIFF
--- a/packages/sdks/web-js-sdk/README.md
+++ b/packages/sdks/web-js-sdk/README.md
@@ -113,7 +113,7 @@ const sessionToken = sdk.getSessionToken();
 
 Descope also supports OIDC login. To enable OIDC login, pass `oidcConfig` attribute to the SDK initialization. The `oidcConfig` attribute is either a boolean or a configuration object. If you pass `oidcConfig: true`, the SDK will use the Descope OIDC default application
 
-<!-- readme-check: skip two alternative initializations shown side by side, so `sdk` is declared twice -->
+Initialize the SDK with the default OIDC application:
 
 ```js
 // Initialize the SDK with OIDC
@@ -121,7 +121,11 @@ const sdk = descopeSdk({
   projectId: 'xxx',
   oidcConfig: true,
 });
+```
 
+Or initialize it with a custom OIDC application instead:
+
+```js
 // Initialize the SDK with custom OIDC application
 const sdk = descopeSdk({
   projectId: 'xxx',


### PR DESCRIPTION
Follow-up to #1471. Stacked on it — review that one first; the base will retarget to `main` once #1470 and #1471 land.

## Problem

The `Usage with OIDC` block in `packages/sdks/web-js-sdk/README.md` showed two alternative initializations back to back, both as `const sdk = descopeSdk({...})`. Copy-pasting the block as printed throws:

```
SyntaxError: Identifier 'sdk' has already been declared
```

Same class of defect as the quickstart errors fixed in #1470: a developer copying a documented sample hits a hard failure before reaching the SDK.

#1471 marked the block `<!-- readme-check: skip ... -->` rather than rewriting it, because rewriting sample content was out of scope for the gate PR. This is that rewrite.

## Change

The two initializations are alternatives, not a sequence, so they are now two fenced blocks with a lead-in line each:

- "Initialize the SDK with the default OIDC application:" -> `oidcConfig: true`
- "Or initialize it with a custom OIDC application instead:" -> `oidcConfig: { applicationId, redirectUri, scope }`

Both parse standalone, and either one can be copied on its own. The code inside the blocks is unchanged — only the fence boundary and the two lead-in lines are new.

The `readme-check: skip` directive is removed, so the gate from #1471 now covers this block. No skip directives remain anywhere in the repo.

## Verification

```
$ node ./tools/scripts/checkReadmeSamples.mjs
13 JavaScript README sample(s) parse across 2 file(s).
```

Green, with no `skipped ...` lines (previously 12 checked + 1 skipped). The canary self-check inside the script still passes, so the gate is not a no-op.

## Not in scope

`npx prettier --check` on this README already fails on `main`'s stacked base, at lines outside this diff (inside the quickstart block from #1470). Left alone rather than mixing an unrelated reformat into a docs fix. Prettier is not run over READMEs in CI — only `pnpm run lint` and `pnpm run readmeCheck` are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
