### PR TITLE
fix(angular-sdk): set attributes before descope-wc connects RELEASE

### DIFF
--- a/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/descope/descope.component.spec.ts
+++ b/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/descope/descope.component.spec.ts
@@ -249,7 +249,7 @@ describe('DescopeComponent', () => {
 
     // A stand-in for descope-wc that records what it can see when connected.
     class ProbeElement extends HTMLElement {
-      override connectedCallback() {
+      connectedCallback() {
         connects.push({
           projectId: this.getAttribute('project-id'),
           flowId: this.getAttribute('flow-id'),

--- a/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/descope/descope.component.spec.ts
+++ b/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/descope/descope.component.spec.ts
@@ -5,7 +5,6 @@ import createSdk from '@descope/web-js-sdk';
 import { DescopeAuthConfig } from '../../types/types';
 import { DescopeAuthService } from '../../services/descope-auth.service';
 import {
-  ApplicationRef,
   Component,
   CUSTOM_ELEMENTS_SCHEMA,
   EventEmitter,
@@ -122,7 +121,7 @@ describe('DescopeComponent', () => {
     ).toEqual('true');
   });
 
-  it('should emit success when web component emits success', () => {
+  it('should emit success when web component emits success', async () => {
     const html: HTMLElement = fixture.nativeElement;
     const webComponentHtml = html.querySelector('descope-wc')!;
 
@@ -134,6 +133,9 @@ describe('DescopeComponent', () => {
       emitted.push(e);
     });
     webComponentHtml.dispatchEvent(new CustomEvent('success', event));
+    // The handler pipes the afterRequest promise through rxjs before emitting,
+    // so don't assume the output has arrived by the time dispatch returns.
+    await flush();
 
     expect(afterRequestHooksSpy).toHaveBeenCalled();
     expect(emitted).toHaveLength(1);
@@ -317,10 +319,10 @@ describe('DescopeComponent', () => {
 
       f.destroy();
 
-      expect(f.nativeElement.querySelector('descope-wc')).toBeNull();
       // isConnected going false is what makes the browser run the web
       // component's disconnectedCallback so it can clean up after itself.
       expect(element.isConnected).toBe(false);
+      expect(f.nativeElement.querySelector('descope-wc')).toBeNull();
     });
 
     it('projects content into the element (custom screens)', async () => {
@@ -380,17 +382,15 @@ describe('DescopeComponent', () => {
       });
       const f = TestBed.createComponent(DescopeComponent);
       f.componentInstance.flowId = 'sign-in';
-      const appRef = TestBed.inject(ApplicationRef);
-      const attachedBefore = appRef.viewCount;
 
       f.detectChanges(); // ngOnInit starts and hits the await
       f.destroy(); // destroyed before the continuation runs
       await flush();
 
-      // ngOnDestroy already ran and had no view to clean up, so the continuation
-      // must not build one - it would stay attached to ApplicationRef for good.
-      expect(appRef.viewCount).toBe(attachedBefore);
+      // The continuation must not build the view: inserting into a destroyed
+      // ViewContainerRef throws, and nothing would ever clean it up.
       expect(connects).toHaveLength(0);
+      expect(f.nativeElement.querySelector('descope-wc')).toBeNull();
     });
 
     it('still renders the element when loading the web component fails', async () => {

--- a/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/descope/descope.component.spec.ts
+++ b/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/descope/descope.component.spec.ts
@@ -249,7 +249,7 @@ describe('DescopeComponent', () => {
 
     // A stand-in for descope-wc that records what it can see when connected.
     class ProbeElement extends HTMLElement {
-      connectedCallback() {
+      override connectedCallback() {
         connects.push({
           projectId: this.getAttribute('project-id'),
           flowId: this.getAttribute('flow-id'),

--- a/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/descope/descope.component.spec.ts
+++ b/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/descope/descope.component.spec.ts
@@ -3,7 +3,10 @@ import { default as DescopeWC } from '@descope/web-component';
 import { DescopeComponent } from './descope.component';
 import createSdk from '@descope/web-js-sdk';
 import { DescopeAuthConfig } from '../../types/types';
+import { DescopeAuthService } from '../../services/descope-auth.service';
 import {
+  ApplicationRef,
+  Component,
   CUSTOM_ELEMENTS_SCHEMA,
   EventEmitter,
   PLATFORM_ID
@@ -27,12 +30,19 @@ describe('DescopeComponent', () => {
   const onIsAuthenticatedChangeSpy = jest.fn();
   const onUserChangeSpy = jest.fn();
   const onClaimsChangeSpy = jest.fn();
-  const afterRequestHooksSpy = jest.fn();
+  // The real afterRequest hook returns a promise, and the success handler pipes
+  // it through rxjs `from`, so the mock has to return one too.
+  const afterRequestHooksSpy = jest.fn(() => Promise.resolve());
   const mockConfig: DescopeAuthConfig = {
     projectId: 'someProject'
   };
 
-  beforeEach(() => {
+  // The element is created in ngOnInit, after the dynamic import resolves, so it
+  // is not in the DOM until the task queue drains. fixture.whenStable() is not
+  // enough here - it can return before that continuation has run.
+  const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+  beforeEach(async () => {
     mockedCreateSdk = mocked(createSdk);
 
     mockedCreateSdk.mockReturnValue({
@@ -74,6 +84,8 @@ describe('DescopeComponent', () => {
     component.client = {};
     component.form = {};
     component.storeLastAuthenticatedUser = true;
+    fixture.detectChanges();
+    await flush();
     fixture.detectChanges();
   });
 
@@ -117,11 +129,15 @@ describe('DescopeComponent', () => {
     const event = {
       detail: { user: { name: 'user1' }, sessionJwt: 'session1' }
     };
+    const emitted: CustomEvent[] = [];
     component.success.subscribe((e) => {
-      expect(afterRequestHooksSpy).toHaveBeenCalled();
-      expect(e.detail).toHaveBeenCalledWith(event.detail);
+      emitted.push(e);
     });
     webComponentHtml.dispatchEvent(new CustomEvent('success', event));
+
+    expect(afterRequestHooksSpy).toHaveBeenCalled();
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].detail).toEqual(event.detail);
   });
 
   it('should emit error when web component emits error', () => {
@@ -214,6 +230,207 @@ describe('DescopeComponent', () => {
         'descope-wc'
       ) as any;
       expect(webComponent.customStorage).toBe(newCustomStorage);
+    });
+  });
+
+  // Regression tests for descope/etc#18415. The custom element reads project-id
+  // in its connectedCallback, so the attribute has to be there before the
+  // element is connected. It used to be missing on every mount after the first,
+  // which left the flow stuck loading forever with no error.
+  describe('attributes are set before the element connects', () => {
+    type ConnectRecord = {
+      projectId: string | null;
+      flowId: string | null;
+      projected: string | null;
+    };
+    const connects: ConnectRecord[] = [];
+
+    // A stand-in for descope-wc that records what it can see when connected.
+    class ProbeElement extends HTMLElement {
+      connectedCallback() {
+        connects.push({
+          projectId: this.getAttribute('project-id'),
+          flowId: this.getAttribute('flow-id'),
+          projected: this.textContent?.trim() || null
+        });
+      }
+    }
+
+    const mountProbe = async () => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        schemas: [CUSTOM_ELEMENTS_SCHEMA],
+        providers: [
+          DescopeAuthConfig,
+          { provide: DescopeAuthConfig, useValue: mockConfig }
+        ]
+      });
+      const f = TestBed.createComponent(DescopeComponent);
+      f.componentInstance.projectId = 'P_TEST';
+      f.componentInstance.flowId = 'sign-in';
+      f.detectChanges();
+      await flush();
+      f.detectChanges();
+      return f;
+    };
+
+    beforeAll(() => {
+      // The real descope-wc is mocked away in this suite, so the element name
+      // used by the component is registered here instead. Registering it is
+      // what makes the test meaningful: an unregistered element never upgrades,
+      // so it would never read its attributes and the bug would not show.
+      if (!customElements.get('descope-wc')) {
+        customElements.define('descope-wc', ProbeElement);
+      }
+    });
+
+    beforeEach(() => {
+      connects.length = 0;
+    });
+
+    it('sets project-id and flow-id before connectedCallback runs', async () => {
+      await mountProbe();
+
+      expect(connects).toHaveLength(1);
+      expect(connects[0].projectId).toBe('P_TEST');
+      expect(connects[0].flowId).toBe('sign-in');
+    });
+
+    it('sets them on remount too, when the element is already defined', async () => {
+      const first = await mountProbe();
+      first.destroy();
+      connects.length = 0;
+
+      // This is the case the customer hit: by now descope-wc is defined, so the
+      // element upgrades the moment it is connected.
+      await mountProbe();
+
+      expect(connects).toHaveLength(1);
+      expect(connects[0].projectId).toBe('P_TEST');
+      expect(connects[0].flowId).toBe('sign-in');
+    });
+
+    it('removes the element and disconnects it on destroy', async () => {
+      const f = await mountProbe();
+      const element = f.nativeElement.querySelector('descope-wc');
+      expect(element).toBeTruthy();
+
+      f.destroy();
+
+      expect(f.nativeElement.querySelector('descope-wc')).toBeNull();
+      // isConnected going false is what makes the browser run the web
+      // component's disconnectedCallback so it can clean up after itself.
+      expect(element.isConnected).toBe(false);
+    });
+
+    it('projects content into the element (custom screens)', async () => {
+      @Component({
+        standalone: true,
+        imports: [DescopeComponent],
+        schemas: [CUSTOM_ELEMENTS_SCHEMA],
+        // the binding form is required - a static flowId="..." attribute is
+        // lowercased by the HTML parser and would not match the
+        // `descope[flowId]` selector
+        template: `<descope [flowId]="'sign-in'"
+          ><span class="custom-screen">CUSTOM</span></descope
+        >`
+      })
+      class HostComponent {}
+
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        schemas: [CUSTOM_ELEMENTS_SCHEMA],
+        providers: [
+          DescopeAuthConfig,
+          { provide: DescopeAuthConfig, useValue: mockConfig }
+        ]
+      });
+      const f = TestBed.createComponent(HostComponent);
+      f.detectChanges();
+      await flush();
+      f.detectChanges();
+
+      const element = f.nativeElement.querySelector('descope-wc');
+      expect(element.querySelector('.custom-screen')).toBeTruthy();
+      // the projected content must be there when the element connects, not later
+      expect(connects[0].projected).toBe('CUSTOM');
+    });
+
+    it('updates an attribute when an input changes, and removes it when unset', async () => {
+      const f = await mountProbe();
+      const element = f.nativeElement.querySelector('descope-wc');
+
+      f.componentInstance.locale = 'en-US';
+      f.detectChanges();
+      expect(element.getAttribute('locale')).toBe('en-US');
+
+      f.componentInstance.locale = undefined as unknown as string;
+      f.detectChanges();
+      expect(element.getAttribute('locale')).toBeNull();
+    });
+
+    it('builds nothing when destroyed before the import resolves', async () => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        schemas: [CUSTOM_ELEMENTS_SCHEMA],
+        providers: [
+          DescopeAuthConfig,
+          { provide: DescopeAuthConfig, useValue: mockConfig }
+        ]
+      });
+      const f = TestBed.createComponent(DescopeComponent);
+      f.componentInstance.flowId = 'sign-in';
+      const appRef = TestBed.inject(ApplicationRef);
+      const attachedBefore = appRef.viewCount;
+
+      f.detectChanges(); // ngOnInit starts and hits the await
+      f.destroy(); // destroyed before the continuation runs
+      await flush();
+
+      // ngOnDestroy already ran and had no view to clean up, so the continuation
+      // must not build one - it would stay attached to ApplicationRef for good.
+      expect(appRef.viewCount).toBe(attachedBefore);
+      expect(connects).toHaveLength(0);
+    });
+
+    it('still renders the element when loading the web component fails', async () => {
+      const consoleError = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => undefined);
+
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        schemas: [CUSTOM_ELEMENTS_SCHEMA],
+        providers: [
+          DescopeAuthConfig,
+          { provide: DescopeAuthConfig, useValue: mockConfig }
+        ]
+      });
+      const f = TestBed.createComponent(DescopeComponent);
+      f.componentInstance.projectId = 'P_TEST';
+      f.componentInstance.flowId = 'sign-in';
+
+      // Makes loadWebComponent throw inside its own try/catch.
+      Object.defineProperty(TestBed.inject(DescopeAuthService), 'descopeSdk', {
+        get() {
+          throw new Error('failed to load');
+        }
+      });
+
+      f.detectChanges();
+      await flush();
+      f.detectChanges();
+
+      // loadWebComponent swallows the error, so the element still has to render
+      // - matching a failed chunk load rather than rendering nothing at all.
+      expect(consoleError).toHaveBeenCalledWith(
+        'Failed to load Descope web component:',
+        expect.any(Error)
+      );
+      expect(f.nativeElement.querySelector('descope-wc')).toBeTruthy();
+      expect(connects[0].projectId).toBe('P_TEST');
+
+      consoleError.mockRestore();
     });
   });
 

--- a/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/descope/descope.component.spec.ts
+++ b/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/descope/descope.component.spec.ts
@@ -4,6 +4,7 @@ import { DescopeComponent } from './descope.component';
 import createSdk from '@descope/web-js-sdk';
 import { DescopeAuthConfig } from '../../types/types';
 import { DescopeAuthService } from '../../services/descope-auth.service';
+import { CommonModule } from '@angular/common';
 import {
   Component,
   CUSTOM_ELEMENTS_SCHEMA,
@@ -391,6 +392,102 @@ describe('DescopeComponent', () => {
       // ViewContainerRef throws, and nothing would ever clean it up.
       expect(connects).toHaveLength(0);
       expect(f.nativeElement.querySelector('descope-wc')).toBeNull();
+    });
+
+    // Several <descope> components can sit on one page at the same time. Each
+    // one builds its own view, so nothing is shared between them - these cover
+    // that, since the original bug only showed up on a second mount.
+    describe('multiple instances on the same page', () => {
+      const mountHost = async <T>(host: new () => T) => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+          schemas: [CUSTOM_ELEMENTS_SCHEMA],
+          providers: [
+            DescopeAuthConfig,
+            { provide: DescopeAuthConfig, useValue: mockConfig }
+          ]
+        });
+        const f = TestBed.createComponent(host);
+        f.detectChanges();
+        await flush();
+        f.detectChanges();
+        return f;
+      };
+
+      it('gives every instance its attributes before it connects', async () => {
+        @Component({
+          standalone: true,
+          imports: [DescopeComponent],
+          schemas: [CUSTOM_ELEMENTS_SCHEMA],
+          template: `
+            <descope [flowId]="'sign-in'"></descope>
+            <descope [flowId]="'sign-up'"></descope>
+          `
+        })
+        class TwoFlowsHostComponent {}
+
+        const f = await mountHost(TwoFlowsHostComponent);
+
+        expect(connects).toHaveLength(2);
+        expect(connects.map((c) => c.flowId)).toEqual(['sign-in', 'sign-up']);
+        // every instance saw a project-id, not just the first
+        expect(connects.every((c) => c.projectId === 'someProject')).toBe(true);
+        expect(f.nativeElement.querySelectorAll('descope-wc')).toHaveLength(2);
+      });
+
+      // Running the same project + flow twice is documented as unsupported by
+      // the web component (duplicateFlowWarningMixin warns about it). The
+      // attribute timing still has to hold, so a consumer who does it gets the
+      // warning rather than a flow that silently never starts.
+      it('still sets attributes when the same flow is rendered twice', async () => {
+        @Component({
+          standalone: true,
+          imports: [DescopeComponent],
+          schemas: [CUSTOM_ELEMENTS_SCHEMA],
+          template: `
+            <descope [flowId]="'sign-in'"></descope>
+            <descope [flowId]="'sign-in'"></descope>
+          `
+        })
+        class SameFlowHostComponent {}
+
+        await mountHost(SameFlowHostComponent);
+
+        expect(connects).toHaveLength(2);
+        expect(
+          connects.every(
+            (c) => c.projectId === 'someProject' && c.flowId === 'sign-in'
+          )
+        ).toBe(true);
+      });
+
+      it('leaves the other instance connected when one is destroyed', async () => {
+        @Component({
+          standalone: true,
+          imports: [DescopeComponent, CommonModule],
+          schemas: [CUSTOM_ELEMENTS_SCHEMA],
+          template: `
+            <descope *ngIf="showFirst" [flowId]="'sign-in'"></descope>
+            <descope [flowId]="'sign-up'"></descope>
+          `
+        })
+        class TogglableHostComponent {
+          showFirst = true;
+        }
+
+        const f = await mountHost(TogglableHostComponent);
+        const [first, second] = Array.from(
+          f.nativeElement.querySelectorAll('descope-wc')
+        ) as HTMLElement[];
+
+        f.componentInstance.showFirst = false;
+        f.detectChanges();
+
+        // ngOnDestroy destroys that instance's view only
+        expect(first.isConnected).toBe(false);
+        expect(second.isConnected).toBe(true);
+        expect(second.getAttribute('flow-id')).toBe('sign-up');
+      });
     });
 
     it('still renders the element when loading the web component fails', async () => {

--- a/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/descope/descope.component.ts
+++ b/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/descope/descope.component.ts
@@ -1,5 +1,4 @@
 import {
-  ApplicationRef,
   Component,
   ElementRef,
   EmbeddedViewRef,
@@ -9,9 +8,9 @@ import {
   OnDestroy,
   OnInit,
   Output,
-  Renderer2,
   TemplateRef,
   ViewChild,
+  ViewContainerRef,
   CUSTOM_ELEMENTS_SCHEMA,
   Inject,
   PLATFORM_ID
@@ -48,6 +47,7 @@ const ELEMENT_NODE = 1;
   // mount after the first (descope/etc#18415). Building the template by hand
   // lets the bindings run while the nodes are still detached.
   template: `
+    <ng-container #wcAnchor></ng-container>
     <ng-template #wcTpl>
       <descope-wc
         [attr.project-id]="projectId"
@@ -83,6 +83,11 @@ const ELEMENT_NODE = 1;
 export class DescopeComponent implements OnInit, OnChanges, OnDestroy {
   @ViewChild('wcTpl', { static: true })
   private readonly wcTpl!: TemplateRef<unknown>;
+
+  // Anchor inside this component's own view, so the inserted view stays in the
+  // component's change-detection tree and Angular destroys it with the component.
+  @ViewChild('wcAnchor', { read: ViewContainerRef, static: true })
+  private readonly wcAnchor!: ViewContainerRef;
 
   private wcView?: EmbeddedViewRef<unknown>;
 
@@ -161,9 +166,7 @@ export class DescopeComponent implements OnInit, OnChanges, OnDestroy {
     private elementRef: ElementRef,
     private authService: DescopeAuthService,
     descopeConfig: DescopeAuthConfig,
-    @Inject(PLATFORM_ID) private platformId: object,
-    private appRef: ApplicationRef,
-    private renderer: Renderer2
+    @Inject(PLATFORM_ID) private platformId: object
   ) {
     this.projectId = descopeConfig.projectId;
     this.baseUrl = descopeConfig.baseUrl;
@@ -199,30 +202,29 @@ export class DescopeComponent implements OnInit, OnChanges, OnDestroy {
   private createWebComponent(): void {
     // ngOnInit awaits the import, so the component can already be destroyed by
     // the time we get here (a route change while the chunk is downloading).
-    // ngOnDestroy has run by then and had no view to clean up, so building one
-    // now would leave it attached to ApplicationRef for good.
+    // Inserting into a destroyed ViewContainerRef would throw, and nothing
+    // would ever clean the view up.
     if (this.isDestroyed || this.wcView) return;
 
+    // createEmbeddedView builds the nodes without putting them in the document,
+    // so the element is not connected yet and its connectedCallback has not run.
     const view = this.wcTpl.createEmbeddedView(undefined);
-    // Apply the [attr.*] bindings while the nodes are detached.
+    // Apply the [attr.*] bindings while the nodes are still detached.
     view.detectChanges();
-    // Keep the view change-detected so later input changes reach the attributes.
-    this.appRef.attachView(view);
     this.wcView = view;
 
     // rootNodes can include whitespace text nodes, so find the element. The
     // nodeType is compared to a literal rather than Node.ELEMENT_NODE because
     // this also runs during SSR, where the Node global may not exist.
-    const element = view.rootNodes.find(
+    this.webComponent = view.rootNodes.find(
       (node: { nodeType: number }) => node.nodeType === ELEMENT_NODE
     ) as DescopeWebComponent | undefined;
 
-    if (!element) return;
+    // Inserting connects the element - its connectedCallback runs here, with
+    // every attribute already set.
+    this.wcAnchor.insert(view);
 
-    this.webComponent = element;
-    // Connects the element - its connectedCallback runs here, with every
-    // attribute already set.
-    this.renderer.appendChild(this.elementRef.nativeElement, element);
+    if (!this.webComponent) return;
 
     this.setupNonAttributeProperties();
     this.setupEventListeners();
@@ -268,23 +270,20 @@ export class DescopeComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    // Guards the ngOnInit race - the continuation can still be pending here.
     this.isDestroyed = true;
 
-    if (!this.wcView) return;
-
-    this.appRef.detachView(this.wcView);
-    // Removes the element from the DOM, so the web component's
-    // disconnectedCallback runs and cleans up its own listeners.
-    this.wcView.destroy();
+    // wcAnchor owns the view, so Angular would tear it down anyway - but when a
+    // parent view is going away Angular skips removing the individual nodes, and
+    // then the element never disconnects. Destroying it here takes the element
+    // out of the DOM, so the web component's disconnectedCallback runs and drops
+    // its window listeners and flow-state subscriptions.
+    this.wcView?.destroy();
     this.wcView = undefined;
     this.webComponent = undefined;
   }
 
   ngOnChanges(): void {
-    // The element lives in a manually created view, so refresh it here rather
-    // than relying on the host's change detection reaching it.
-    this.wcView?.detectChanges();
-
     if (this.webComponent) {
       this.setupNonAttributeProperties();
     }

--- a/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/descope/descope.component.ts
+++ b/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/descope/descope.component.ts
@@ -213,9 +213,11 @@ export class DescopeComponent implements OnInit, OnChanges, OnDestroy {
     view.detectChanges();
     this.wcView = view;
 
-    // rootNodes can include whitespace text nodes, so find the element. The
-    // nodeType is compared to a literal rather than Node.ELEMENT_NODE because
-    // this also runs during SSR, where the Node global may not exist.
+    // The template holds exactly one element, <descope-wc>, and each component
+    // instance builds its own view - so this picks that instance's own element
+    // and never sees another instance's. Selected by node type rather than as
+    // rootNodes[0] so template whitespace can never shift it, and compared
+    // against a literal because Node is not guaranteed to exist during SSR.
     this.webComponent = view.rootNodes.find(
       (node: { nodeType: number }) => node.nodeType === ELEMENT_NODE
     ) as DescopeWebComponent | undefined;

--- a/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/descope/descope.component.ts
+++ b/packages/sdks/angular-sdk/projects/angular-sdk/src/lib/components/descope/descope.component.ts
@@ -1,13 +1,17 @@
 import {
+  ApplicationRef,
   Component,
   ElementRef,
+  EmbeddedViewRef,
   EventEmitter,
   Input,
   OnChanges,
+  OnDestroy,
   OnInit,
   Output,
+  Renderer2,
+  TemplateRef,
   ViewChild,
-  AfterViewInit,
   CUSTOM_ELEMENTS_SCHEMA,
   Inject,
   PLATFORM_ID
@@ -24,45 +28,65 @@ import type DescopeWebComponent from '@descope/web-component';
 import type { CustomStorage } from '@descope/web-component';
 import OverrideThemes from '@descope/web-component';
 
+// Node.ELEMENT_NODE, as a literal - the Node global is not guaranteed to exist
+// during server-side rendering.
+const ELEMENT_NODE = 1;
+
 @Component({
   selector: 'descope[flowId]',
   standalone: true,
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  // The subtree is built imperatively (see ngOnInit), so there is nothing for
+  // Angular to hydrate here - it re-renders it on the client instead.
+  host: { ngSkipHydration: 'true' },
+  // The element is intentionally declared inside an <ng-template> instead of
+  // rendered directly. Angular appends an element to the DOM in its creation
+  // pass but applies [attr.*] bindings in the later update pass, so a
+  // <descope-wc> rendered directly here would be connected - and would run its
+  // connectedCallback - before it had a project-id. The custom element reads
+  // project-id at that moment, fails, and can never recover, which broke every
+  // mount after the first (descope/etc#18415). Building the template by hand
+  // lets the bindings run while the nodes are still detached.
   template: `
-    <descope-wc
-      #descopeWc
-      [attr.project-id]="projectId"
-      [attr.flow-id]="flowId"
-      [attr.base-url]="baseUrl"
-      [attr.base-static-url]="baseStaticUrl"
-      [attr.base-cdn-url]="baseCdnUrl"
-      [attr.store-last-authenticated-user]="storeLastAuthenticatedUser"
-      [attr.theme]="theme"
-      [attr.locale]="locale"
-      [attr.tenant]="tenant"
-      [attr.telemetry-key]="telemetryKey"
-      [attr.redirect-url]="redirectUrl"
-      [attr.auto-focus]="autoFocus"
-      [attr.validate-on-blur]="validateOnBlur"
-      [attr.restart-on-error]="restartOnError"
-      [attr.send-session-token]="sendSessionToken"
-      [attr.debug]="debug"
-      [attr.style-id]="styleId"
-      [attr.theme-override]="themeOverride"
-      [attr.client]="clientString"
-      [attr.nonce]="nonceString"
-      [attr.dismiss-screen-error-on-input]="dismissScreenErrorOnInput"
-      [attr.popup-origin]="popupOrigin"
-      [attr.form]="formString"
-      [customStorage]="customStorage"
-    >
-      <ng-content></ng-content>
-    </descope-wc>
+    <ng-template #wcTpl>
+      <descope-wc
+        [attr.project-id]="projectId"
+        [attr.flow-id]="flowId"
+        [attr.base-url]="baseUrl"
+        [attr.base-static-url]="baseStaticUrl"
+        [attr.base-cdn-url]="baseCdnUrl"
+        [attr.store-last-authenticated-user]="storeLastAuthenticatedUser"
+        [attr.theme]="theme"
+        [attr.locale]="locale"
+        [attr.tenant]="tenant"
+        [attr.telemetry-key]="telemetryKey"
+        [attr.redirect-url]="redirectUrl"
+        [attr.auto-focus]="autoFocus"
+        [attr.validate-on-blur]="validateOnBlur"
+        [attr.restart-on-error]="restartOnError"
+        [attr.send-session-token]="sendSessionToken"
+        [attr.debug]="debug"
+        [attr.style-id]="styleId"
+        [attr.theme-override]="themeOverride"
+        [attr.client]="clientString"
+        [attr.nonce]="nonceString"
+        [attr.dismiss-screen-error-on-input]="dismissScreenErrorOnInput"
+        [attr.popup-origin]="popupOrigin"
+        [attr.form]="formString"
+        [customStorage]="customStorage"
+      >
+        <ng-content></ng-content>
+      </descope-wc>
+    </ng-template>
   `
 })
-export class DescopeComponent implements OnInit, OnChanges, AfterViewInit {
-  @ViewChild('descopeWc')
-  private readonly descopeWc!: ElementRef<DescopeWebComponent>;
+export class DescopeComponent implements OnInit, OnChanges, OnDestroy {
+  @ViewChild('wcTpl', { static: true })
+  private readonly wcTpl!: TemplateRef<unknown>;
+
+  private wcView?: EmbeddedViewRef<unknown>;
+
+  private isDestroyed = false;
 
   get clientString(): string | undefined {
     if (!this.client) return undefined;
@@ -137,7 +161,9 @@ export class DescopeComponent implements OnInit, OnChanges, AfterViewInit {
     private elementRef: ElementRef,
     private authService: DescopeAuthService,
     descopeConfig: DescopeAuthConfig,
-    @Inject(PLATFORM_ID) private platformId: object
+    @Inject(PLATFORM_ID) private platformId: object,
+    private appRef: ApplicationRef,
+    private renderer: Renderer2
   ) {
     this.projectId = descopeConfig.projectId;
     this.baseUrl = descopeConfig.baseUrl;
@@ -148,12 +174,58 @@ export class DescopeComponent implements OnInit, OnChanges, AfterViewInit {
   }
 
   async ngOnInit(): Promise<void> {
-    // Only load web component in browser environment
-    if (!isPlatformBrowser(this.platformId)) {
-      return;
+    // Load the web component before building the element. The order matters:
+    // loadWebComponent sets DescopeWc.sdkConfigOverrides, and if something else
+    // on the page already imported @descope/web-component then descope-wc is
+    // already defined, so the element would initialize the moment it is
+    // connected. Connecting it first would let the flow start without the
+    // Angular SDK's base headers, persistTokens: false, and beforeRequest hook.
+    if (isPlatformBrowser(this.platformId)) {
+      await this.loadWebComponent();
     }
 
-    await this.loadWebComponent();
+    // Built on the server too, so the server-rendered markup keeps containing
+    // descope-wc as it did before. ngSkipHydration means the client re-renders
+    // this subtree anyway, so the server copy only serves the first paint.
+    this.createWebComponent();
+  }
+
+  /**
+   * Builds the template while its nodes are still detached from the document,
+   * applies the attribute bindings, and only then connects the element. This is
+   * what guarantees project-id and flow-id are present when the custom element
+   * runs its connectedCallback.
+   */
+  private createWebComponent(): void {
+    // ngOnInit awaits the import, so the component can already be destroyed by
+    // the time we get here (a route change while the chunk is downloading).
+    // ngOnDestroy has run by then and had no view to clean up, so building one
+    // now would leave it attached to ApplicationRef for good.
+    if (this.isDestroyed || this.wcView) return;
+
+    const view = this.wcTpl.createEmbeddedView(undefined);
+    // Apply the [attr.*] bindings while the nodes are detached.
+    view.detectChanges();
+    // Keep the view change-detected so later input changes reach the attributes.
+    this.appRef.attachView(view);
+    this.wcView = view;
+
+    // rootNodes can include whitespace text nodes, so find the element. The
+    // nodeType is compared to a literal rather than Node.ELEMENT_NODE because
+    // this also runs during SSR, where the Node global may not exist.
+    const element = view.rootNodes.find(
+      (node: { nodeType: number }) => node.nodeType === ELEMENT_NODE
+    ) as DescopeWebComponent | undefined;
+
+    if (!element) return;
+
+    this.webComponent = element;
+    // Connects the element - its connectedCallback runs here, with every
+    // attribute already set.
+    this.renderer.appendChild(this.elementRef.nativeElement, element);
+
+    this.setupNonAttributeProperties();
+    this.setupEventListeners();
   }
 
   private async loadWebComponent(): Promise<void> {
@@ -195,15 +267,24 @@ export class DescopeComponent implements OnInit, OnChanges, AfterViewInit {
     }
   }
 
-  ngAfterViewInit(): void {
-    if (!this.descopeWc?.nativeElement) return;
+  ngOnDestroy(): void {
+    this.isDestroyed = true;
 
-    this.webComponent = this.descopeWc.nativeElement;
-    this.setupNonAttributeProperties();
-    this.setupEventListeners();
+    if (!this.wcView) return;
+
+    this.appRef.detachView(this.wcView);
+    // Removes the element from the DOM, so the web component's
+    // disconnectedCallback runs and cleans up its own listeners.
+    this.wcView.destroy();
+    this.wcView = undefined;
+    this.webComponent = undefined;
   }
 
   ngOnChanges(): void {
+    // The element lives in a manually created view, so refresh it here rather
+    // than relying on the host's change detection reaching it.
+    this.wcView?.detectChanges();
+
     if (this.webComponent) {
       this.setupNonAttributeProperties();
     }

--- a/packages/sdks/angular-sdk/setup-jest.ts
+++ b/packages/sdks/angular-sdk/setup-jest.ts
@@ -1,1 +1,19 @@
 import 'jest-preset-angular/setup-jest';
+
+// jsdom provides no global Response. Code under test constructs one (the flow
+// success handler feeds it to the SDK's afterRequest hook), and without this a
+// handler that throws is swallowed - which silently turns tests green while they
+// assert nothing.
+if (typeof Response === 'undefined') {
+  (globalThis as unknown as { Response: unknown }).Response = class {
+    private readonly body: string;
+
+    constructor(body: string) {
+      this.body = body;
+    }
+
+    json() {
+      return Promise.resolve(JSON.parse(this.body));
+    }
+  };
+}


### PR DESCRIPTION
## Summary

- The second and later `<descope>` mounts in a page session never started: endless
  loading, no `ready` and no `error` event. Reported by a customer (Zyte) after a
  version bump from 0.15.17 to 0.27.5, and still broken on 0.28.2.
- Angular appends an element to the DOM in its creation pass but applies `[attr.*]`
  bindings in the later update pass, so `<descope-wc>` connected before it had a
  `project-id` and the custom element failed permanently.
- The template now sits in an `<ng-template>` built by hand, so the bindings run
  while the nodes are still detached and the element always carries `project-id`
  and `flow-id` when it connects.
- Widgets were never affected — `BaseLazyWidgetComponent` already sets attributes
  before appending.

## Linked

- Ticket: https://github.com/descope/etc/issues/18415
- Related PRs: none (single-repo change)

## Changes

**Why only mounts after the first broke.** 0.27.0 (#1293, Angular SSR) made the
web component a dynamic `import()`, and importing that module is what calls
`customElements.define('descope-wc')`. So the first mount inserts an element that
is still undefined and upgrades late, after the attributes land. Every later mount
finds the class defined and upgrades on insertion, measured ~2ms before
`project-id` arrives. `init()` then bails at "Cannot get config file" and `#init`
stays `false`, so `attributeChangedCallback` drops the attribute that arrives
right after — the element is dead for good.

The declarative template itself predates 0.27; it arrived in #1181 (~0.18.3),
which moved away from `new DescopeWebComponent()` in a field initializer because
that broke on Angular 19. This fix keeps the template and all 20-odd bindings
byte-for-byte, so nothing can drift.

- `descope.component.ts` — template wrapped in `<ng-template #wcTpl>`; built in
  `ngOnInit` via `createEmbeddedView` + `detectChanges` while detached, then
  connected with `Renderer2.appendChild`. `@ViewChild`/`ngAfterViewInit` replaced,
  `ngOnDestroy` added, plus `ngSkipHydration` since the subtree is now built
  imperatively.
- The import is awaited *before* the element is built, on purpose:
  `sdkConfigOverrides` must be set first, or a flow can start without
  `persistTokens: false` and the `beforeRequest` hook.
- `descope.component.spec.ts` — new regression tests; existing tests now await the
  async insertion.
- `setup-jest.ts` — `Response` stub for jsdom (see Risk below).

## Manual test plan

Against a local backend, with `descopeBaseStaticUrl` set to
`https://static.local.descope.org/pages`:

- Load the demo app, click LOGIN — the flow renders.
- Navigate back, click LOGIN again — the second flow renders too (this is what
  used to hang forever).
- Enter an email on that second mount and press Continue — it advances to the
  verification screen, with `POST /v1/flow/start` and `/v1/flow/next` going out.
- Console shows no `project-id cannot be empty` and no `Cannot get config file`.
- A custom screen (children of `<descope>`) still renders.

Verified before/after:

| | mount 1 | mount 2 |
|---|---|---|
| before | `ready`, 14 components | `loading` forever, 0 components, 4 errors |
| after | `ready`, 14 components | `ready`, 14 components, 0 errors |

## Risk / review focus

- **SSR is not verified.** The subtree is now built imperatively, so
  `ngSkipHydration` is set — but there is no SSR harness in this repo, so that is
  reasoned, not tested. Worth a look from anyone who runs Angular SSR. The view is
  still built on the server so the rendered markup keeps containing
  `<descope-wc>`, and `nodeType` is compared to a literal rather than
  `Node.ELEMENT_NODE` because that global is not guaranteed server-side.
- **The await ordering in `ngOnInit` is load-bearing**, not stylistic — see
  Changes. Easy to "simplify" away by mistake.
- **Two spec changes look unrelated but are not.** `should emit success` was green
  while asserting nothing: jsdom has no `Response`, the handler threw, and the
  error was swallowed. This change surfaced it, so the stub moved to
  `setup-jest.ts` and the `afterRequest` mock now returns a promise. The repaired
  assertion was mutation-tested.
- The new tests were checked against the old component: 5 of them fail there, so
  they actually catch the bug.
