### PR TITLE
feat(nextjs-sdk): add skipRefreshTokenValidation option to authMiddleware

### DIFF
--- a/packages/sdks/nextjs-sdk/README.md
+++ b/packages/sdks/nextjs-sdk/README.md
@@ -248,6 +248,10 @@ export default authMiddleware({
   // Optional: log level for the middleware
   // Defaults to 'info'
   // logLevel: 'debug' | 'info' | 'warn' | 'error'
+
+	// Optional: skip the refresh token validation fallback
+	// Defaults to false
+	skipRefreshTokenValidation?: boolean
 })
 
 export const config = {
@@ -289,6 +293,20 @@ This setup ensures that you can clearly define which routes in your application 
   	privateRoutes: ['/dashboard', '/profile']
   };
   ```
+
+##### Skipping Refresh Token Validation
+
+By default, when the session token is missing or expired, the middleware falls back to validating the refresh token, and lets the request through if it is valid.
+The middleware does not refresh the session, so server side code that relies on `session()` will still see no valid session.
+
+Set `skipRefreshTokenValidation: true` to require a valid session token - requests with only a valid refresh token will be redirected to the sign-in route.
+This is useful when your server side code needs a valid session on every private route.
+
+```typescript
+const options = {
+	skipRefreshTokenValidation: true
+};
+```
 
 ##### Read session information in server side
 

--- a/packages/sdks/nextjs-sdk/README.md
+++ b/packages/sdks/nextjs-sdk/README.md
@@ -308,6 +308,15 @@ const options = {
 };
 ```
 
+###### What the app is expected to do
+
+A user with an expired session token and a still valid refresh token is redirected to the sign-in route.
+On the client, `AuthProvider` refreshes the session token from the refresh token on its own (`autoRefresh` is on by default), so the user becomes authenticated again without re-authenticating.
+
+Your sign-in page is expected to send an already authenticated user away, otherwise they will sit on it.
+Rendering `<Descope />` with `redirectAfterSuccess` covers this, as does checking `useSession()` and routing away yourself.
+The redirect replaces the original pathname and only carries over its query parameters, so if you want to return the user to the page they came from, capture it yourself before redirecting.
+
 ##### Read session information in server side
 
 use the `session()` helper to read session information in Server Components and Route handlers.

