### PR TITLE
feat(web-component): accept session JWT from the native bridge (bridge v4)

### DIFF
--- a/packages/sdks/web-component/src/lib/descope-wc/BaseDescopeWc.ts
+++ b/packages/sdks/web-component/src/lib/descope-wc/BaseDescopeWc.ts
@@ -413,16 +413,12 @@ class BaseDescopeWc extends BaseClass {
   #injectSessionJwt<T extends FlowStartOptions | FlowNextOptions>(
     options?: T,
   ): T | undefined {
-    // a native host (bridge v4+) passes the session JWT in nativeOptions only
-    // when the app opted in - the session lives natively, not in this web view
-    const nativeSessionJwt = (
-      this as { nativeOptions?: { sessionJwt?: string } }
-    ).nativeOptions?.sessionJwt;
-    if (nativeSessionJwt) {
-      return { ...(options ?? {}), sessionJwt: nativeSessionJwt } as T;
-    }
     if (!this.sendSessionToken) return options;
-    const sessionToken = getSessionToken?.(this.storagePrefix);
+    // a native host (bridge v4+) passes the session JWT in nativeOptions -
+    // the session lives natively, not in this web view - so it wins over storage
+    const sessionToken =
+      (this as { nativeOptions?: { sessionJwt?: string } }).nativeOptions
+        ?.sessionJwt || getSessionToken?.(this.storagePrefix);
     if (!sessionToken) return options;
     return { ...(options ?? {}), sessionJwt: sessionToken } as T;
   }

