### PR TITLE
fix(user-management-widget): dedupe re-invited user in the users table RELEASE

### DIFF
--- a/packages/widgets/user-management-widget/src/lib/widget/state/asyncActions/createUser.ts
+++ b/packages/widgets/user-management-widget/src/lib/widget/state/asyncActions/createUser.ts
@@ -20,9 +20,11 @@ const reducer = buildAsyncReducer(action)(
     onFulfilled: (state, action) => {
       // Re-inviting an existing login id returns the same user. Replace the
       // existing row instead of prepending a duplicate (matches updateUser).
-      const userIdx = state.usersList.data.findIndex(
-        (user) => user.userId === action.payload.userId,
-      );
+      const userIdx = action.payload?.userId
+        ? state.usersList.data.findIndex(
+            (user) => user.userId === action.payload.userId,
+          )
+        : -1;
       if (userIdx !== -1) {
         state.usersList.data[userIdx] = action.payload;
       } else {

--- a/packages/widgets/user-management-widget/src/lib/widget/state/asyncActions/createUser.ts
+++ b/packages/widgets/user-management-widget/src/lib/widget/state/asyncActions/createUser.ts
@@ -18,7 +18,16 @@ const action = createAsyncThunk<
 const reducer = buildAsyncReducer(action)(
   {
     onFulfilled: (state, action) => {
-      state.usersList.data.unshift(action.payload);
+      // Re-inviting an existing login id returns the same user. Replace the
+      // existing row instead of prepending a duplicate (matches updateUser).
+      const userIdx = state.usersList.data.findIndex(
+        (user) => user.userId === action.payload.userId,
+      );
+      if (userIdx !== -1) {
+        state.usersList.data[userIdx] = action.payload;
+      } else {
+        state.usersList.data.unshift(action.payload);
+      }
     },
   },
   withRequestStatus((state: State) => state.createUser),

--- a/packages/widgets/user-management-widget/test/createUserReducer.test.ts
+++ b/packages/widgets/user-management-widget/test/createUserReducer.test.ts
@@ -1,0 +1,85 @@
+import { createReducer } from '@reduxjs/toolkit';
+import { createUser } from '../src/lib/widget/state/asyncActions/createUser';
+import { initialState } from '../src/lib/widget/state/initialState';
+import { State } from '../src/lib/widget/state/types';
+import { User } from '../src/lib/widget/api/types';
+
+// Build a standalone reducer that only knows the createUser cases, so we can
+// drive it with createUser.action.fulfilled(...) against the widget's
+// initialState.
+const reducer = createReducer(initialState, (builder) =>
+  createUser.reducer(builder),
+);
+
+const makeUser = (userId: string, loginId: string): User =>
+  ({
+    userId,
+    loginIds: [loginId],
+    status: 'invited',
+  }) as User;
+
+const fulfilled = (state: State, payload: User) =>
+  reducer(state, createUser.action.fulfilled(payload, 'req-id', {} as any));
+
+describe('createUser reducer', () => {
+  it('prepends a brand-new user to the list', () => {
+    const user = makeUser('u1', 'a@test.com');
+
+    const state = fulfilled(initialState, user);
+
+    expect(state.usersList.data).toHaveLength(1);
+    expect(state.usersList.data[0]).toEqual(user);
+  });
+
+  it('does not duplicate a user re-invited with the same login id', () => {
+    const user = makeUser('u1', 'a@test.com');
+
+    let state = fulfilled(initialState, user);
+    // Re-invite: backend returns the same user (same userId).
+    const reinvited = { ...user, status: 'invited' } as User;
+    state = fulfilled(state, reinvited);
+
+    expect(state.usersList.data).toHaveLength(1);
+    expect(state.usersList.data[0]).toEqual(reinvited);
+  });
+
+  it('replaces a re-invited user in place without moving it to the top', () => {
+    const first = makeUser('u1', 'a@test.com');
+    const second = makeUser('u2', 'b@test.com');
+
+    let state = fulfilled(initialState, first);
+    state = fulfilled(state, second); // second is now at the top, first at index 1
+
+    // Re-invite the older user (not at the head).
+    const reinvitedFirst = { ...first, status: 'invited' } as User;
+    state = fulfilled(state, reinvitedFirst);
+
+    expect(state.usersList.data).toHaveLength(2);
+    expect(state.usersList.data[0]).toEqual(second);
+    expect(state.usersList.data[1]).toEqual(reinvitedFirst);
+  });
+
+  it('prepends a different user without touching the existing one', () => {
+    const first = makeUser('u1', 'a@test.com');
+    const second = makeUser('u2', 'b@test.com');
+
+    let state = fulfilled(initialState, first);
+    state = fulfilled(state, second);
+
+    expect(state.usersList.data).toHaveLength(2);
+    expect(state.usersList.data[0]).toEqual(second);
+    expect(state.usersList.data[1]).toEqual(first);
+  });
+
+  it('still fires success notification and clears loading on re-invite', () => {
+    const user = makeUser('u1', 'a@test.com');
+
+    let state = fulfilled(initialState, user);
+    state = fulfilled(state, user);
+
+    expect(state.createUser.loading).toBe(false);
+    expect(
+      state.notifications.filter((n) => n.type === 'success'),
+    ).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes a visual bug where inviting the same login ID more than once in the User Management widget added a duplicate row to the users table until a page refresh (reported by customer Backline AI).
- Root cause: `createUser`'s reducer always ran `usersList.data.unshift(payload)`. On a re-invite the backend returns the same user (same `userId`, HTTP 200), so each invite prepended another row.
- Fix: the reducer now finds the returned user by `userId` and replaces the existing row in place (mirroring `updateUser`), falling back to `unshift` for a genuinely new user.

## Linked
- Fixes: descope/etc#17997
- Related PRs: none (frontend-only)

## Changes
- `state/asyncActions/createUser.ts`: `onFulfilled` de-dupes by `userId` instead of blind `unshift`.
- `test/createUserReducer.test.ts` (new): reducer unit tests for new-user prepend, re-invite dedupe (latest payload wins, position preserved), distinct-user prepend, and success-notification/loading side-effects still firing on re-invite.

## Manual test plan
- Add a user with any login ID in the widget, then submit the same login ID again 2-3 times -> table shows a single row, no refresh needed.
- Refresh -> still a single row.
- Add a genuinely different user -> appears once at the top.

## Risk / review focus
- Single reducer branch; the new-user path is unchanged. Low regression risk, no public API change.
- Relies on the backend returning the same `userId` on re-invite - confirmed in `managementservice` (auth.go / user.go) and verified live against the local backend (two `POST /user/create` 200s produced one row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)