--- a/packages/sdks/nextjs-sdk/src/server/authMiddleware.ts
+++ b/packages/sdks/nextjs-sdk/src/server/authMiddleware.ts
@@ -74,6 +74,9 @@ const getRefreshJwt = (
 	req: NextRequest,
 	options: MiddlewareOptions
 ): string | undefined => {
+	if (options?.skipRefreshTokenValidation) {
+		return undefined;
+	}
 	const refreshJwt = req.cookies?.get(
 		options?.refreshTokenCookieName || 'DSR'
 	)?.value;
@@ -151,9 +154,7 @@ const createAuthMiddleware =
 			logger.debug('[Auth middleware] Failed to validate session JWT', err);
 
 			// Try to validate the refresh token instead
-			const refreshJwt = options.skipRefreshTokenValidation
-				? undefined
-				: getRefreshJwt(req, options);
+			const refreshJwt = getRefreshJwt(req, options);
 			if (refreshJwt) {
 				logger.debug('[Auth middleware] Attempting to validate refresh token');
 				try {

--- a/packages/sdks/nextjs-sdk/src/server/authMiddleware.ts
+++ b/packages/sdks/nextjs-sdk/src/server/authMiddleware.ts
@@ -43,6 +43,13 @@ type MiddlewareOptions = {
 	// Defaults to 'DSR'
 	// Used to refresh the session when the JWT expires
 	refreshTokenCookieName?: string;
+
+	// Skip the refresh token validation fallback
+	// By default, a valid refresh token is enough to pass the middleware even
+	// when the session token is expired. Set to true to require a valid session
+	// token, e.g. when server side code relies on `session()`
+	// Defaults to false
+	skipRefreshTokenValidation?: boolean;
 };
 
 const getSessionJwt = (
@@ -144,7 +151,9 @@ const createAuthMiddleware =
 			logger.debug('[Auth middleware] Failed to validate session JWT', err);
 
 			// Try to validate the refresh token instead
-			const refreshJwt = getRefreshJwt(req, options);
+			const refreshJwt = options.skipRefreshTokenValidation
+				? undefined
+				: getRefreshJwt(req, options);
 			if (refreshJwt) {
 				logger.debug('[Auth middleware] Attempting to validate refresh token');
 				try {

--- a/packages/sdks/nextjs-sdk/test/server/authMiddleware.test.ts
+++ b/packages/sdks/nextjs-sdk/test/server/authMiddleware.test.ts
@@ -451,6 +451,29 @@ describe('authMiddleware', () => {
 			expect(NextResponse.redirect).toHaveBeenCalled();
 		});
 
+		it('allows access with a valid session token when skipRefreshTokenValidation is true', async () => {
+			mockValidateJwt.mockResolvedValueOnce({
+				jwt: 'validSessionJwt',
+				token: { iss: 'project-1', sub: 'user-123' }
+			});
+
+			const middleware = authMiddleware({
+				skipRefreshTokenValidation: true
+			});
+			const mockReq = createMockNextRequest({
+				pathname: '/private',
+				cookies: { DS: 'validSessionJwt', DSR: 'validRefreshJwt' }
+			});
+
+			await middleware(mockReq);
+
+			expect(mockValidateJwt).toHaveBeenCalledTimes(1);
+			expect(mockValidateJwt).toHaveBeenCalledWith('validSessionJwt');
+
+			expect(NextResponse.redirect).not.toHaveBeenCalled();
+			expect(NextResponse.next).toHaveBeenCalled();
+		});
+
 		it('allows access to public routes even when both tokens fail', async () => {
 			// Both calls fail
 			mockValidateJwt

--- a/packages/sdks/nextjs-sdk/test/server/authMiddleware.test.ts
+++ b/packages/sdks/nextjs-sdk/test/server/authMiddleware.test.ts
@@ -429,6 +429,28 @@ describe('authMiddleware', () => {
 			expect(headersArg.get('x-descope-session')).toBeNull();
 		});
 
+		it('skips refresh token validation when skipRefreshTokenValidation is true', async () => {
+			// Session JWT fails, refresh token should never be validated
+			mockValidateJwt.mockRejectedValueOnce(new Error('Session JWT expired'));
+
+			const middleware = authMiddleware({
+				skipRefreshTokenValidation: true
+			});
+			const mockReq = createMockNextRequest({
+				pathname: '/private',
+				cookies: { DS: 'expiredSessionJwt', DSR: 'validRefreshJwt' }
+			});
+
+			await middleware(mockReq);
+
+			// Only the session JWT is validated
+			expect(mockValidateJwt).toHaveBeenCalledTimes(1);
+			expect(mockValidateJwt).toHaveBeenCalledWith('expiredSessionJwt');
+
+			// Expect redirect since the session token is the only thing that counts
+			expect(NextResponse.redirect).toHaveBeenCalled();
+		});
+
 		it('allows access to public routes even when both tokens fail', async () => {
 			// Both calls fail
 			mockValidateJwt


### PR DESCRIPTION
Fixes: https://github.com/descope/etc/issues/18445

## Problem

`authMiddleware` always falls back to validating the refresh token (`DSR`) when the session token (`DS`) is missing or expired, and lets the request through if the refresh token is valid. There was no way to turn that off.

The middleware doesn't actually refresh the session, so a request that passed only on the refresh token reaches server side code with no valid session - `session()` validates the session token only, so it returns `undefined`. Apps that need a live session on every private route had no way to express that.

## Change

New `MiddlewareOptions` flag:

```ts
// Skip the refresh token validation fallback
// By default, a valid refresh token is enough to pass the middleware even
// when the session token is expired. Set to true to require a valid session
// token, e.g. when server side code relies on `session()`
// Defaults to false
skipRefreshTokenValidation?: boolean;
```

When `true`, the `DSR` cookie is never read or validated, and a request without a valid session token is redirected to the sign-in route. Default (`false`) keeps the current behavior - no breaking change.

Note: the issue suggested `validateRefreshToken` (default `true`); went with `skipRefreshTokenValidation` (default `false`) to avoid a `skip`/`validate` double negative at the call site and keep the opt-in explicit.

## Notes

- Phase 1 only - the flag makes the middleware stricter. Actually performing the refresh at the edge (rotation-safe cookie write-back) is a separate, bigger design and is not part of this PR
- Unit test covers the skip path; the existing tests cover the default fallback path. `authMiddleware.ts` stays at 100% coverage
- README documents the option and why you'd reach for it