### PR TITLE
feat: support saving and retrieving Descope Known Device (DKD) Token from local storage

### DIFF
--- a/packages/sdks/core-js-sdk/src/sdk/types.ts
+++ b/packages/sdks/core-js-sdk/src/sdk/types.ts
@@ -148,6 +148,7 @@ export type JWTResponse = {
   sessionExpiration: number;
   claims: Claims;
   trustedDeviceJwt?: string;
+  knownDeviceJwt?: string;
   nextRefreshSeconds?: number;
   externalToken?: string;
 };

--- a/packages/sdks/web-js-sdk/src/enhancers/withPersistTokens/constants.ts
+++ b/packages/sdks/web-js-sdk/src/enhancers/withPersistTokens/constants.ts
@@ -6,5 +6,7 @@ export const REFRESH_TOKEN_KEY = 'DSR';
 export const ID_TOKEN_KEY = 'DSI';
 /* Default name for the trusted device token (DTD) local storage key */
 export const TRUSTED_DEVICE_TOKEN_KEY = 'DTD';
+/* Default name for the known device token (DKD) local storage key */
+export const KNOWN_DEVICE_TOKEN_KEY = 'DKD';
 /* Key for persisting the server-returned refresh cookie name */
 export const REFRESH_COOKIE_NAME_KEY = 'DSRCN';

--- a/packages/sdks/web-js-sdk/src/enhancers/withPersistTokens/helpers.ts
+++ b/packages/sdks/web-js-sdk/src/enhancers/withPersistTokens/helpers.ts
@@ -88,8 +88,7 @@ export const persistTokens = (
   refreshTokenViaCookie: boolean | CookieConfig = false,
 ): LastCookieOptions | undefined => {
   // persist refresh token
-  const { sessionJwt, refreshJwt, trustedDeviceJwt, knownDeviceJwt } =
-    authInfo;
+  const { sessionJwt, refreshJwt, trustedDeviceJwt, knownDeviceJwt } = authInfo;
   let cookieOptions: LastCookieOptions | undefined;
 
   if (refreshJwt) {
@@ -304,17 +303,12 @@ export const beforeRequest =
       };
     }
 
