### PR TITLE
fix(core-js-sdk): keep Response fields when a transformResponse hook is set

### DIFF
--- a/packages/sdks/core-js-sdk/src/httpClient/index.ts
+++ b/packages/sdks/core-js-sdk/src/httpClient/index.ts
@@ -5,6 +5,7 @@ import {
   AfterRequest,
   BeforeRequest,
   CreateHttpClientConfig,
+  ExtendedResponse,
   HttpClient,
   HTTPMethods,
   MultipleHooks,
@@ -163,13 +164,29 @@ const createHttpClient = ({
     if (hooks?.transformResponse) {
       const json = await res.json();
       const cookies = transformSetCookie(res.headers?.get('set-cookie') || '');
-      const mutableResponse = {
-        ...res,
+      // Proxy rather than shallow-copy: `{ ...res }` keeps own enumerable
+      // properties only, dropping `ok`/`status` when they are prototype
+      // accessors.
+      const overrides = Object.assign(Object.create(null), {
         json: () => Promise.resolve(json),
         cookies,
-      };
+      });
+      const mutableResponse = new Proxy(res, {
+        get: (target, prop) => {
+          if (prop in overrides) return overrides[prop];
+          const value = target[prop];
+          // bind so the real response stays the receiver
+          return typeof value === 'function' ? value.bind(target) : value;
+        },
+        // hook writes land here - accessors on the response are read-only
+        set: (_target, prop, value) => {
+          overrides[prop] = value;
+          return true;
+        },
+        has: (target, prop) => prop in overrides || prop in target,
+      }) as ExtendedResponse;
       // we want to make sure cloning the response will keep the transformed json data
-      mutableResponse.clone = () => mutableResponse;
+      overrides.clone = () => mutableResponse;
       return hooks.transformResponse(mutableResponse);
     }
 

--- a/packages/sdks/core-js-sdk/test/httpClient.test.ts
+++ b/packages/sdks/core-js-sdk/test/httpClient.test.ts
@@ -643,6 +643,114 @@ describe('createFetchLogger', () => {
     });
   });
 
+  describe('transformResponse with prototype-accessor responses', () => {
+    // Unlike the plain-object mocks above, a spec-compliant `Response` keeps
+    // `ok`, `status` and `headers` on the prototype.
+    class ProtoAccessorResponse {
+      constructor(
+        private body: string,
+        private code: number,
+        private setCookie = '',
+      ) {}
+
+      get ok() {
+        return this.code >= 200 && this.code < 300;
+      }
+
+      get status() {
+        return this.code;
+      }
+
+      get statusText() {
+        return this.ok ? 'OK' : 'Bad Request';
+      }
+
+      get headers() {
+        return new Headers(
+          this.setCookie ? { 'set-cookie': this.setCookie } : {},
+        );
+      }
+
+      text() {
+        return Promise.resolve(this.body);
+      }
+    }
+
+    it('should keep ok, status and headers on a 2xx response', async () => {
+      mockFetch.mockReturnValue(
+        new ProtoAccessorResponse(
+          JSON.stringify({ test: 123 }),
+          200,
+          'DSR=123, DS=456',
+        ),
+      );
+
+      const res = await hookedHttpClient.post('1/2/3', {});
+
+      expect(res.ok).toBe(true);
+      expect(res.status).toBe(200);
+      expect(res.headers.get('set-cookie')).toBe('DSR=123, DS=456');
+      expect(await res.json()).toEqual({
+        test: 123,
+        refreshJwt: '123',
+        sessionJwt: '456',
+      });
+    });
+
+    it('should keep ok and status on a non-2xx response', async () => {
+      mockFetch.mockReturnValue(
+        new ProtoAccessorResponse(
+          JSON.stringify({ errorCode: 'E011002' }),
+          400,
+        ),
+      );
+
+      const res = await hookedHttpClient.post('1/2/3', {});
+
+      expect(res.ok).toBe(false);
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ errorCode: 'E011002' });
+    });
+
+    it('should keep the transformed json when the response is cloned', async () => {
+      mockFetch.mockReturnValue(
+        new ProtoAccessorResponse(JSON.stringify({ test: 123 }), 200, 'DS=456'),
+      );
+
+      const res = await hookedHttpClient.post('1/2/3', {});
+      const clone = res.clone();
+
+      expect(clone.ok).toBe(true);
+      expect(clone.status).toBe(200);
+      expect(await clone.json()).toEqual({ test: 123, sessionJwt: '456' });
+    });
+
+    it('should let a hook mutate the response without touching the original', async () => {
+      const original = new ProtoAccessorResponse(
+        JSON.stringify({ test: 123 }),
+        200,
+      );
+      mockFetch.mockReturnValue(original);
+
+      const mutatingClient = createHttpClient({
+        baseUrl: 'http://descope.com',
+        projectId,
+        hooks: {
+          transformResponse: async (response: ExtendedResponse) => {
+            (response as any).extra = 'added';
+            return response;
+          },
+        },
+      });
+
+      const res = await mutatingClient.post('1/2/3', {});
+
+      expect((res as any).extra).toBe('added');
+      expect((original as any).extra).toBeUndefined();
+      expect(res.ok).toBe(true);
+    });
+  });
+
   describe('retry functionality', () => {
     let logger: any;
     let fetch: jest.Mock;


### PR DESCRIPTION
## Related Issues
https://github.com/descope/descope-react-native/issues/187

## Description
- Fix `transformResponse` hooks receiving a shallow copy of the response - a spec-compliant `Response` keeps `ok`, `status` and `headers` on the prototype, so the copy dropped them and every result came back with `ok` and `code` undefined
- Proxy the real response instead, overriding only `json`, `cookies` and `clone`
- Add regression tests for 2xx, non-2xx, `clone()` and hook mutation, using a response whose fields are prototype accessors

## Must
- [x] Tests
- [ ] Documentation