### PR TITLE
feat(user-management-widget): show role descriptions in roles selector

### DIFF
--- a/packages/libs/sdk-component-drivers/src/MultiSelectDriver.ts
+++ b/packages/libs/sdk-component-drivers/src/MultiSelectDriver.ts
@@ -1,9 +1,69 @@
 import { BaseDriver } from './BaseDriver';
 
+type MultiSelectOption = {
+  label: string;
+  value: string;
+  description?: string;
+};
+
+type RenderItemInput = {
+  displayName?: string;
+  value: string;
+  label: string;
+  description?: string;
+};
+
+type MultiSelectComboBoxElement = HTMLElement & {
+  renderItem: (item: RenderItemInput) => string;
+};
+
+// Mirrors the combo-box's own default item rendering (name/value/label), plus
+// a description line rendered beneath the label. The chip and filtering logic
+// read the item's `data-name`/`data-id` attributes, not its markup, so adding
+// the description here doesn't affect the selected-item chips.
+const renderItemWithDescription = ({
+  displayName,
+  value,
+  label,
+  description,
+}: RenderItemInput) => {
+  const ele = document.createElement('span');
+  ele.setAttribute('data-name', label);
+  ele.setAttribute('data-id', value);
+  ele.setAttribute(
+    'style',
+    'display: flex; flex-direction: column; gap: 0.125rem;',
+  );
+
+  const nameEle = document.createElement('span');
+  nameEle.textContent = displayName || label;
+  ele.appendChild(nameEle);
+
+  if (description) {
+    const descriptionEle = document.createElement('span');
+    descriptionEle.setAttribute(
+      'style',
+      'font-size: 0.75em; opacity: 0.65; white-space: normal;',
+    );
+    descriptionEle.textContent = description;
+    ele.appendChild(descriptionEle);
+  }
+
+  return ele.outerHTML;
+};
+
 export class MultiSelectDriver extends BaseDriver {
   nodeName = 'descope-multi-select-combo-box';
 
-  async setData(data: { label: string; value: string }[]) {
-    (await this.asyncEle)?.setAttribute('data', JSON.stringify(data.sort()));
+  async setData(data: MultiSelectOption[]) {
+    const ele = await this.asyncEle;
+    if (!ele) return;
+
+    ele.setAttribute('data', JSON.stringify(data.sort()));
+
+    if (data.some(({ description }) => description)) {
+      (ele as MultiSelectComboBoxElement).renderItem =
+        renderItemWithDescription;
+    }
   }
 }

--- a/packages/widgets/user-management-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initCreateUserModalMixin.ts
+++ b/packages/widgets/user-management-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initCreateUserModalMixin.ts
@@ -151,9 +151,10 @@ export const initCreateUserModalMixin = createSingletonMixin(
 
       #updateRolesMultiSelect = async () => {
         await this.#rolesMultiSelect.setData(
-          getTenantRoles(this.state).map(({ name }) => ({
+          getTenantRoles(this.state).map(({ name, description }) => ({
             value: name,
             label: name,
+            description,
           })),
         );
       };

--- a/packages/widgets/user-management-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initEditUserModalMixin.ts
+++ b/packages/widgets/user-management-widget/src/lib/widget/mixins/initMixin/initComponentsMixins/initEditUserModalMixin.ts
@@ -106,9 +106,10 @@ export const initEditUserModalMixin = createSingletonMixin(
 
       #updateRolesMultiSelect = async () => {
         await this.#rolesMultiSelect.setData(
-          getTenantRoles(this.state).map(({ name }) => ({
+          getTenantRoles(this.state).map(({ name, description }) => ({
             value: name,
             label: name,
+            description,
           })),
         );
       };


### PR DESCRIPTION
Fixes descope/etc#18131

[View Shuni run](https://shuni.descope.ai/sessions?sandbox=iajczxw3mdof8ur0jqp36)

## Summary

Implemented the feature request: role descriptions now appear beneath each role name in the users management widget's roles selector (both create-user and edit-user modals).

**Root cause / approach**: The roles selector is `<descope-multi-select-combo-box>`, an external component (`@descope-ui/descope-multi-select-combo-box`) driven from descope-js via `MultiSelectDriver`. I confirmed by reading its published source that:
- It supports a `renderItem(item)` property that returns the HTML for each dropdown option.
- The selected-chip label/value and dedup logic read the item's `data-name`/`data-id` attributes (via Vaadin's `itemLabelPath`/`itemValuePath`), not its inner markup — so enriching an option's HTML with a description line is safe and doesn't leak into the selected chips.

**Changes**:
1. `packages/libs/sdk-component-drivers/src/MultiSelectDriver.ts` — `setData` now accepts an optional `description` per option; when any item carries a description, it assigns a `renderItem` function that renders the role name with its description on a second line beneath it (still setting `data-name`/`data-id` as before, so chips/values are unaffected). Other consumers of this shared driver (permissions, sub-tenant roles, IPs) that don't pass a `description` are unaffected.
2. `initCreateUserModalMixin.ts` and `initEditUserModalMixin.ts` (user-management-widget) — now pass each role's `description` through to the roles multiselect's `setData`.

**Verification**:
- `nx run sdk-component-drivers:build/lint` and `nx run user-management-widget:build/lint` all pass.
- `nx run user-management-widget:test:unit` — 68/68 tests pass.
- Also rebuilt `role-management-widget` and `access-key-management-widget` (other consumers of `MultiSelectDriver`) to confirm no regressions.
- Reverted an incidental `pnpm-lock.yaml` diff produced by the local install's `postinstall` bump of `@descope/web-components-ui`, unrelated to this fix.

Changes are committed on the working branch.

---
*Created by [Shuni](https://github.com/descope/shuni) 🐕*