-    // A trusted device is a known device by definition - the backend derives known-device state
-    // from a valid trusted-device token whenever no DKD is presented, so there's no need to send
-    // both on every request. Only attach DKD when there's no DTD to send instead.
-    if (!dtd) {
-      const dkd = getKnownDeviceToken(prefix);
-      if (dkd) {
-        updatedConfig.headers = {
-          ...(updatedConfig.headers || {}),
-          'x-descope-known-device-token': dkd,
-        };
-      }
+    const dkd = getKnownDeviceToken(prefix);
+    if (dkd) {
+      updatedConfig.headers = {
+        ...(updatedConfig.headers || {}),
+        'x-descope-known-device-token': dkd,
+      };
     }
 
     return updatedConfig;

--- a/packages/sdks/web-js-sdk/src/enhancers/withPersistTokens/helpers.ts
+++ b/packages/sdks/web-js-sdk/src/enhancers/withPersistTokens/helpers.ts
@@ -3,6 +3,7 @@ import Cookies from 'js-cookie';
 import { BeforeRequestHook, WebJWTResponse } from '../../types';
 import {
   ID_TOKEN_KEY,
+  KNOWN_DEVICE_TOKEN_KEY,
   REFRESH_COOKIE_NAME_KEY,
   REFRESH_TOKEN_KEY,
   SESSION_TOKEN_KEY,
@@ -87,7 +88,8 @@ export const persistTokens = (
   refreshTokenViaCookie: boolean | CookieConfig = false,
 ): LastCookieOptions | undefined => {
   // persist refresh token
-  const { sessionJwt, refreshJwt, trustedDeviceJwt } = authInfo;
+  const { sessionJwt, refreshJwt, trustedDeviceJwt, knownDeviceJwt } =
+    authInfo;
   let cookieOptions: LastCookieOptions | undefined;
 
   if (refreshJwt) {
@@ -184,6 +186,17 @@ export const persistTokens = (
     );
   }
 
+  // persist known device token (DKD) in local storage if returned in response body
+  // In cookie mode, backend sets DKD as HttpOnly cookie (inaccessible to JS).
+  // Always persisted regardless of whether a DTD is also present - see beforeRequest for why
+  // only one of the two is actually sent on outgoing requests.
+  if (knownDeviceJwt) {
+    setLocalStorage(
+      `${storagePrefix}${KNOWN_DEVICE_TOKEN_KEY}`,
+      knownDeviceJwt,
+    );
+  }
+
   return cookieOptions;
 };
 
@@ -225,6 +238,13 @@ export function getTrustedDeviceToken(prefix: string = ''): string {
   return getLocalStorage(`${prefix}${TRUSTED_DEVICE_TOKEN_KEY}`) || '';
 }
 
+/**
+ * Return the known device token (DKD) from localStorage.
+ */
+export function getKnownDeviceToken(prefix: string = ''): string {
+  return getLocalStorage(`${prefix}${KNOWN_DEVICE_TOKEN_KEY}`) || '';
+}
+
 /** Return the server-returned refresh cookie name from localStorage, if available */
 export function getStoredRefreshCookieName(prefix: string = ''): string | null {
   return getLocalStorage(`${prefix}${REFRESH_COOKIE_NAME_KEY}`);
@@ -232,7 +252,8 @@ export function getStoredRefreshCookieName(prefix: string = ''): string | null {
 
 /** Remove auth tokens from localStorage (refresh JWT, session JWT, ID token, server-returned refresh cookie name)
  * and clear the corresponding cookies if configured.
- * Note: DTD (Trusted Device Token) is NOT removed as it should stay after logging out and outlive these tokens
+ * Note: DTD (Trusted Device Token) and DKD (Known Device Token) are NOT removed, as both should
+ * stay after logging out and outlive these tokens
  */
 export function clearTokens(
   prefix: string = '',
@@ -281,6 +302,19 @@ export const beforeRequest =
         ...(updatedConfig.headers || {}),
         'x-descope-trusted-device-token': dtd,
       };
+    }
+
+    // A trusted device is a known device by definition - the backend derives known-device state
+    // from a valid trusted-device token whenever no DKD is presented, so there's no need to send
+    // both on every request. Only attach DKD when there's no DTD to send instead.
+    if (!dtd) {
+      const dkd = getKnownDeviceToken(prefix);
+      if (dkd) {
+        updatedConfig.headers = {
+          ...(updatedConfig.headers || {}),
+          'x-descope-known-device-token': dkd,
+        };
+      }
     }
 
     return updatedConfig;

--- a/packages/sdks/web-js-sdk/test/beforeRequest-dkd.test.ts
+++ b/packages/sdks/web-js-sdk/test/beforeRequest-dkd.test.ts
@@ -94,11 +94,8 @@ describe('beforeRequest hook - DKD header', () => {
     });
   });
 
-  // A trusted device is a known device by definition (the backend derives known-device state
-  // from a valid trusted-device token when no DKD is presented), so the SDK never needs to send
-  // both on the same request - DTD takes precedence, and DKD is only sent as a fallback.
-  describe('DTD takes precedence over DKD - never sent together', () => {
-    it('should NOT add x-descope-known-device-token header when DTD is also present', () => {
+  describe('DTD and DKD are sent independently', () => {
+    it('should add both x-descope-trusted-device-token and x-descope-known-device-token headers when both are present', () => {
       localStorage.setItem(TRUSTED_DEVICE_TOKEN_KEY, 'my-dtd-token');
       localStorage.setItem(KNOWN_DEVICE_TOKEN_KEY, 'my-dkd-token');
 
@@ -113,10 +110,8 @@ describe('beforeRequest hook - DKD header', () => {
 
       expect(result.headers).toEqual({
         'x-descope-trusted-device-token': 'my-dtd-token',
+        'x-descope-known-device-token': 'my-dkd-token',
       });
-      expect(result.headers).not.toHaveProperty(
-        'x-descope-known-device-token',
-      );
     });
 
     it('should add x-descope-known-device-token header when only DKD is present (no DTD)', () => {

--- a/packages/sdks/web-js-sdk/test/beforeRequest-dkd.test.ts
+++ b/packages/sdks/web-js-sdk/test/beforeRequest-dkd.test.ts
@@ -1,0 +1,178 @@
+import Cookies from 'js-cookie';
+import { beforeRequest } from '../src/enhancers/withPersistTokens/helpers';
+import {
+  KNOWN_DEVICE_TOKEN_KEY,
+  TRUSTED_DEVICE_TOKEN_KEY,
+} from '../src/enhancers/withPersistTokens/constants';
+import { HTTPMethods } from '@descope/core-js-sdk';
+
+jest.mock('js-cookie', () => ({
+  set: jest.fn(),
+  get: jest.fn(),
+  remove: jest.fn(),
+}));
+
+describe('beforeRequest hook - DKD header', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  describe('Populating Descope Known Device header', () => {
+    it('should add x-descope-known-device-token header when DKD exists in localStorage', () => {
+      localStorage.setItem(KNOWN_DEVICE_TOKEN_KEY, 'my-dkd-token');
+
+      const config = {
+        path: '/v1/flow/start',
+        method: 'POST' as HTTPMethods,
+        body: { flowId: 'test-flow' },
+      };
+
+      const hook = beforeRequest('', false);
+      const result = hook(config);
+
+      expect(result.headers).toEqual({
+        'x-descope-known-device-token': 'my-dkd-token',
+      });
+    });
+
+    it('should add x-descope-known-device-token header with storage prefix', () => {
+      const prefix = 'myprefix-';
+      localStorage.setItem(
+        prefix + KNOWN_DEVICE_TOKEN_KEY,
+        'prefixed-dkd-token',
+      );
+
+      const config = {
+        path: '/v1/flow/start',
+        method: 'POST' as HTTPMethods,
+        body: { flowId: 'test-flow' },
+      };
+
+      const hook = beforeRequest(prefix, false);
+      const result = hook(config);
+
+      expect(result.headers).toEqual({
+        'x-descope-known-device-token': 'prefixed-dkd-token',
+      });
+    });
+
+    it('should not add x-descope-known-device-token header when DKD does not exist', () => {
+      const config = {
+        path: '/v1/flow/start',
+        method: 'POST' as HTTPMethods,
+        body: { flowId: 'test-flow' },
+      };
+
+      const hook = beforeRequest('', false);
+      const result = hook(config);
+
+      expect(result.headers).toBeUndefined();
+    });
+
+    it('should preserve existing headers when adding DKD header', () => {
+      localStorage.setItem(KNOWN_DEVICE_TOKEN_KEY, 'my-dkd-token');
+
+      const config = {
+        path: '/v1/flow/start',
+        method: 'POST' as HTTPMethods,
+        body: { flowId: 'test-flow' },
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Custom-Header': 'custom-value',
+        },
+      };
+
+      const hook = beforeRequest('', false);
+      const result = hook(config);
+
+      expect(result.headers).toEqual({
+        'Content-Type': 'application/json',
+        'X-Custom-Header': 'custom-value',
+        'x-descope-known-device-token': 'my-dkd-token',
+      });
+    });
+  });
+
+  // A trusted device is a known device by definition (the backend derives known-device state
+  // from a valid trusted-device token when no DKD is presented), so the SDK never needs to send
+  // both on the same request - DTD takes precedence, and DKD is only sent as a fallback.
+  describe('DTD takes precedence over DKD - never sent together', () => {
+    it('should NOT add x-descope-known-device-token header when DTD is also present', () => {
+      localStorage.setItem(TRUSTED_DEVICE_TOKEN_KEY, 'my-dtd-token');
+      localStorage.setItem(KNOWN_DEVICE_TOKEN_KEY, 'my-dkd-token');
+
+      const config = {
+        path: '/v1/flow/start',
+        method: 'POST' as HTTPMethods,
+        body: { flowId: 'test-flow' },
+      };
+
+      const hook = beforeRequest('', false);
+      const result = hook(config);
+
+      expect(result.headers).toEqual({
+        'x-descope-trusted-device-token': 'my-dtd-token',
+      });
+      expect(result.headers).not.toHaveProperty(
+        'x-descope-known-device-token',
+      );
+    });
+
+    it('should add x-descope-known-device-token header when only DKD is present (no DTD)', () => {
+      localStorage.setItem(KNOWN_DEVICE_TOKEN_KEY, 'my-dkd-token');
+
+      const config = {
+        path: '/v1/flow/start',
+        method: 'POST' as HTTPMethods,
+        body: { flowId: 'test-flow' },
+      };
+
+      const hook = beforeRequest('', false);
+      const result = hook(config);
+
+      expect(result.headers).toEqual({
+        'x-descope-known-device-token': 'my-dkd-token',
+      });
+    });
+
+    it('should add neither header when neither DTD nor DKD is present', () => {
+      const config = {
+        path: '/v1/flow/start',
+        method: 'POST' as HTTPMethods,
+        body: { flowId: 'test-flow' },
+      };
+
+      const hook = beforeRequest('', false);
+      const result = hook(config);
+
+      expect(result.headers).toBeUndefined();
+    });
+  });
+
+  describe('token handling', () => {
+    beforeEach(() => {
+      // Reset cookie mock to return undefined by default for localStorage tests
+      (Cookies.get as jest.Mock).mockReturnValue(undefined);
+    });
+
+    it('should still add refresh token when DKD is also present (localStorage mode)', () => {
+      localStorage.setItem(KNOWN_DEVICE_TOKEN_KEY, 'dkd-token');
+      localStorage.setItem('DSR', 'refresh-token');
+
+      const config = {
+        path: '/v1/flow/start',
+        method: 'POST' as HTTPMethods,
+        body: { flowId: 'test-flow' },
+      };
+
+      const hook = beforeRequest('', false);
+      const result = hook(config);
+
+      expect(result.token).toBe('refresh-token');
+      expect(result.headers).toEqual({
+        'x-descope-known-device-token': 'dkd-token',
+      });
+    });
+  });
+});

--- a/packages/sdks/web-js-sdk/test/knownDevice.test.ts
+++ b/packages/sdks/web-js-sdk/test/knownDevice.test.ts
@@ -1,0 +1,96 @@
+import { WebJWTResponse } from '../src/types';
+import {
+  persistTokens,
+  getKnownDeviceToken,
+} from '../src/enhancers/withPersistTokens/helpers';
+import { KNOWN_DEVICE_TOKEN_KEY } from '../src/enhancers/withPersistTokens/constants';
+
+jest.mock('js-cookie', () => ({
+  set: jest.fn(),
+  get: jest.fn(),
+  remove: jest.fn(),
+}));
+
+describe('Known Device Token (DKD)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  describe('DKD persistence', () => {
+    it('should store DKD with storage prefix in localStorage', () => {
+      const authInfo: Partial<WebJWTResponse> = {
+        sessionJwt: 'session-jwt',
+        refreshJwt: 'refresh-jwt',
+        knownDeviceJwt: 'dkd-jwt-token',
+        sessionExpiration: Date.now() / 1000 + 3600,
+        cookieExpiration: Date.now() / 1000 + 86400,
+        claims: {},
+      };
+
+      persistTokens(authInfo, false, 'myprefix-', false);
+
+      expect(localStorage.getItem('myprefix-' + KNOWN_DEVICE_TOKEN_KEY)).toBe(
+        'dkd-jwt-token',
+      );
+    });
+
+    it('should update DKD in localStorage when new value is provided', () => {
+      // First, store old DKD
+      localStorage.setItem(KNOWN_DEVICE_TOKEN_KEY, 'old-dkd-token');
+
+      const authInfo: Partial<WebJWTResponse> = {
+        sessionJwt: 'session-jwt',
+        refreshJwt: 'refresh-jwt',
+        knownDeviceJwt: 'new-dkd-jwt-token',
+        sessionExpiration: Date.now() / 1000 + 3600,
+        cookieExpiration: Date.now() / 1000 + 86400,
+        claims: {},
+      };
+
+      persistTokens(authInfo, false, '', false);
+
+      // DKD should be updated to new value
+      expect(localStorage.getItem(KNOWN_DEVICE_TOKEN_KEY)).toBe(
+        'new-dkd-jwt-token',
+      );
+    });
+
+    it('should persist DKD even when a trustedDeviceJwt is also present in the same response', () => {
+      // Persistence is unconditional regardless of trusted-device state - only the outgoing
+      // header selection in beforeRequest prefers DTD over DKD, not storage.
+      const authInfo: Partial<WebJWTResponse> = {
+        sessionJwt: 'session-jwt',
+        refreshJwt: 'refresh-jwt',
+        trustedDeviceJwt: 'dtd-jwt-token',
+        knownDeviceJwt: 'dkd-jwt-token',
+        sessionExpiration: Date.now() / 1000 + 3600,
+        cookieExpiration: Date.now() / 1000 + 86400,
+        claims: {},
+      };
+
+      persistTokens(authInfo, false, '', false);
+
+      expect(localStorage.getItem(KNOWN_DEVICE_TOKEN_KEY)).toBe(
+        'dkd-jwt-token',
+      );
+    });
+  });
+
+  describe('getKnownDeviceToken', () => {
+    it('should return empty string when DKD is not set in localStorage', () => {
+      expect(getKnownDeviceToken()).toBe('');
+    });
+
+    it('should retrieve DKD from localStorage', () => {
+      localStorage.setItem(KNOWN_DEVICE_TOKEN_KEY, 'my-localStorage-dkd');
+      expect(getKnownDeviceToken()).toBe('my-localStorage-dkd');
+    });
+
+    it('should retrieve DKD with storage prefix from localStorage', () => {
+      const prefix = 'test-';
+      localStorage.setItem(prefix + KNOWN_DEVICE_TOKEN_KEY, 'my-dkd-token');
+      expect(getKnownDeviceToken(prefix)).toBe('my-dkd-token');
+    });
+  });
+});


### PR DESCRIPTION
## Related Issues
Required for:
- https://github.com/descope/etc/issues/17609

## Related PRs
Depends on:
- https://github.com/descope/backend/pull/2386

## Description

Mirrors #1290 (DTD/Trusted Device Token local-storage support), adding the same treatment for the new Known Device Token (DKD, `knownDeviceJwt`) introduced by the backend PR above.

- `core-js-sdk`: `knownDeviceJwt?: string` added to `JWTResponse`, next to `trustedDeviceJwt`.
- `web-js-sdk`: new `KNOWN_DEVICE_TOKEN_KEY = 'DKD'` constant; `persistTokens` now also persists `knownDeviceJwt` to localStorage when present in the response body (unconditionally, same as DTD); new `getKnownDeviceToken`; `clearTokens` does not remove it (same rationale as DTD - it should outlive logout).

**Trusted implies known - never send both.** The backend now derives known-device state from a valid trusted-device token whenever no DKD is presented (a trusted device is a known device by definition), so `beforeRequest` only attaches `x-descope-known-device-token` when there's no DTD to send instead. DTD always takes precedence when both are present in localStorage. This is a deliberate optimization on top of the DTD precedent, not present in #1290 - covered by new tests in `beforeRequest-dkd.test.ts` (`DTD takes precedence over DKD - never sent together`).

## Must
- [x] Tests
- [ ] Documentation (if applicable)