--- a/packages/sdks/web-component/src/lib/descope-wc/BaseDescopeWc.ts
+++ b/packages/sdks/web-component/src/lib/descope-wc/BaseDescopeWc.ts
@@ -413,6 +413,14 @@ class BaseDescopeWc extends BaseClass {
   #injectSessionJwt<T extends FlowStartOptions | FlowNextOptions>(
     options?: T,
   ): T | undefined {
+    // a native host (bridge v4+) passes the session JWT in nativeOptions only
+    // when the app opted in - the session lives natively, not in this web view
+    const nativeSessionJwt = (
+      this as { nativeOptions?: { sessionJwt?: string } }
+    ).nativeOptions?.sessionJwt;
+    if (nativeSessionJwt) {
+      return { ...(options ?? {}), sessionJwt: nativeSessionJwt } as T;
+    }
     if (!this.sendSessionToken) return options;
     const sessionToken = getSessionToken?.(this.storagePrefix);
     if (!sessionToken) return options;

--- a/packages/sdks/web-component/src/lib/descope-wc/BaseDescopeWc.ts
+++ b/packages/sdks/web-component/src/lib/descope-wc/BaseDescopeWc.ts
@@ -410,15 +410,19 @@ class BaseDescopeWc extends BaseClass {
   // options types and preserves the given type on return. The token is read
   // via the standalone helper - the wrapping SDKs (e.g. react-sdk) override
   // the inner sdk with persistTokens: false, so the instance getter is absent
+  // the session JWT provided by a native host, if any - overridden by DescopeWc
+  // when it's connected to a native bridge (bridge v4+)
+  protected get nativeSessionJwt(): string | undefined {
+    return undefined;
+  }
+
   #injectSessionJwt<T extends FlowStartOptions | FlowNextOptions>(
     options?: T,
   ): T | undefined {
     if (!this.sendSessionToken) return options;
-    // a native host (bridge v4+) passes the session JWT in nativeOptions -
-    // the session lives natively, not in this web view - so it wins over storage
+    // a native host's token wins - the session lives natively, not in this web view
     const sessionToken =
-      (this as { nativeOptions?: { sessionJwt?: string } }).nativeOptions
-        ?.sessionJwt || getSessionToken?.(this.storagePrefix);
+      this.nativeSessionJwt || getSessionToken?.(this.storagePrefix);
     if (!sessionToken) return options;
     return { ...(options ?? {}), sessionJwt: sessionToken } as T;
   }

--- a/packages/sdks/web-component/src/lib/descope-wc/BaseDescopeWc.ts
+++ b/packages/sdks/web-component/src/lib/descope-wc/BaseDescopeWc.ts
@@ -412,6 +412,7 @@ class BaseDescopeWc extends BaseClass {
   // the inner sdk with persistTokens: false, so the instance getter is absent
   // the session JWT provided by a native host, if any - overridden by DescopeWc
   // when it's connected to a native bridge (bridge v4+)
+  // eslint-disable-next-line class-methods-use-this
   protected get nativeSessionJwt(): string | undefined {
     return undefined;
   }

--- a/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
+++ b/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
@@ -264,6 +264,10 @@ class DescopeWc extends BaseDescopeWc {
     sessionJwt?: string;
   };
 
+  protected get nativeSessionJwt(): string | undefined {
+    return this.nativeOptions?.sessionJwt;
+  }
+
   /**
    * Get all loaded SDK script modules from elements with data-script-id attribute
    * @returns Array of script modules that can be refreshed before form submission

--- a/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
+++ b/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
@@ -140,7 +140,10 @@ class DescopeWc extends BaseDescopeWc {
 
   // bridgeVersion tracks compatibility with the native SDK bridges.
   // v3: support multiple WCs in a single page via new registration mechanism (User Profile Widget)
-  static readonly bridgeVersion = 3; // readable off the constructor before any wc mounts
+  // v4: nativeOptions.sessionJwt - the native layer can opt in to sending the
+  //     current session JWT on flow start/next, exposing its validated claims
+  //     to the flow via the sessionJwtClaims context key
+  static readonly bridgeVersion = 4; // readable off the constructor before any wc mounts
 
   bridgeVersion = DescopeWc.bridgeVersion; // readable off a live instance
 
@@ -255,6 +258,9 @@ class DescopeWc extends BaseDescopeWc {
     ssoRedirect?: string;
     externalAuthRedirect?: string;
     origin?: string;
+    // set only when the native host app opted in to sending the session JWT
+    // on flow requests; the session lives natively, not in this web view
+    sessionJwt?: string;
   };
 
   /**

--- a/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
+++ b/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
@@ -140,9 +140,9 @@ class DescopeWc extends BaseDescopeWc {
 
   // bridgeVersion tracks compatibility with the native SDK bridges.
   // v3: support multiple WCs in a single page via new registration mechanism (User Profile Widget)
-  // v4: nativeOptions.sessionJwt - the native layer can opt in to sending the
-  //     current session JWT on flow start/next, exposing its validated claims
-  //     to the flow via the sessionJwtClaims context key
+  // v4: nativeOptions.sessionJwt - the native layer passes the current session
+  //     JWT; when the send-session-token opt-in is enabled it is sent on flow
+  //     start/next, exposing its validated claims via sessionJwtClaims
   static readonly bridgeVersion = 4; // readable off the constructor before any wc mounts
 
   bridgeVersion = DescopeWc.bridgeVersion; // readable off a live instance
@@ -258,8 +258,9 @@ class DescopeWc extends BaseDescopeWc {
     ssoRedirect?: string;
     externalAuthRedirect?: string;
     origin?: string;
-    // set only when the native host app opted in to sending the session JWT
-    // on flow requests; the session lives natively, not in this web view
+    // the current session JWT of the native host app - the session lives
+    // natively, not in this web view. Sent on flow requests only when the
+    // send-session-token opt-in is enabled on this component
     sessionJwt?: string;
   };
 

--- a/packages/sdks/web-component/test/descope-wc.native.test.ts
+++ b/packages/sdks/web-component/test/descope-wc.native.test.ts
@@ -392,7 +392,7 @@ describe('web-component', () => {
       delete (window as any).descopeBridge;
     });
 
-    it('Exposes bridgeVersion = 3 as both an instance field and a static field', async () => {
+    it('Exposes bridgeVersion = 4 as both an instance field and a static field', async () => {
       startMock.mockReturnValueOnce(generateSdkResponse());
 
       // legacy bridges omit registerFlow/unregisterFlow; ensure that path still works
@@ -408,9 +408,9 @@ describe('web-component', () => {
         },
       );
 
-      expect(wcEle.bridgeVersion).toBe(3);
+      expect(wcEle.bridgeVersion).toBe(4);
       // static accessor for natives that read the version from the constructor
-      expect((wcEle.constructor as any).bridgeVersion).toBe(3);
+      expect((wcEle.constructor as any).bridgeVersion).toBe(4);
     });
 
     it('Calls descopeBridge.registerFlow(this) on connect with the wc instance', async () => {

--- a/packages/sdks/web-component/test/descope-wc.sendSessionToken.test.ts
+++ b/packages/sdks/web-component/test/descope-wc.sendSessionToken.test.ts
@@ -76,6 +76,28 @@ describe('web-component', () => {
       ).toBeUndefined();
     });
 
+    it('sends the native bridge session jwt even without the attribute', async () => {
+      startMock.mockReturnValueOnce(generateSdkResponse());
+      nextMock.mockReturnValueOnce(generateSdkResponse());
+      getSessionTokenMock.mockReturnValue('');
+
+      document.body.innerHTML = `<descope-wc flow-id="sign-in" project-id="1"></descope-wc>`;
+
+      await waitFor(() => expect(startMock).toHaveBeenCalled(), {
+        timeout: WAIT_TIMEOUT,
+      });
+      const wc = document.getElementsByTagName('descope-wc')[0] as any;
+      wc.nativeOptions = {
+        platform: 'android',
+        bridgeVersion: 4,
+        sessionJwt: 'native-session-jwt',
+      };
+      await wc.sdk.flow.next('exec-id', 'step-id', 'interaction-id');
+      expect(nextMock.mock.calls[0][NEXT_OPTIONS_ARG_IDX]).toEqual(
+        expect.objectContaining({ sessionJwt: 'native-session-jwt' }),
+      );
+    });
+
     it('does not add the key when no session token exists', async () => {
       startMock.mockReturnValueOnce(generateSdkResponse());
       getSessionTokenMock.mockReturnValue('');

--- a/packages/sdks/web-component/test/descope-wc.sendSessionToken.test.ts
+++ b/packages/sdks/web-component/test/descope-wc.sendSessionToken.test.ts
@@ -76,7 +76,29 @@ describe('web-component', () => {
       ).toBeUndefined();
     });
 
-    it('sends the native bridge session jwt even without the attribute', async () => {
+    it('prefers the native bridge session jwt when enabled', async () => {
+      startMock.mockReturnValueOnce(generateSdkResponse());
+      nextMock.mockReturnValueOnce(generateSdkResponse());
+      getSessionTokenMock.mockReturnValue('');
+
+      document.body.innerHTML = `<descope-wc flow-id="sign-in" project-id="1" send-session-token="true"></descope-wc>`;
+
+      await waitFor(() => expect(startMock).toHaveBeenCalled(), {
+        timeout: WAIT_TIMEOUT,
+      });
+      const wc = document.getElementsByTagName('descope-wc')[0] as any;
+      wc.nativeOptions = {
+        platform: 'android',
+        bridgeVersion: 4,
+        sessionJwt: 'native-session-jwt',
+      };
+      await wc.sdk.flow.next('exec-id', 'step-id', 'interaction-id');
+      expect(nextMock.mock.calls[0][NEXT_OPTIONS_ARG_IDX]).toEqual(
+        expect.objectContaining({ sessionJwt: 'native-session-jwt' }),
+      );
+    });
+
+    it('does not send the native bridge session jwt without the attribute', async () => {
       startMock.mockReturnValueOnce(generateSdkResponse());
       nextMock.mockReturnValueOnce(generateSdkResponse());
       getSessionTokenMock.mockReturnValue('');
@@ -93,9 +115,9 @@ describe('web-component', () => {
         sessionJwt: 'native-session-jwt',
       };
       await wc.sdk.flow.next('exec-id', 'step-id', 'interaction-id');
-      expect(nextMock.mock.calls[0][NEXT_OPTIONS_ARG_IDX]).toEqual(
-        expect.objectContaining({ sessionJwt: 'native-session-jwt' }),
-      );
+      expect(
+        nextMock.mock.calls[0][NEXT_OPTIONS_ARG_IDX]?.sessionJwt,
+      ).toBeUndefined();
     });
 
     it('does not add the key when no session token exists', async () => {


### PR DESCRIPTION
## Related Issues
Required for:
https://github.com/descope/etc/issues/17811

## Related PRs
### Related PRs
- https://github.com/descope/descope-js/pull/1467 (web opt-in, merged)

## In a Nutshell
- Bridge version bumped to 4
- New optional `nativeOptions.sessionJwt` set by native SDK bridges
- When present, it is sent on flow start/next options (same path as the web `send-session-token` opt-in)

## Description
Native SDKs (Android/iOS, used by React Native) run flows in a web view where the session lives natively, not in web storage. With bridge v4, a native host that opted in can pass the current session JWT through `nativeOptions`, and the web component sends it on flow start/next request options so the flow can check the validated session claims server side. Companion native SDK PRs add the opt-in flag.

## Must
- [ ] Tests
- [ ] Documentation (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)