### PR TITLE
feat(core-js-sdk): support enchanted link over SMS

### DIFF
--- a/packages/sdks/core-js-sdk/README.md
+++ b/packages/sdks/core-js-sdk/README.md
@@ -24,6 +24,22 @@ const loginId = 'loginId';
 sdk.otp.signIn.email(loginId);
 ```
 
+## Enchanted Link over SMS
+
+The enchanted link can be delivered by SMS instead of email, using `signInWithPhone`,
+`signUpWithPhone`, `signUpOrInWithPhone` and `update.phone.sms`. The login ID is a phone number, and
+the response is a `PhoneEnchantedLinkResponse`, which carries `maskedPhone` instead of `maskedEmail`.
+Unlike the email message, the text message contains only the correct link, so the user has nothing
+to choose. Polling with `waitForSession` and verification are unchanged.
+
+```js
+const { data } = await sdk.enchantedLink.signUpOrInWithPhone(
+  '+11234567890',
+  'https://myapp.com/verify-enchanted-link',
+);
+const jwt = await sdk.enchantedLink.waitForSession(data.pendingRef);
+```
+
 ## Outbound Connect
 
 Connect to outbound applications (e.g., Google, Microsoft) to access user data from external services.

--- a/packages/sdks/core-js-sdk/src/constants/apiPaths.ts
+++ b/packages/sdks/core-js-sdk/src/constants/apiPaths.ts
@@ -30,6 +30,7 @@ export default {
     session: '/v1/auth/enchantedlink/pending-session',
     update: {
       email: '/v1/auth/enchantedlink/update/email',
+      phone: '/v1/auth/enchantedlink/update/phone',
     },
     signUpOrIn: '/v1/auth/enchantedlink/signup-in',
   },

--- a/packages/sdks/core-js-sdk/src/index.ts
+++ b/packages/sdks/core-js-sdk/src/index.ts
@@ -41,6 +41,7 @@ export type {
   JWTResponse,
   LoginOptions,
   PasskeyOptions,
+  PhoneEnchantedLinkResponse,
   ResponseData,
   SdkResponse,
   TOTPResponse,

--- a/packages/sdks/core-js-sdk/src/sdk/enchantedLink/index.ts
+++ b/packages/sdks/core-js-sdk/src/sdk/enchantedLink/index.ts
@@ -8,9 +8,12 @@ import { normalizeWaitForSessionConfig } from '../../utils';
 import { pathJoin, transformResponse } from '../helpers';
 import {
   DeliveryMethods,
+  DeliveryPhone,
   SdkResponse,
   JWTResponse,
   EnchantedLinkResponse,
+  PhoneEnchantedLinkResponse,
+  ResponseData,
   User,
   LoginOptions,
   UpdateOptions,
@@ -22,17 +25,12 @@ import {
   withSignValidations,
   withVerifyValidations,
   withUpdateEmailValidations,
+  withUpdatePhoneValidations,
 } from './validations';
 
-const withEnchantedLink = (httpClient: HttpClient) => ({
-  verify: withVerifyValidations(
-    (token: string): Promise<SdkResponse<never>> =>
-      transformResponse(
-        httpClient.post(apiPaths.enchantedLink.verify, { token }),
-      ),
-  ),
-
-  signIn: withSignValidations(
+const withEnchantedLink = (httpClient: HttpClient) => {
+  const postSignIn =
+    <T extends ResponseData>(delivery: DeliveryMethods) =>
     (
       loginId: string,
       URI?: string,
@@ -41,10 +39,10 @@ const withEnchantedLink = (httpClient: HttpClient) => ({
         ...loginOptions
       }: LoginOptions & { providerId?: string } = {},
       token?: string,
-    ): Promise<SdkResponse<EnchantedLinkResponse>> =>
+    ): Promise<SdkResponse<T>> =>
       transformResponse(
         httpClient.post(
-          pathJoin(apiPaths.enchantedLink.signIn, DeliveryMethods.email),
+          pathJoin(apiPaths.enchantedLink.signIn, delivery),
           {
             loginId,
             URI,
@@ -53,10 +51,10 @@ const withEnchantedLink = (httpClient: HttpClient) => ({
           },
           { token },
         ),
-      ),
-  ),
+      );
 
-  signUpOrIn: withSignValidations(
+  const postSignUpOrIn =
+    <T extends ResponseData>(delivery: DeliveryMethods) =>
     (
       loginId: string,
       URI?: string,
@@ -64,21 +62,18 @@ const withEnchantedLink = (httpClient: HttpClient) => ({
         providerId,
         ...signUpOptions
       }: SignUpOptions & { providerId?: string } = {},
-    ): Promise<SdkResponse<EnchantedLinkResponse>> =>
+    ): Promise<SdkResponse<T>> =>
       transformResponse(
-        httpClient.post(
-          pathJoin(apiPaths.enchantedLink.signUpOrIn, DeliveryMethods.email),
-          {
-            loginId,
-            URI,
-            loginOptions: signUpOptions,
-            providerId,
-          },
-        ),
-      ),
-  ),
+        httpClient.post(pathJoin(apiPaths.enchantedLink.signUpOrIn, delivery), {
+          loginId,
+          URI,
+          loginOptions: signUpOptions,
+          providerId,
+        }),
+      );
 
-  signUp: withSignValidations(
+  const postSignUp =
+    <T extends ResponseData>(delivery: DeliveryMethods) =>
     (
       loginId: string,
       URI?: string,
@@ -87,72 +82,125 @@ const withEnchantedLink = (httpClient: HttpClient) => ({
         providerId,
         ...signUpOptions
       }: SignUpOptions & { providerId?: string } = {},
-    ): Promise<SdkResponse<EnchantedLinkResponse>> =>
+    ): Promise<SdkResponse<T>> =>
       transformResponse(
-        httpClient.post(
-          pathJoin(apiPaths.enchantedLink.signUp, DeliveryMethods.email),
-          {
-            loginId,
-            URI,
-            user,
-            loginOptions: signUpOptions,
-            providerId,
-          },
-        ),
-      ),
-  ),
+        httpClient.post(pathJoin(apiPaths.enchantedLink.signUp, delivery), {
+          loginId,
+          URI,
+          user,
+          loginOptions: signUpOptions,
+          providerId,
+        }),
+      );
 
-  waitForSession: withWaitForSessionValidations(
-    (
-      pendingRef: string,
-      config?: WaitForSessionConfig,
-    ): Promise<SdkResponse<JWTResponse>> =>
-      new Promise((resolve) => {
-        const { pollingIntervalMs, timeoutMs } =
-          normalizeWaitForSessionConfig(config);
-        let timeout: NodeJS.Timeout | undefined;
-        const interval = setInterval(async () => {
-          const resp = await httpClient.post(apiPaths.enchantedLink.session, {
-            pendingRef,
-          });
-          if (resp.ok) {
-            clearInterval(interval);
-            if (timeout) clearTimeout(timeout);
-            resolve(transformResponse(Promise.resolve(resp)));
-          }
-        }, pollingIntervalMs);
-
-        timeout = setTimeout(() => {
-          resolve({
-            error: {
-              errorDescription: `Session polling timeout exceeded: ${timeoutMs}ms`,
-              errorCode: '0',
-            },
-            ok: false,
-          });
-          clearInterval(interval);
-        }, timeoutMs);
-      }),
-  ),
-
-  update: {
-    email: withUpdateEmailValidations(
-      <T extends boolean>(
-        loginId: string,
-        email: string,
-        URI?: string,
-        token?: string,
-        updateOptions?: UpdateOptions<T>,
-      ): Promise<SdkResponse<EnchantedLinkResponse>> =>
+  return {
+    verify: withVerifyValidations(
+      (token: string): Promise<SdkResponse<never>> =>
         transformResponse(
-          httpClient.post(
-            apiPaths.enchantedLink.update.email,
-            { loginId, email, URI, ...updateOptions },
-            { token },
-          ),
+          httpClient.post(apiPaths.enchantedLink.verify, { token }),
         ),
     ),
-  },
-});
+
+    signIn: withSignValidations(
+      postSignIn<EnchantedLinkResponse>(DeliveryMethods.email),
+    ),
+
+    /** Send an enchanted link over SMS to sign an existing user in */
+    signInWithPhone: withSignValidations(
+      postSignIn<PhoneEnchantedLinkResponse>(DeliveryPhone.sms),
+    ),
+
+    signUpOrIn: withSignValidations(
+      postSignUpOrIn<EnchantedLinkResponse>(DeliveryMethods.email),
+    ),
+
+    /** Send an enchanted link over SMS to sign a user up or in */
+    signUpOrInWithPhone: withSignValidations(
+      postSignUpOrIn<PhoneEnchantedLinkResponse>(DeliveryPhone.sms),
+    ),
+
+    signUp: withSignValidations(
+      postSignUp<EnchantedLinkResponse>(DeliveryMethods.email),
+    ),
+
+    /** Send an enchanted link over SMS to sign a new user up */
+    signUpWithPhone: withSignValidations(
+      postSignUp<PhoneEnchantedLinkResponse>(DeliveryPhone.sms),
+    ),
+
+    waitForSession: withWaitForSessionValidations(
+      (
+        pendingRef: string,
+        config?: WaitForSessionConfig,
+      ): Promise<SdkResponse<JWTResponse>> =>
+        new Promise((resolve) => {
+          const { pollingIntervalMs, timeoutMs } =
+            normalizeWaitForSessionConfig(config);
+          let timeout: NodeJS.Timeout | undefined;
+          const interval = setInterval(async () => {
+            const resp = await httpClient.post(apiPaths.enchantedLink.session, {
+              pendingRef,
+            });
+            if (resp.ok) {
+              clearInterval(interval);
+              if (timeout) clearTimeout(timeout);
+              resolve(transformResponse(Promise.resolve(resp)));
+            }
+          }, pollingIntervalMs);
+
+          timeout = setTimeout(() => {
+            resolve({
+              error: {
+                errorDescription: `Session polling timeout exceeded: ${timeoutMs}ms`,
+                errorCode: '0',
+              },
+              ok: false,
+            });
+            clearInterval(interval);
+          }, timeoutMs);
+        }),
+    ),
+
+    update: {
+      email: withUpdateEmailValidations(
+        <T extends boolean>(
+          loginId: string,
+          email: string,
+          URI?: string,
+          token?: string,
+          updateOptions?: UpdateOptions<T>,
+        ): Promise<SdkResponse<EnchantedLinkResponse>> =>
+          transformResponse(
+            httpClient.post(
+              apiPaths.enchantedLink.update.email,
+              { loginId, email, URI, ...updateOptions },
+              { token },
+            ),
+          ),
+      ),
+      phone: {
+        sms: withUpdatePhoneValidations(
+          <T extends boolean>(
+            loginId: string,
+            phone: string,
+            URI?: string,
+            token?: string,
+            updateOptions?: UpdateOptions<T>,
+          ): Promise<SdkResponse<PhoneEnchantedLinkResponse>> =>
+            transformResponse(
+              httpClient.post(
+                pathJoin(
+                  apiPaths.enchantedLink.update.phone,
+                  DeliveryPhone.sms,
+                ),
+                { loginId, phone, URI, ...updateOptions },
+                { token },
+              ),
+            ),
+        ),
+      },
+    },
+  };
+};
 
 export default withEnchantedLink;

--- a/packages/sdks/core-js-sdk/src/sdk/types.ts
+++ b/packages/sdks/core-js-sdk/src/sdk/types.ts
@@ -194,6 +194,16 @@ export type EnchantedLinkResponse = {
   maskedEmail: string;
 };
 
+/** Enchanted link response for the SMS delivery routes */
+export type PhoneEnchantedLinkResponse = {
+  /** Pending reference URL to poll while waiting for user to click the link */
+  pendingRef: string;
+  /** Link id, on which link the user should click */
+  linkId: string;
+  /** Phone to which the link was sent to */
+  maskedPhone: string;
+};
+
 /** URL response to redirect user in case of OAuth or SSO */
 export type URLResponse = {
   url: string;

--- a/packages/sdks/core-js-sdk/test/sdk/enchantedLink.test.ts
+++ b/packages/sdks/core-js-sdk/test/sdk/enchantedLink.test.ts
@@ -100,6 +100,61 @@ describe('Enchanted Link', () => {
         response: httpResponse,
       });
     });
+
+    describe('signUpWithPhone', () => {
+      it('should throw an error when loginId is not a string', () => {
+        expect(() => sdk.enchantedLink.signUpWithPhone(undefined)).toThrow(
+          '"loginId" must be a string',
+        );
+      });
+
+      it('should send the correct request', () => {
+        sdk.enchantedLink.signUpWithPhone(
+          '+9720000000',
+          'http://some.thing.com',
+          {
+            phone: '+9720000000',
+          },
+        );
+        expect(mockHttpClient.post).toHaveBeenCalledWith(
+          apiPaths.enchantedLink.signUp + '/sms',
+          {
+            loginId: '+9720000000',
+            URI: 'http://some.thing.com',
+            user: { phone: '+9720000000' },
+            loginOptions: {},
+          },
+        );
+      });
+
+      it('should return the correct response with maskedPhone', async () => {
+        const httpRespJson = {
+          pendingRef: 'pendingRef',
+          linkId: 'linkId',
+          maskedPhone: '+972********00',
+        };
+        const httpResponse = {
+          ok: true,
+          json: () => httpRespJson,
+          clone: () => ({
+            json: () => Promise.resolve(httpRespJson),
+          }),
+          status: 200,
+        };
+        mockHttpClient.post.mockResolvedValue(httpResponse);
+        const resp = await sdk.enchantedLink.signUpWithPhone(
+          '+9720000000',
+          'http://some.thing.com',
+        );
+
+        expect(resp).toEqual({
+          code: 200,
+          data: httpRespJson,
+          ok: true,
+          response: httpResponse,
+        });
+      });
+    });
   });
   describe('signIn', () => {
     it('should throw an error when loginId is not a string', () => {
@@ -194,6 +249,58 @@ describe('Enchanted Link', () => {
         response: httpResponse,
       });
     });
+
+    describe('signInWithPhone', () => {
+      it('should throw an error when loginId is not a string', () => {
+        expect(() =>
+          sdk.enchantedLink.signInWithPhone(undefined, 'http://some.thing.com'),
+        ).toThrow('"loginId" must be a string');
+      });
+
+      it('should send the correct request', () => {
+        sdk.enchantedLink.signInWithPhone(
+          '+9720000000',
+          'http://some.thing.com',
+        );
+        expect(mockHttpClient.post).toHaveBeenCalledWith(
+          apiPaths.enchantedLink.signIn + '/sms',
+          {
+            loginId: '+9720000000',
+            URI: 'http://some.thing.com',
+            loginOptions: {},
+          },
+          { token: undefined },
+        );
+      });
+
+      it('should return the correct response with maskedPhone', async () => {
+        const httpRespJson = {
+          pendingRef: 'pendingRef',
+          linkId: 'linkId',
+          maskedPhone: '+972********00',
+        };
+        const httpResponse = {
+          ok: true,
+          json: () => httpRespJson,
+          clone: () => ({
+            json: () => Promise.resolve(httpRespJson),
+          }),
+          status: 200,
+        };
+        mockHttpClient.post.mockResolvedValue(httpResponse);
+        const resp = await sdk.enchantedLink.signInWithPhone(
+          '+9720000000',
+          'http://some.thing.com',
+        );
+
+        expect(resp).toEqual({
+          code: 200,
+          data: httpRespJson,
+          ok: true,
+          response: httpResponse,
+        });
+      });
+    });
   });
 
   describe('signUpOrIn', () => {
@@ -264,6 +371,57 @@ describe('Enchanted Link', () => {
         data: httpRespJson,
         ok: true,
         response: httpResponse,
+      });
+    });
+
+    describe('signUpOrInWithPhone', () => {
+      it('should throw an error when loginId is not a string', () => {
+        expect(() => sdk.enchantedLink.signUpOrInWithPhone(undefined)).toThrow(
+          '"loginId" must be a string',
+        );
+      });
+
+      it('should send the correct request', () => {
+        sdk.enchantedLink.signUpOrInWithPhone(
+          '+9720000000',
+          'http://some.thing.com',
+        );
+        expect(mockHttpClient.post).toHaveBeenCalledWith(
+          apiPaths.enchantedLink.signUpOrIn + '/sms',
+          {
+            loginId: '+9720000000',
+            loginOptions: {},
+            URI: 'http://some.thing.com',
+          },
+        );
+      });
+
+      it('should return the correct response with maskedPhone', async () => {
+        const httpRespJson = {
+          pendingRef: 'pendingRef',
+          linkId: 'linkId',
+          maskedPhone: '+972********00',
+        };
+        const httpResponse = {
+          ok: true,
+          json: () => httpRespJson,
+          clone: () => ({
+            json: () => Promise.resolve(httpRespJson),
+          }),
+          status: 200,
+        };
+        mockHttpClient.post.mockResolvedValue(httpResponse);
+        const resp = await sdk.enchantedLink.signUpOrInWithPhone(
+          '+9720000000',
+          'http://some.thing.com',
+        );
+
+        expect(resp).toEqual({
+          code: 200,
+          data: httpRespJson,
+          ok: true,
+          response: httpResponse,
+        });
       });
     });
   });
@@ -518,6 +676,94 @@ describe('Enchanted Link', () => {
           'loginId',
           'new@email.com',
           'new@email.com',
+        );
+
+        expect(resp).toEqual({
+          code: 200,
+          data: httpRespJson,
+          ok: true,
+          response: httpResponse,
+        });
+      });
+    });
+
+    describe('phone.sms', () => {
+      it('should throw an error when loginId is not a string', () => {
+        expect(() =>
+          sdk.enchantedLink.update.phone.sms(1, '+9720000000'),
+        ).toThrow('"loginId" must be a string');
+      });
+
+      it('should throw an error when phone is not in phone format', () => {
+        expect(() =>
+          sdk.enchantedLink.update.phone.sms('loginId', 'nonPhone'),
+        ).toThrow('"nonPhone" is not a valid phone number');
+      });
+
+      it('should send the correct request', () => {
+        sdk.enchantedLink.update.phone.sms(
+          'loginId',
+          '+9720000000',
+          'http://some.thing.com',
+          'token',
+        );
+        expect(mockHttpClient.post).toHaveBeenCalledWith(
+          apiPaths.enchantedLink.update.phone + '/sms',
+          {
+            phone: '+9720000000',
+            loginId: 'loginId',
+            URI: 'http://some.thing.com',
+          },
+          { token: 'token' },
+        );
+      });
+
+      it('should send the correct request with template options', () => {
+        sdk.enchantedLink.update.phone.sms(
+          'loginId',
+          '+9720000000',
+          'http://some.thing.com',
+          'token',
+          {
+            providerId: 'some-provider',
+            templateOptions: {
+              ble: 'blue',
+            },
+          },
+        );
+        expect(mockHttpClient.post).toHaveBeenCalledWith(
+          apiPaths.enchantedLink.update.phone + '/sms',
+          {
+            phone: '+9720000000',
+            loginId: 'loginId',
+            URI: 'http://some.thing.com',
+            providerId: 'some-provider',
+            templateOptions: {
+              ble: 'blue',
+            },
+          },
+          { token: 'token' },
+        );
+      });
+
+      it('should return the correct response with maskedPhone', async () => {
+        const httpRespJson = {
+          pendingRef: 'pendingRef',
+          linkId: 'linkId',
+          maskedPhone: '+972********00',
+        };
+        const httpResponse = {
+          ok: true,
+          json: () => httpRespJson,
+          clone: () => ({
+            json: () => Promise.resolve(httpRespJson),
+          }),
+          status: 200,
+        };
+        mockHttpClient.post.mockResolvedValue(httpResponse);
+        const resp = await sdk.enchantedLink.update.phone.sms(
+          'loginId',
+          '+9720000000',
         );
 
         expect(resp).toEqual({


### PR DESCRIPTION
Adds Enchanted Link over SMS to core-js-sdk.

- Four new phone methods on the enchantedLink module.
- Additive only. Existing email methods unchanged.
- Failing e2e widget tests are pre-existing flake, unrelated to this diff.

Part of descope/etc#18315
