### PR TITLE
feat(react-sdk): support Preact via preact/compat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ node_modules
 /connect.lock
 packages/**/coverage
 packages/**/build
+packages/**/build-preact
 /libpeerconnection.log
 npm-debug.log
 yarn-error.log

--- a/packages/sdks/react-sdk/README.md
+++ b/packages/sdks/react-sdk/README.md
@@ -5,6 +5,7 @@ The Descope SDK for React provides convenient access to the Descope for an appli
 ## Requirements
 
 - The SDK supports React version 16 and above.
+- The SDK also runs on [Preact](#preact-support) 10.11+ via `preact/compat`.
 - A Descope `Project ID` is required for using the SDK. Find it on the [project page in the Descope Console](https://app.descope.com/settings/project).
 
 ## Installing the SDK
@@ -410,7 +411,7 @@ function Layout() {
 
 <AuthProvider projectId="my-project-id" autoRefresh={{ customActivityTracking: true }}>
   <Layout />
-</AuthProvider>
+</AuthProvider>;
 ```
 
 **For more SDK usage examples refer to [docs](https://docs.descope.com/build/guides/client_sdks/)**
@@ -808,7 +809,9 @@ Example:
 
 ## Code Example
 
-You can find an example react app in the [examples folder](./examples).
+You can find an example react app in the [examples folder](./examples), and a
+Preact one in [examples/preact-app](./examples/preact-app) (see
+[Preact Support](#preact-support)).
 
 ### Setup
 
@@ -852,6 +855,123 @@ See the following table for customization environment variables for the example 
 |                             |                                                                                                               |                                  |
 | DESCOPE_OIDC_ENABLED        | **"true"** - Use OIDC login                                                                                   | None                             |
 | DESCOPE_OIDC_APPLICATION_ID | Descope OIDC Application ID, In case OIDC login is used                                                       | None                             |
+
+## Preact Support
+
+The SDK runs unmodified on Preact 10.11+ through `preact/compat` - the same
+package, the same API, no Preact-specific entry point. Its test suite is
+executed twice in CI: once against React and once with `react` aliased to
+`preact/compat` (`npm run test:preact`), so hooks, `<Descope />`, and the
+widgets are covered under both.
+
+### Setup
+
+Alias `react` and `react-dom` to `preact/compat` in your bundler. Most Preact
+setups already do this:
+
+```js
+// vite.config.js
+import { defineConfig } from 'vite';
+import preact from '@preact/preset-vite';
+
+export default defineConfig({
+  plugins: [preact()], // aliases react/react-dom -> preact/compat
+});
+```
+
+```js
+// webpack.config.js
+module.exports = {
+  resolve: {
+    alias: {
+      react: 'preact/compat',
+      'react-dom': 'preact/compat',
+      'react-dom/test-utils': 'preact/compat/test-utils',
+      'react/jsx-runtime': 'preact/compat/jsx-runtime',
+    },
+  },
+};
+```
+
+The SDK declares `react` as a peer dependency. Point it at `preact/compat` so
+installs stay quiet without pulling React in:
+
+```json
+{
+  "dependencies": {
+    "react": "npm:@preact/compat",
+    "react-dom": "npm:@preact/compat"
+  }
+}
+```
+
+For TypeScript, map the types as well - the SDK's declarations reference
+`React.FC`, `React.Ref` and `DOMAttributes`:
+
+```json
+{
+  "compilerOptions": {
+    "paths": {
+      "react": ["./node_modules/preact/compat/"],
+      "react-dom": ["./node_modules/preact/compat/"]
+    }
+  }
+}
+```
+
+Then use the SDK exactly as documented above:
+
+```jsx
+import { render } from 'preact';
+import { AuthProvider, Descope, useSession } from '@descope/react-sdk';
+
+render(
+  <AuthProvider projectId="my-project-id">
+    <App />
+  </AuthProvider>,
+  document.getElementById('root'),
+);
+```
+
+A complete working app is in [examples/preact-app](./examples/preact-app) -
+run it with `npm run start:preact`.
+
+### Behavioural differences to be aware of
+
+Two things differ from React. Neither blocks any SDK feature, but both can
+surface in tests or on the server:
+
+1. **Effects run after paint.** Preact schedules `useEffect` on the next
+   frame, while React flushes it before the browser paints. `<Descope />`
+   attaches its `success` / `error` / `ready` listeners from an effect, so an
+   event dispatched in the same tick as mount can be missed. Real flows emit
+   these events long after mount, so this only tends to matter in tests - wait
+   for the listener rather than assuming it is attached:
+
+   ```js
+   await waitFor(() => {
+     fireEvent(container.querySelector('descope-wc'), new CustomEvent('error'));
+     expect(document.querySelector('.error')).not.toBeNull();
+   });
+   ```
+
+2. **SSR needs the async renderer.** `<Descope />` and the widgets lazy-load
+   their web component, so the first server render suspends.
+   `preact-render-to-string`'s synchronous `renderToString` throws on a
+   suspended subtree instead of emitting the `<Suspense>` fallback - use
+   `renderToStringAsync` (v6+):
+
+   ```js
+   import { renderToStringAsync } from 'preact-render-to-string';
+
+   const html = await renderToStringAsync(<App />);
+   ```
+
+If you would rather not pull in a compat layer at all,
+[`@descope/web-component`](https://www.npmjs.com/package/@descope/web-component)
+is a framework-agnostic custom element - but it does not provide the
+`useSession` / `useUser` / `useDescope` hooks or the `AuthProvider` session
+management this SDK adds.
 
 ## Performance / Bundle Size
 

--- a/packages/sdks/react-sdk/examples/preact-app/App.tsx
+++ b/packages/sdks/react-sdk/examples/preact-app/App.tsx
@@ -1,0 +1,107 @@
+/* eslint-disable no-console */
+import React, { useCallback, useRef, useState } from 'react';
+import {
+  Descope,
+  UserProfile,
+  useDescope,
+  useSession,
+  useUser,
+} from '../../src';
+
+const card: React.CSSProperties = {
+  borderRadius: 10,
+  margin: 'auto',
+  border: '1px solid lightgray',
+  padding: 20,
+  width: '600px',
+  background: '#ecf0f3',
+};
+
+const Login = () => {
+  const [errorMessage, setErrorMessage] = useState('');
+  const [isFlowLoading, setIsFlowLoading] = useState(true);
+
+  // Exercises the imperative handle - `ref` resolves to the `descope-wc`
+  // element, which is what the React SDK exposes through `useImperativeHandle`.
+  const flowRef = useRef<HTMLElement>(null);
+
+  const onError = useCallback(
+    () => setErrorMessage('Something went wrong'),
+    [],
+  );
+  const onReady = useCallback(() => {
+    setIsFlowLoading(false);
+    console.log('flow element:', flowRef.current?.tagName);
+  }, []);
+  const onSuccess = useCallback(
+    (e: CustomEvent) => console.log('logged in', e.detail),
+    [],
+  );
+
+  return (
+    <div style={card}>
+      <h2>Login</h2>
+      {isFlowLoading && <div>Loading...</div>}
+      <Descope
+        ref={flowRef}
+        flowId={process.env.DESCOPE_FLOW_ID || 'sign-up-or-in'}
+        onSuccess={onSuccess}
+        onError={onError}
+        onReady={onReady}
+        theme={process.env.DESCOPE_THEME as any}
+        styleId={process.env.DESCOPE_STYLE_ID}
+        locale={process.env.DESCOPE_LOCALE}
+        redirectUrl={process.env.DESCOPE_REDIRECT_URL}
+        tenant={process.env.DESCOPE_TENANT_ID}
+        debug={process.env.DESCOPE_DEBUG_MODE === 'true'}
+        client={{ version: '1.0.2' }}
+        logger={console}
+      />
+      {errorMessage && <div className="error">{errorMessage}</div>}
+    </div>
+  );
+};
+
+const Home = () => {
+  const { user, isUserLoading } = useUser();
+  const { sessionToken, claims } = useSession();
+  const sdk = useDescope();
+
+  const [showProfile, setShowProfile] = useState(false);
+
+  if (isUserLoading) return <div style={card}>Loading user...</div>;
+
+  return (
+    <div style={card}>
+      <h2>Hello {user?.name || user?.email}</h2>
+      <p>Subject claim: {String(claims?.sub)}</p>
+      <p>Session token length: {sessionToken?.length ?? 0}</p>
+
+      <button type="button" onClick={() => setShowProfile((v) => !v)}>
+        {showProfile ? 'Hide' : 'Show'} profile widget
+      </button>
+      <button type="button" onClick={() => sdk.logout()}>
+        Logout
+      </button>
+
+      {/* A widget - another web component behind the same props mapping */}
+      {showProfile && (
+        <UserProfile
+          widgetId="user-profile-widget"
+          theme={process.env.DESCOPE_THEME as any}
+          logger={console}
+        />
+      )}
+    </div>
+  );
+};
+
+const App = () => {
+  const { isAuthenticated, isSessionLoading } = useSession();
+
+  if (isSessionLoading) return <div style={card}>Loading...</div>;
+
+  return isAuthenticated ? <Home /> : <Login />;
+};
+
+export default App;

--- a/packages/sdks/react-sdk/examples/preact-app/index.html
+++ b/packages/sdks/react-sdk/examples/preact-app/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Descope Preact demo app</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./index.tsx"></script>
+  </body>
+</html>

--- a/packages/sdks/react-sdk/examples/preact-app/index.tsx
+++ b/packages/sdks/react-sdk/examples/preact-app/index.tsx
@@ -1,0 +1,25 @@
+/**
+ * Entry point of the Preact demo app.
+ *
+ * Note that this file renders with Preact's own `render` - the SDK below is
+ * the unmodified React SDK, resolved to `preact/compat` by the alias in
+ * `rollup.config.preact-app.mjs` (the equivalent of `@preact/preset-vite` or a
+ * webpack `resolve.alias`).
+ */
+import { render } from 'preact';
+import React from 'react';
+import { AuthProvider } from '../../src';
+import App from './App';
+
+render(
+  <AuthProvider
+    projectId={process.env.DESCOPE_PROJECT_ID!}
+    baseUrl={process.env.DESCOPE_BASE_URL}
+    baseStaticUrl={process.env.DESCOPE_BASE_STATIC_URL}
+    baseCdnUrl={process.env.DESCOPE_BASE_CDN_URL}
+    refreshCookieName={process.env.DESCOPE_REFRESH_COOKIE_NAME}
+  >
+    <App />
+  </AuthProvider>,
+  document.getElementById('root')!,
+);

--- a/packages/sdks/react-sdk/jest.preact.config.js
+++ b/packages/sdks/react-sdk/jest.preact.config.js
@@ -1,0 +1,43 @@
+/**
+ * Runs the exact same test suite as `jest.config.js`, but with `react` and
+ * `react-dom` aliased to `preact/compat` - the same aliasing a Preact app does
+ * in its bundler (`@preact/preset-vite`, webpack `resolve.alias`, etc.).
+ *
+ * The point is that this config shares the test files with the React run:
+ * any behaviour the React suite asserts is asserted against Preact too, so a
+ * compat regression fails CI instead of reaching a consumer.
+ */
+import base from './jest.config.js';
+
+export default {
+  ...base,
+
+  displayName: 'preact',
+
+  // `test/` is the shared suite, `test-preact/` holds the compat-only checks.
+  roots: ['src', 'test', 'test-preact'],
+
+  // The React run already reports coverage; this run is about behaviour parity.
+  collectCoverage: false,
+  coverageDirectory: undefined,
+
+  // jest-environment-jsdom defaults `customExportConditions` to `['browser']`,
+  // and preact's `browser` condition points at its ESM build - which the CJS
+  // test runtime can't parse. Emptying it falls back to `require`.
+  testEnvironmentOptions: {
+    ...base.testEnvironmentOptions,
+    customExportConditions: [],
+  },
+
+  // Order matters - the first matching pattern wins, so the more specific
+  // subpath entries have to come before the bare `react`/`react-dom` ones.
+  moduleNameMapper: {
+    '^react/jsx-runtime$': 'preact/compat/jsx-runtime',
+    '^react/jsx-dev-runtime$': 'preact/compat/jsx-dev-runtime',
+    '^react-dom/client$': 'preact/compat/client',
+    '^react-dom/server$': 'preact/compat/server',
+    '^react-dom/test-utils$': 'preact/compat/test-utils',
+    '^react-dom$': 'preact/compat',
+    '^react$': 'preact/compat',
+  },
+};

--- a/packages/sdks/react-sdk/package.json
+++ b/packages/sdks/react-sdk/package.json
@@ -52,7 +52,10 @@
     "lint": "eslint '+(src|examples)/**/*.+(ts|tsx)' --fix",
     "prepublishOnly": "npm run build",
     "start": "npx nx run react-sdk:build && rollup -c rollup.config.app.mjs -w",
-    "test": "jest"
+    "start:preact": "npx nx run react-sdk:build && rollup -c rollup.config.preact-app.mjs -w",
+    "build:preact-app": "rollup -c rollup.config.preact-app.mjs",
+    "test": "jest && npm run test:preact",
+    "test:preact": "jest -c jest.preact.config.js"
   },
   "lint-staged": {
     "+(src|examples)/**/*.{js,ts,jsx,tsx}": [
@@ -60,18 +63,18 @@
     ]
   },
   "dependencies": {
-    "@descope/sdk-helpers": "workspace:*",
     "@descope/access-key-management-widget": "workspace:*",
+    "@descope/applications-portal-widget": "workspace:*",
     "@descope/audit-management-widget": "workspace:*",
+    "@descope/core-js-sdk": "workspace:*",
+    "@descope/outbound-applications-widget": "workspace:*",
     "@descope/role-management-widget": "workspace:*",
+    "@descope/sdk-helpers": "workspace:*",
+    "@descope/tenant-profile-widget": "workspace:*",
     "@descope/user-management-widget": "workspace:*",
     "@descope/user-profile-widget": "workspace:*",
-    "@descope/applications-portal-widget": "workspace:*",
-    "@descope/outbound-applications-widget": "workspace:*",
     "@descope/web-component": "workspace:*",
-    "@descope/web-js-sdk": "workspace:*",
-    "@descope/core-js-sdk": "workspace:*",
-    "@descope/tenant-profile-widget": "workspace:*"
+    "@descope/web-js-sdk": "workspace:*"
   },
   "devDependencies": {
     "@babel/core": "7.26.0",
@@ -79,6 +82,8 @@
     "@babel/preset-react": "7.26.3",
     "@babel/preset-typescript": "7.26.0",
     "@open-wc/rollup-plugin-html": "^1.2.5",
+    "@remix-run/router": "1.21.0",
+    "@rollup/plugin-alias": "5.1.1",
     "@rollup/plugin-commonjs": "^28.0.0",
     "@rollup/plugin-node-resolve": "^15.0.0",
     "@rollup/plugin-replace": "^5.0.0",
@@ -88,11 +93,12 @@
     "@testing-library/react-hooks": "8.0.1",
     "@testing-library/user-event": "14.5.2",
     "@types/jest": "^29.0.0",
-    "@types/react": "18.3.18",
     "@types/node": "^20.0.0",
+    "@types/react": "18.3.18",
     "@types/react-dom": "18.3.5",
     "@types/react-router-dom": "^5.3.3",
     "babel-jest": "29.7.0",
+    "core-js": "3.40.0",
     "eslint": "8.57.1",
     "eslint-config-airbnb": "19.0.4",
     "eslint-config-airbnb-typescript": "17.1.0",
@@ -113,13 +119,17 @@
     "eslint-plugin-react-hooks": "4.6.2",
     "eslint-plugin-testing-library": "6.2.2",
     "jest": "^29.0.0",
+    "jest-environment-jsdom": "^29.0.0",
     "jest-extended": "^4.0.0",
     "lint-staged": "^13.0.3",
+    "object-assign": "^4.1.1",
     "oidc-client-ts": "3.2.0",
+    "preact": "^10.29.8",
+    "preact-render-to-string": "^6.7.0",
     "pretty-quick": "^3.1.3",
     "react": "18.3.1",
-    "react-router": "6.28.1",
     "react-dom": "18.3.1",
+    "react-router": "6.28.1",
     "react-router-dom": "6.28.1",
     "rollup": "^4.0.0",
     "rollup-plugin-auto-external": "^2.0.0",
@@ -129,20 +139,22 @@
     "rollup-plugin-dotenv": "^0.5.0",
     "rollup-plugin-dts": "^6.1.1",
     "rollup-plugin-livereload": "^2.0.5",
+    "rollup-plugin-no-emit": "1.2.1",
     "rollup-plugin-serve": "^3.0.0",
     "rollup-plugin-terser": "^7.0.2",
+    "scheduler": "^0.25.0",
     "ts-jest": "^29.0.0",
     "ts-node": "10.9.1",
-    "typescript": "^5.0.2",
-    "object-assign": "^4.1.1",
-    "scheduler": "^0.25.0",
-    "@remix-run/router": "1.21.0",
-    "jest-environment-jsdom": "^29.0.0",
-    "core-js": "3.40.0",
-    "rollup-plugin-no-emit": "1.2.1"
+    "typescript": "^5.0.2"
   },
   "peerDependencies": {
     "@types/react": ">=16",
+    "preact": ">=10.11.0",
     "react": ">=16"
+  },
+  "peerDependenciesMeta": {
+    "preact": {
+      "optional": true
+    }
   }
 }

--- a/packages/sdks/react-sdk/rollup.config.preact-app.mjs
+++ b/packages/sdks/react-sdk/rollup.config.preact-app.mjs
@@ -76,8 +76,12 @@ export default {
     html(),
     // Only serve in watch mode (`npm run start:preact`); a plain build is what
     // CI runs to prove the app compiles against `preact/compat`.
+    //
+    // An explicit port keeps this off 3000, which `npm start` (the React
+    // example) already takes by browsersync default - so the two can run side
+    // by side, which is the whole point of having both.
     ...(process.env.ROLLUP_WATCH
-      ? [browsersync({ server: 'build-preact', single: true })]
+      ? [browsersync({ server: 'build-preact', single: true, port: 3001 })]
       : []),
   ],
 };

--- a/packages/sdks/react-sdk/rollup.config.preact-app.mjs
+++ b/packages/sdks/react-sdk/rollup.config.preact-app.mjs
@@ -1,0 +1,83 @@
+/**
+ * Builds `examples/preact-app` - the React SDK running inside a Preact app.
+ *
+ * It is the same pipeline as `rollup.config.app.mjs` plus the `react` ->
+ * `preact/compat` alias, which is the only thing a Preact consumer has to do
+ * (`@preact/preset-vite` and webpack's `resolve.alias` set up the same map).
+ */
+import html from '@open-wc/rollup-plugin-html';
+import alias from '@rollup/plugin-alias';
+import commonjs from '@rollup/plugin-commonjs';
+import nodeResolve from '@rollup/plugin-node-resolve';
+import replace from '@rollup/plugin-replace';
+import typescript from '@rollup/plugin-typescript';
+import browsersync from 'rollup-plugin-browsersync';
+import del from 'rollup-plugin-delete';
+import dotenv from 'rollup-plugin-dotenv';
+
+import packageJson from './package.json' with { type: 'json' };
+
+const envKeys = [
+  'DESCOPE_PROJECT_ID',
+  'DESCOPE_BASE_URL',
+  'DESCOPE_BASE_STATIC_URL',
+  'DESCOPE_BASE_CDN_URL',
+  'DESCOPE_FLOW_ID',
+  'DESCOPE_THEME',
+  'DESCOPE_STYLE_ID',
+  'DESCOPE_LOCALE',
+  'DESCOPE_REDIRECT_URL',
+  'DESCOPE_DEBUG_MODE',
+  'DESCOPE_TENANT_ID',
+  'DESCOPE_REFRESH_COOKIE_NAME',
+];
+
+const preactCompat = {
+  react: 'preact/compat',
+  'react-dom': 'preact/compat',
+  'react-dom/client': 'preact/compat/client',
+  'react-dom/test-utils': 'preact/compat/test-utils',
+  'react/jsx-runtime': 'preact/compat/jsx-runtime',
+};
+
+export default {
+  preserveSymlinks: true,
+  preserveEntrySignatures: false,
+  input: 'examples/preact-app/index.html',
+  output: { dir: 'build-preact', format: 'esm' },
+  plugins: [
+    del({ targets: 'build-preact' }),
+    alias({
+      entries: Object.entries(preactCompat).map(([find, replacement]) => ({
+        find: new RegExp(`^${find}$`),
+        replacement,
+      })),
+    }),
+    typescript({
+      declaration: false,
+      declarationDir: null,
+      outDir: undefined,
+    }),
+    commonjs(),
+    nodeResolve({ browser: true }),
+    dotenv(), // should happen before replace plugin
+    replace({
+      BUILD_VERSION: JSON.stringify(packageJson.version),
+      preventAssignment: true,
+      'process.env.NODE_ENV': JSON.stringify('development'),
+      ...envKeys.reduce((acc, key) => {
+        Object.assign(acc, {
+          [`process.env.${key}`]: JSON.stringify(process.env[key] || ''),
+        });
+        return acc;
+      }, {}),
+      delimiters: ['', ''],
+    }),
+    html(),
+    // Only serve in watch mode (`npm run start:preact`); a plain build is what
+    // CI runs to prove the app compiles against `preact/compat`.
+    ...(process.env.ROLLUP_WATCH
+      ? [browsersync({ server: 'build-preact', single: true })]
+      : []),
+  ],
+};

--- a/packages/sdks/react-sdk/src/components/Descope.tsx
+++ b/packages/sdks/react-sdk/src/components/Descope.tsx
@@ -25,7 +25,10 @@ const DescopeWC = lazy(async () => {
   };
 
   const WebComponent: any =
-    customElements?.get('descope-wc') ||
+    // `customElements` is undeclared (not just undefined) on the server, so it
+    // has to be reached through `globalThis` - `customElements?.` alone throws
+    // a ReferenceError and defeats the lazy loading above.
+    globalThis.customElements?.get('descope-wc') ||
     (await import('@descope/web-component').then((module) => module.default));
 
   WebComponent.sdkConfigOverrides = {

--- a/packages/sdks/react-sdk/test-preact/compat.test.tsx
+++ b/packages/sdks/react-sdk/test-preact/compat.test.tsx
@@ -1,0 +1,261 @@
+/**
+ * Preact-only assertions. The shared `test/` suite already runs against
+ * `preact/compat` (see `jest.preact.config.js`); this file covers the parts
+ * that are meaningless under React - that the alias is actually in effect, and
+ * that the custom-element bridge behaves identically once it is.
+ */
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import React from 'react';
+import {
+  AccessKeyManagement,
+  ApplicationsPortal,
+  AuditManagement,
+  AuthProvider,
+  Descope,
+  OutboundApplications,
+  RoleManagement,
+  SignInFlow,
+  SignUpFlow,
+  SignUpOrInFlow,
+  TenantProfile,
+  UserManagement,
+  UserProfile,
+  useDescope,
+  useSession,
+  useUser,
+} from '../src';
+
+Object.defineProperty(global, 'Response', {
+  value: class {},
+  configurable: true,
+  writable: true,
+});
+
+jest.mock('@descope/web-component', () => ({ default: {} }));
+jest.mock('@descope/user-management-widget', () => ({ default: {} }));
+jest.mock('@descope/user-profile-widget', () => ({ default: {} }));
+jest.mock('@descope/role-management-widget', () => ({ default: {} }));
+jest.mock('@descope/access-key-management-widget', () => ({ default: {} }));
+jest.mock('@descope/audit-management-widget', () => ({ default: {} }));
+jest.mock('@descope/applications-portal-widget', () => ({ default: {} }));
+jest.mock('@descope/outbound-applications-widget', () => ({ default: {} }));
+jest.mock('@descope/tenant-profile-widget', () => ({ default: {} }));
+
+const afterRequest = jest.fn();
+jest.mock('@descope/web-js-sdk', () => {
+  const sdk = {
+    logout: jest.fn(),
+    onSessionTokenChange: jest.fn(() => () => {}),
+    onIsAuthenticatedChange: jest.fn(() => () => {}),
+    onUserChange: jest.fn(() => () => {}),
+    onClaimsChange: jest.fn(() => () => {}),
+    refresh: jest.fn(() => Promise.resolve()),
+    me: jest.fn(() => Promise.resolve()),
+    httpClient: {
+      hooks: {
+        // eslint-disable-next-line global-require
+        afterRequest: (...args: any[]) =>
+          // eslint-disable-next-line no-use-before-define
+          (global as any).__afterRequest(...args),
+        beforeRequest: jest.fn(),
+      },
+    },
+  };
+  return { createSdk: () => sdk };
+});
+(global as any).__afterRequest = afterRequest;
+
+const withProvider = (ui: React.ReactNode) => (
+  <AuthProvider projectId="p1">{ui}</AuthProvider>
+);
+
+// Waits for the web component to mount *and* for the SDK's `useEffect`s to
+// have run - under Preact effects are scheduled after paint, so the element
+// being in the DOM does not imply its listeners are attached yet.
+const findWc = async (container: HTMLElement, tag = 'descope-wc') => {
+  await waitFor(() => expect(container.querySelector(tag)).toBeTruthy());
+  await new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+  return container.querySelector(tag) as HTMLElement;
+};
+
+describe('preact/compat aliasing', () => {
+  it('resolves `react` to preact/compat, not React', () => {
+    // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
+    expect(require('react')).toBe(require('preact/compat'));
+    // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
+    expect(require('react-dom')).toBe(require('preact/compat'));
+    // Preact reports its own version, React would report `18.x` here.
+    // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
+    expect(require('preact').options).toBeDefined();
+  });
+});
+
+describe('custom element bridge under preact/compat', () => {
+  it('maps `.attr` props to kebab-case attributes', async () => {
+    const { container } = render(
+      withProvider(<Descope flowId="f" theme="dark" locale="en" debug />),
+    );
+    const wc = await findWc(container);
+
+    expect(wc.getAttribute('theme')).toBe('dark');
+    expect(wc.getAttribute('locale')).toBe('en');
+    expect(wc.getAttribute('debug')).toBe('true');
+  });
+
+  it('serialises non-string `.attr` values instead of "[object Object]"', async () => {
+    const { container } = render(
+      withProvider(<Descope flowId="f" client={{ version: '1.2.3' }} />),
+    );
+    const wc = await findWc(container);
+
+    expect(JSON.parse(wc.getAttribute('client'))).toEqual({
+      version: '1.2.3',
+    });
+  });
+
+  it('sets `.prop` props as element properties, not attributes', async () => {
+    const errorTransformer = jest.fn();
+    const { container } = render(
+      withProvider(<Descope flowId="f" errorTransformer={errorTransformer} />),
+    );
+    const wc = await findWc(container);
+
+    expect((wc as any).errorTransformer).toBe(errorTransformer);
+    expect(wc.hasAttribute('errorTransformer')).toBe(false);
+    expect(wc.hasAttribute('error-transformer')).toBe(false);
+  });
+
+  it('removes an attribute when its value becomes nullish', async () => {
+    const { container, rerender } = render(
+      withProvider(<Descope flowId="f" theme="dark" />),
+    );
+    const wc = await findWc(container);
+    expect(wc.getAttribute('theme')).toBe('dark');
+
+    rerender(withProvider(<Descope flowId="f" theme={undefined} />));
+    await waitFor(() =>
+      expect(container.querySelector('descope-wc').hasAttribute('theme')).toBe(
+        false,
+      ),
+    );
+  });
+
+  it('exposes the web component through the forwarded ref', async () => {
+    const ref = React.createRef<HTMLElement>();
+    const { container } = render(
+      withProvider(<Descope ref={ref} flowId="f" />),
+    );
+    await findWc(container);
+
+    await waitFor(() => expect(ref.current).toBeTruthy());
+    expect(ref.current.tagName).toBe('DESCOPE-WC');
+  });
+});
+
+describe('custom events under preact/compat', () => {
+  it('forwards `error` and `ready` to their callbacks', async () => {
+    const onError = jest.fn();
+    const onReady = jest.fn();
+    const { container } = render(
+      withProvider(<Descope flowId="f" onError={onError} onReady={onReady} />),
+    );
+    const wc = await findWc(container);
+
+    fireEvent(wc, new CustomEvent('error', { detail: { a: 1 } }));
+    fireEvent(wc, new CustomEvent('ready', {}));
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onReady).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs the SDK afterRequest hook before calling `onSuccess`', async () => {
+    const onSuccess = jest.fn();
+    const { container } = render(
+      withProvider(<Descope flowId="f" onSuccess={onSuccess} />),
+    );
+    const wc = await findWc(container);
+
+    fireEvent(wc, new CustomEvent('success', { detail: { sessionJwt: 'x' } }));
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1));
+    expect(afterRequest).toHaveBeenCalled();
+  });
+
+  it('detaches listeners on unmount', async () => {
+    const onError = jest.fn();
+    const { container, unmount } = render(
+      withProvider(<Descope flowId="f" onError={onError} />),
+    );
+    const wc = await findWc(container);
+    unmount();
+
+    fireEvent(wc, new CustomEvent('error', {}));
+    expect(onError).not.toHaveBeenCalled();
+  });
+});
+
+describe('hooks under preact/compat', () => {
+  it('throws outside of <AuthProvider />', () => {
+    const Boom = () => {
+      useSession();
+      return null;
+    };
+    // Preact surfaces the throw through its own error boundary path; assert
+    // the component cannot render rather than matching on React's message.
+    expect(() => render(<Boom />)).toThrow(
+      /You can only use this hook in the context of <AuthProvider \/>/,
+    );
+  });
+
+  it('provides session, user and sdk from context', async () => {
+    const seen: Record<string, any> = {};
+    const Probe = () => {
+      const session = useSession();
+      const user = useUser();
+      seen.sdk = useDescope();
+      seen.isAuthenticated = session.isAuthenticated;
+      seen.user = user.user;
+      return null;
+    };
+
+    render(withProvider(<Probe />));
+
+    await waitFor(() => expect(seen.sdk).toBeTruthy());
+    expect(typeof seen.sdk.logout).toBe('function');
+    expect(seen.isAuthenticated).toBe(false);
+  });
+});
+
+describe('widgets under preact/compat', () => {
+  it.each([
+    ['descope-user-management-widget', UserManagement],
+    ['descope-role-management-widget', RoleManagement],
+    ['descope-access-key-management-widget', AccessKeyManagement],
+    ['descope-audit-management-widget', AuditManagement],
+    ['descope-user-profile-widget', UserProfile],
+    ['descope-applications-portal-widget', ApplicationsPortal],
+    ['descope-tenant-profile-widget', TenantProfile],
+    ['descope-outbound-applications-widget', OutboundApplications],
+  ])('renders <%s>', async (tag, Widget: any) => {
+    const { container } = render(
+      withProvider(<Widget tenant="t1" widgetId="w1" />),
+    );
+    const el = await findWc(container, tag);
+
+    expect(el).toBeTruthy();
+    expect(el.getAttribute('widget-id')).toBe('w1');
+  });
+
+  it.each([
+    ['sign-in', SignInFlow],
+    ['sign-up', SignUpFlow],
+    ['sign-up-or-in', SignUpOrInFlow],
+  ])('renders the %s default flow', async (flowId, Flow: any) => {
+    const { container } = render(withProvider(<Flow />));
+    const wc = await findWc(container);
+
+    expect(wc.getAttribute('flow-id')).toBe(flowId);
+  });
+});

--- a/packages/sdks/react-sdk/test-preact/compat.test.tsx
+++ b/packages/sdks/react-sdk/test-preact/compat.test.tsx
@@ -24,6 +24,7 @@ import {
   useSession,
   useUser,
 } from '../src';
+import { findWcWithListener } from '../testUtils/wcListeners';
 
 Object.defineProperty(global, 'Response', {
   value: class {},
@@ -69,16 +70,19 @@ const withProvider = (ui: React.ReactNode) => (
   <AuthProvider projectId="p1">{ui}</AuthProvider>
 );
 
-// Waits for the web component to mount *and* for the SDK's `useEffect`s to
-// have run - under Preact effects are scheduled after paint, so the element
-// being in the DOM does not imply its listeners are attached yet.
+// Attributes and properties are applied from the ref callback, which runs
+// before effects, so mounting is all these need to wait for.
 const findWc = async (container: HTMLElement, tag = 'descope-wc') => {
   await waitFor(() => expect(container.querySelector(tag)).toBeTruthy());
-  await new Promise((resolve) => {
-    setTimeout(resolve, 0);
-  });
   return container.querySelector(tag) as HTMLElement;
 };
+
+// Event tests need more: `<Descope />` attaches its listeners from a
+// `useEffect`, which Preact runs after paint, and an event dispatched before
+// then is lost rather than deferred. `success` is the one listener it always
+// registers, so its attachment marks the whole effect as having run.
+const findFlowWc = (container: HTMLElement) =>
+  findWcWithListener(container, 'descope-wc', 'success');
 
 describe('preact/compat aliasing', () => {
   it('resolves `react` to preact/compat, not React', () => {
@@ -161,7 +165,7 @@ describe('custom events under preact/compat', () => {
     const { container } = render(
       withProvider(<Descope flowId="f" onError={onError} onReady={onReady} />),
     );
-    const wc = await findWc(container);
+    const wc = await findFlowWc(container);
 
     fireEvent(wc, new CustomEvent('error', { detail: { a: 1 } }));
     fireEvent(wc, new CustomEvent('ready', {}));
@@ -175,7 +179,7 @@ describe('custom events under preact/compat', () => {
     const { container } = render(
       withProvider(<Descope flowId="f" onSuccess={onSuccess} />),
     );
-    const wc = await findWc(container);
+    const wc = await findFlowWc(container);
 
     fireEvent(wc, new CustomEvent('success', { detail: { sessionJwt: 'x' } }));
 
@@ -188,7 +192,7 @@ describe('custom events under preact/compat', () => {
     const { container, unmount } = render(
       withProvider(<Descope flowId="f" onError={onError} />),
     );
-    const wc = await findWc(container);
+    const wc = await findFlowWc(container);
     unmount();
 
     fireEvent(wc, new CustomEvent('error', {}));

--- a/packages/sdks/react-sdk/test-preact/ssr-sync.test.tsx
+++ b/packages/sdks/react-sdk/test-preact/ssr-sync.test.tsx
@@ -1,0 +1,38 @@
+/**
+ * @jest-environment node
+ *
+ * Kept in its own file so the module registry - and therefore `lazy()` - is
+ * still unresolved, which is the state every server process starts in.
+ *
+ * Unlike React's `renderToString`, preact-render-to-string's *sync* renderer
+ * refuses to render a suspended subtree rather than emitting the fallback.
+ * Pinned here so the README's "use renderToStringAsync" note stays honest.
+ */
+import React from 'react';
+import { renderToString } from 'preact-render-to-string';
+import { AuthProvider, Descope } from '../src';
+
+jest.mock('@descope/web-component', () => ({ default: {} }));
+jest.mock('@descope/web-js-sdk', () => ({
+  createSdk: () => ({
+    onSessionTokenChange: jest.fn(() => () => {}),
+    onIsAuthenticatedChange: jest.fn(() => () => {}),
+    onUserChange: jest.fn(() => () => {}),
+    onClaimsChange: jest.fn(() => () => {}),
+    refresh: jest.fn(() => Promise.resolve()),
+    me: jest.fn(() => Promise.resolve()),
+    httpClient: {
+      hooks: { afterRequest: jest.fn(), beforeRequest: jest.fn() },
+    },
+  }),
+}));
+
+it('rejects the sync renderer on a not-yet-resolved lazy subtree', () => {
+  expect(() =>
+    renderToString(
+      <AuthProvider projectId="p1">
+        <Descope flowId="sign-up-or-in" />
+      </AuthProvider>,
+    ),
+  ).toThrow(/renderToStringAsync/);
+});

--- a/packages/sdks/react-sdk/test-preact/ssr.test.tsx
+++ b/packages/sdks/react-sdk/test-preact/ssr.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment node
+ *
+ * `<Descope />` and the widgets lazy-load their web component because that
+ * code touches browser APIs. This asserts a Preact SSR app can render the SDK
+ * without a DOM. See `ssr-sync.test.tsx` for why the async renderer is the one
+ * a Preact server has to use.
+ */
+import React from 'react';
+import { renderToString, renderToStringAsync } from 'preact-render-to-string';
+import { AuthProvider, Descope, UserProfile } from '../src';
+
+jest.mock('@descope/web-component', () => ({ default: {} }));
+jest.mock('@descope/user-profile-widget', () => ({ default: {} }));
+
+jest.mock('@descope/web-js-sdk', () => ({
+  createSdk: () => ({
+    onSessionTokenChange: jest.fn(() => () => {}),
+    onIsAuthenticatedChange: jest.fn(() => () => {}),
+    onUserChange: jest.fn(() => () => {}),
+    onClaimsChange: jest.fn(() => () => {}),
+    refresh: jest.fn(() => Promise.resolve()),
+    me: jest.fn(() => Promise.resolve()),
+    httpClient: {
+      hooks: { afterRequest: jest.fn(), beforeRequest: jest.fn() },
+    },
+  }),
+}));
+
+describe('server-side rendering with preact-render-to-string', () => {
+  it('renders <AuthProvider /> children without a DOM', () => {
+    expect(typeof document).toBe('undefined');
+
+    const html = renderToString(
+      <AuthProvider projectId="p1">
+        <p>hello</p>
+      </AuthProvider>,
+    );
+
+    expect(html).toBe('<p>hello</p>');
+  });
+
+  it('resolves the lazy flow with renderToStringAsync', async () => {
+    const html = await renderToStringAsync(
+      <AuthProvider projectId="p1">
+        <Descope flowId="sign-up-or-in" />
+      </AuthProvider>,
+    );
+
+    expect(html).toContain('<descope-wc');
+    expect(html).toContain('flow-id="sign-up-or-in"');
+  });
+
+  it('resolves a lazy widget with renderToStringAsync', async () => {
+    const html = await renderToStringAsync(
+      <AuthProvider projectId="p1">
+        <UserProfile widgetId="w1" />
+      </AuthProvider>,
+    );
+
+    expect(html).toContain('<descope-user-profile-widget');
+    expect(html).toContain('widget-id="w1"');
+  });
+});

--- a/packages/sdks/react-sdk/test/components/App.test.tsx
+++ b/packages/sdks/react-sdk/test/components/App.test.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import App from '../../examples/app/App';
 import { AuthProvider, useSession, useUser } from '../../src';
+import { waitForListener } from '../../testUtils/wcListeners';
 
 Object.defineProperty(global, 'Response', {
   value: class {},
@@ -99,20 +100,20 @@ describe('App', () => {
       expect(container.querySelector('descope-wc')).toBeInTheDocument(),
     );
 
-    // `<Descope />` attaches its `error` listener from a `useEffect`, which
-    // runs after paint. React flushes it before `waitFor` above resolves, but
-    // Preact schedules it on the next frame - so dispatch until it sticks
-    // instead of assuming the listener is already there.
-    await waitFor(() => {
-      fireEvent(
-        // eslint-disable-next-line testing-library/no-container
-        container.querySelector('descope-wc'),
-        new CustomEvent('error', {}),
-      );
+    // eslint-disable-next-line testing-library/no-container
+    const wc = container.querySelector('descope-wc');
+    // `<Descope />` attaches its `error` listener from a `useEffect`. React has
+    // flushed that by now, Preact has not - and an event dispatched before the
+    // listener exists is lost, so wait for the attachment before dispatching.
+    await waitForListener(wc, 'error');
 
-      // ensure error is shown
-      expect(document.querySelector('.error')).not.toBeNull();
-    });
+    // mock error
+    fireEvent(wc, new CustomEvent('error', {}));
+
+    // ensure error is shown
+    await waitFor(() =>
+      expect(document.querySelector('.error')).not.toBeNull(),
+    );
   });
 
   it('should render logout button and and call sdk logout', async () => {

--- a/packages/sdks/react-sdk/test/components/App.test.tsx
+++ b/packages/sdks/react-sdk/test/components/App.test.tsx
@@ -99,16 +99,20 @@ describe('App', () => {
       expect(container.querySelector('descope-wc')).toBeInTheDocument(),
     );
 
-    // mock error
-    fireEvent(
-      // eslint-disable-next-line testing-library/no-container
-      container.querySelector('descope-wc'),
-      new CustomEvent('error', {}),
-    );
+    // `<Descope />` attaches its `error` listener from a `useEffect`, which
+    // runs after paint. React flushes it before `waitFor` above resolves, but
+    // Preact schedules it on the next frame - so dispatch until it sticks
+    // instead of assuming the listener is already there.
+    await waitFor(() => {
+      fireEvent(
+        // eslint-disable-next-line testing-library/no-container
+        container.querySelector('descope-wc'),
+        new CustomEvent('error', {}),
+      );
 
-    // ensure error is shown
-    const error = document.querySelector('.error');
-    expect(error).not.toBeNull();
+      // ensure error is shown
+      expect(document.querySelector('.error')).not.toBeNull();
+    });
   });
 
   it('should render logout button and and call sdk logout', async () => {

--- a/packages/sdks/react-sdk/testUtils/wcListeners.ts
+++ b/packages/sdks/react-sdk/testUtils/wcListeners.ts
@@ -1,0 +1,50 @@
+/**
+ * The SDK's components attach their web-component event listeners from a
+ * `useEffect`. React flushes that before a `waitFor` on the element resolves;
+ * Preact schedules it after paint, so the element being in the DOM does not
+ * mean the listener is there yet - and an event dispatched before it is
+ * attached is lost, not deferred.
+ *
+ * Importing this module records every `addEventListener` call so a test can
+ * wait for the attachment itself. That is a real condition to poll on, rather
+ * than a fixed delay racing the effect queue.
+ */
+import { waitFor } from '@testing-library/react';
+
+const attached = new WeakMap<EventTarget, Set<string>>();
+
+const originalAddEventListener = EventTarget.prototype.addEventListener;
+
+EventTarget.prototype.addEventListener = function recordAddEventListener(
+  this: EventTarget,
+  type: string,
+  ...rest: any[]
+) {
+  let types = attached.get(this);
+  if (!types) {
+    types = new Set();
+    attached.set(this, types);
+  }
+  types.add(type);
+  return (originalAddEventListener as any).call(this, type, ...rest);
+};
+
+/** Resolves once `target` has had a listener attached for `type`. */
+export const waitForListener = (target: EventTarget, type: string) =>
+  waitFor(() => expect(attached.get(target)?.has(type)).toBe(true));
+
+/**
+ * Waits for `tag` to mount inside `container` and for the SDK to have attached
+ * its listener for `type` (default `error`, which every flow and widget with a
+ * callback registers). Returns the element, ready to dispatch at.
+ */
+export const findWcWithListener = async (
+  container: HTMLElement,
+  tag = 'descope-wc',
+  type = 'error',
+) => {
+  await waitFor(() => expect(container.querySelector(tag)).toBeTruthy());
+  const el = container.querySelector(tag) as HTMLElement;
+  await waitForListener(el, type);
+  return el;
+};

--- a/packages/sdks/react-sdk/tsconfig.json
+++ b/packages/sdks/react-sdk/tsconfig.json
@@ -16,5 +16,12 @@
     "noErrorTruncation": true
   },
   "include": ["**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules", "build", "dist", "test"]
+  "exclude": [
+    "node_modules",
+    "build",
+    "build-preact",
+    "dist",
+    "test",
+    "test-preact"
+  ]
 }

--- a/packages/sdks/react-sdk/tsconfig.json
+++ b/packages/sdks/react-sdk/tsconfig.json
@@ -22,6 +22,7 @@
     "build-preact",
     "dist",
     "test",
-    "test-preact"
+    "test-preact",
+    "testUtils"
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1301,6 +1301,9 @@ importers:
       '@remix-run/router':
         specifier: 1.21.0
         version: 1.21.0
+      '@rollup/plugin-alias':
+        specifier: 5.1.1
+        version: 5.1.1(rollup@4.22.4)
       '@rollup/plugin-commonjs':
         specifier: ^28.0.0
         version: 28.0.2(rollup@4.22.4)
@@ -1421,6 +1424,12 @@ importers:
       oidc-client-ts:
         specifier: 3.2.0
         version: 3.2.0
+      preact:
+        specifier: ^10.29.8
+        version: 10.29.8(preact-render-to-string@6.7.0)
+      preact-render-to-string:
+        specifier: ^6.7.0
+        version: 6.7.0(preact@10.29.8)
       pretty-quick:
         specifier: ^3.1.3
         version: 3.3.1(prettier@3.5.3)
@@ -14036,6 +14045,19 @@ packages:
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  preact-render-to-string@6.7.0:
+    resolution: {integrity: sha512-Z4WR8fmLMRpdYqJ9i7vrlXSsSrxVJydwrkEXHapexfARbWfGb7vGcnvNQnIzN0cXciMVOlz/XLoiMCi9gUsy9Q==}
+    peerDependencies:
+      preact: '>=10 || >= 11.0.0-0'
+
+  preact@10.29.8:
+    resolution: {integrity: sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==}
+    peerDependencies:
+      preact-render-to-string: '>=5'
+    peerDependenciesMeta:
+      preact-render-to-string:
+        optional: true
 
   prelude-ls@1.1.2:
     resolution: {integrity: sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==}
@@ -31278,6 +31300,14 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  preact-render-to-string@6.7.0(preact@10.29.8):
+    dependencies:
+      preact: 10.29.8(preact-render-to-string@6.7.0)
+
+  preact@10.29.8(preact-render-to-string@6.7.0):
+    optionalDependencies:
+      preact-render-to-string: 6.7.0(preact@10.29.8)
 
   prelude-ls@1.1.2: {}
 


### PR DESCRIPTION
## Related Issues

Fixes: https://github.com/descope/etc/issues/18251

## In a Nutshell

- Run the **existing** react-sdk test suite a second time under `preact/compat`
- Add `test-preact/` for the compat-only checks (alias, custom-element bridge, SSR)
- Add a Preact example app + rollup config + `npm run start:preact`
- Document Preact setup and the two behavioural differences in the README
- Declare `preact` as an optional peer dependency
- Fix a real SSR crash: `customElements?.get(...)` throws on the server

## Description

`@descope/react-sdk` already worked in Preact by accident — it only uses APIs that `preact/compat` implements. This makes that official: CI now runs the SDK's tests twice, once on React and once with `react` pointed at `preact/compat`, so the same tests guard both. It also fixes a bug where the SDK crashed when rendered on a server.

## What this does

**Runs the existing test suite twice.** `jest.preact.config.js` reuses `jest.config.js` with `react`/`react-dom` mapped to `preact/compat` — the same aliasing `@preact/preset-vite` or a webpack `resolve.alias` does. The React and Preact runs share the same test files, so anything the React suite asserts is asserted under Preact too. Chained into `npm test`, so CI covers both with no pipeline change.

```
React:  10 suites, 79 tests
Preact: 13 suites, 105 tests
```

**Adds `test-preact/` for the compat-only checks** — things that are meaningless under React:
- the alias is actually in effect (`require('react') === require('preact/compat')`)
- the custom-element bridge in `withPropsMapping`: `.attr` props become kebab-case attributes, non-string values serialise to JSON rather than `[object Object]`, `.prop` props become element properties, nullish values remove the attribute
- `success` / `error` / `ready` events, the `afterRequest` hook ordering, listener teardown on unmount
- the forwarded ref resolves to the `descope-wc` element
- every widget and default flow renders its custom element
- SSR renders `<Descope />` and a widget with no DOM

**Adds `examples/preact-app`** — a Preact app (rendered with Preact's own `render`) using `AuthProvider`, `Descope`, `UserProfile`, `useSession`, `useUser`, `useDescope`, and an imperative ref. Built by `rollup.config.preact-app.mjs`; `npm run start:preact` serves it. The output bundle contains Preact and no React runtime.

**Documents it** in the README (`## Preact Support`) with bundler, package.json and tsconfig setup, and declares `preact` as an optional peer dependency.

## Behavioural differences found

Both are documented in the README. Neither blocks any SDK feature.

1. **Effects run after paint.** Preact schedules `useEffect` on the next frame; React flushes it before paint. `<Descope />` attaches its event listeners from an effect, so an event dispatched in the same tick as mount can be missed. Real flows emit these events long after mount, so this only surfaces in tests — `App.test.tsx` now waits for the listener to be attached before dispatching, via a new `testUtils/wcListeners.ts` helper that observes `addEventListener` rather than sleeping. Still green under React.

2. **SSR needs the async renderer.** `preact-render-to-string`'s sync `renderToString` throws on a suspended subtree instead of emitting the `<Suspense>` fallback, and `<Descope />` lazy-loads its web component. Consumers need `renderToStringAsync` (v6+). Pinned by a test so the README note stays honest.

## Bug fix

Writing the SSR tests surfaced a real bug:

```js
customElements?.get('descope-wc') || (await import('@descope/web-component'))
```

`customElements` is *undeclared* on the server, not merely undefined, so `?.` does not guard it — this throws `ReferenceError: customElements is not defined`, defeating the SSR-safety the surrounding `lazy()` was written for (see the comment above it). Under React the loader is `async`, so the throw becomes a rejected promise and stays latent; under Preact's async SSR it fails the render. Now reached through `globalThis`.

## Verification

- `npx nx test react-sdk --skip-nx-cache` — both suites green
- `npx rollup -c` — library builds
- `npx rollup -c rollup.config.preact-app.mjs` — example app builds
- `npm run lint` — clean
- `pnpm install --frozen-lockfile` — lockfile up to date

## Notes

- Lockfile diff is +30/-0: only `preact`, `preact-render-to-string` and `@rollup/plugin-alias`. A plain `pnpm add` also drags in a `@descope/web-components-ui` 3.19.0 -> 3.20.2 bump via the root `postinstall`; that was kept out of this PR deliberately.
- No change to the shipped runtime other than the `globalThis` fix — Preact support needs nothing from the SDK itself.
- Two CI failures during this PR were investigated and found unrelated (a `debug-logs` wall-clock assertion and `user-management-widget` e2e `waitForResponse` timeouts); both have standing-down comments below with proposed patches for their owners.

## Must

- [ ] Tests
- [ ] Documentation (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PeQCEtMD3vAXm1RNHN4uL7