### PR TITLE
fix(web-component): bump @descope/flow-scripts to 1.0.19

### DIFF
--- a/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
+++ b/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
@@ -319,7 +319,7 @@ class DescopeWc extends BaseDescopeWc {
         if (!globalThis.descope?.[script.id]) {
           await this.injectNpmLib(
             '@descope/flow-scripts',
-            '1.0.18', // currently using a fixed version when loading scripts
+            '1.0.19', // currently using a fixed version when loading scripts
             `dist/${script.id}.js`,
           );
         }

--- a/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
+++ b/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
@@ -351,6 +351,14 @@ class DescopeWc extends BaseDescopeWc {
                   this.shadowRoot.removeChild(newScriptElement);
                 }
               });
+              // Modules that implement `present` mint their token when presented
+              // (awaited before the next call), not while loading, so they never
+              // invoke the callback here. Consider them loaded once constructed,
+              // otherwise loading always races SDK_SCRIPTS_LOAD_TIMEOUT and the
+              // first submit is delayed by the remainder of that timeout.
+              if (typeof moduleRes.present === 'function') {
+                resolve(script.id);
+              }
             }
           } catch (e) {
             reject(e);

--- a/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
+++ b/packages/sdks/web-component/src/lib/descope-wc/DescopeWc.ts
@@ -319,7 +319,7 @@ class DescopeWc extends BaseDescopeWc {
         if (!globalThis.descope?.[script.id]) {
           await this.injectNpmLib(
             '@descope/flow-scripts',
-            '1.0.17', // currently using a fixed version when loading scripts
+            '1.0.18', // currently using a fixed version when loading scripts
             `dist/${script.id}.js`,
           );
         }

--- a/packages/sdks/web-component/test/descope-wc.clientScripts.test.ts
+++ b/packages/sdks/web-component/test/descope-wc.clientScripts.test.ts
@@ -298,6 +298,67 @@ describe('web-component', () => {
       );
     });
 
+    // The mirror of the test below: a module with no `present` has no submit-time
+    // gate, so its result can only arrive via the load callback. Releasing it at
+    // construction would let the flow request go out without that result - e.g.
+    // fingerprint and forter, which expose neither `present` nor `refresh`.
+    it('should keep waiting for a module that has no present hook', async () => {
+      const mockSilentScript = jest.fn(() => ({
+        id: 'grecaptcha',
+        start: jest.fn(),
+        stop: jest.fn(),
+      }));
+      window.descope = { grecaptcha: mockSilentScript };
+
+      fixtures.configContent = {
+        ...fixtures.configContent,
+        flows: {
+          'sign-in': {
+            startScreenId: 'screen-0',
+            clientScripts: [
+              {
+                id: 'grecaptcha',
+                initArgs: {
+                  enterprise: true,
+                  siteKey: 'SITE_KEY',
+                },
+                resultKey: 'riskToken',
+              },
+            ],
+          },
+        },
+      };
+      fixtures.pageContent =
+        '<descope-button id="submitterId">click</descope-button><input id="email" name="email"></input><span>hey</span>';
+
+      document.body.innerHTML = `<h1>Custom element test</h1> <descope-wc flow-id="sign-in" project-id="1"></descope-wc>`;
+
+      await waitFor(() => screen.findByShadowText('hey'), {
+        timeout: WAIT_TIMEOUT,
+      });
+
+      scriptMock.onload();
+      await waitFor(() => expect(mockSilentScript).toHaveBeenCalled(), {
+        timeout: WAIT_TIMEOUT,
+      });
+
+      fireEvent.click(screen.getByShadowText('click'));
+
+      // Flush microtasks only. The module never called the callback, so nothing
+      // should release the submit until the load timeout elapses.
+      for (let i = 0; i < 50; i += 1) {
+        await Promise.resolve(); // eslint-disable-line no-await-in-loop
+      }
+
+      expect(startMock).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(SDK_SCRIPTS_LOAD_TIMEOUT + 1);
+
+      await waitFor(() => expect(startMock).toHaveBeenCalled(), {
+        timeout: WAIT_TIMEOUT,
+      });
+    });
+
     it('should not wait for the load timeout when the module implements present', async () => {
       mockPresentScript.mockClear();
       mockPresentScript.mockResolvedValueOnce(true);

--- a/packages/sdks/web-component/test/descope-wc.clientScripts.test.ts
+++ b/packages/sdks/web-component/test/descope-wc.clientScripts.test.ts
@@ -220,6 +220,14 @@ describe('web-component', () => {
       });
     });
     it('should send the next request if timeout is reached', async () => {
+      // a module without `present` signals readiness via the callback, so a
+      // module that never calls it is only released by the load timeout
+      const mockSilentScript = jest.fn(() => ({
+        id: 'grecaptcha',
+        start: jest.fn(),
+        stop: jest.fn(),
+      }));
+      window.descope = { grecaptcha: mockSilentScript };
       fixtures.configContent = {
         ...fixtures.configContent,
         flows: {
@@ -249,7 +257,7 @@ describe('web-component', () => {
 
       scriptMock.onload();
       await waitFor(() =>
-        expect(mockClientScript).toHaveBeenCalledWith(
+        expect(mockSilentScript).toHaveBeenCalledWith(
           {
             enterprise: true,
             siteKey: 'SITE_KEY',
@@ -288,6 +296,56 @@ describe('web-component', () => {
           timeout: WAIT_TIMEOUT,
         },
       );
+    });
+
+    it('should not wait for the load timeout when the module implements present', async () => {
+      mockPresentScript.mockClear();
+      mockPresentScript.mockResolvedValueOnce(true);
+
+      fixtures.configContent = {
+        ...fixtures.configContent,
+        flows: {
+          'sign-in': {
+            startScreenId: 'screen-0',
+            clientScripts: [
+              {
+                id: 'grecaptcha',
+                initArgs: {
+                  enterprise: true,
+                  siteKey: 'SITE_KEY',
+                },
+                resultKey: 'riskToken',
+              },
+            ],
+          },
+        },
+      };
+      fixtures.pageContent =
+        '<descope-button id="submitterId">click</descope-button><input id="email" name="email"></input><span>hey</span>';
+
+      document.body.innerHTML = `<h1>Custom element test</h1> <descope-wc flow-id="sign-in" project-id="1"></descope-wc>`;
+
+      await waitFor(() => screen.findByShadowText('hey'), {
+        timeout: WAIT_TIMEOUT,
+      });
+
+      scriptMock.onload();
+      await waitFor(() => expect(mockClientScript).toHaveBeenCalled(), {
+        timeout: WAIT_TIMEOUT,
+      });
+
+      fireEvent.click(screen.getByShadowText('click'));
+
+      // the module never calls the load callback - it produces its token when
+      // presented - so the submit must go through without the load timeout
+      // firing. Flush microtasks only, never advancing timers, so reaching the
+      // next call cannot depend on SDK_SCRIPTS_LOAD_TIMEOUT elapsing.
+      for (let i = 0; i < 50; i += 1) {
+        await Promise.resolve(); // eslint-disable-line no-await-in-loop
+      }
+
+      expect(mockPresentScript).toHaveBeenCalled();
+      expect(startMock).toHaveBeenCalled();
     });
 
     it('should load sdk script when flow configured with sdk script', async () => {


### PR DESCRIPTION
Bumps the pinned `@descope/flow-scripts` version used by `DescopeWc` when loading flow scripts at runtime, from 1.0.17 to **1.0.19**, and adapts the script loader to a contract change that landed in 1.0.18.

## Why 1.0.19 and not 1.0.18

1.0.18 reworked invisible reCAPTCHA: it stopped executing during init and moved token production into `present()`. That broke the loader's only readiness signal in two different ways, and only the pair of changes here plus 1.0.19 closes both.

- **Load-time stall.** `loadSdkScripts` resolved a script's load promise only from the token callback, racing `SDK_SCRIPTS_LOAD_TIMEOUT` (5s), and `#handleSubmit` awaits that race before calling `present()`. A module that mints its token when presented never fired the callback at load, so the first submit was delayed by whatever remained of the 5s window measured from screen render.
- **Tokenless submit.** Releasing the load promise early fixes the stall, but on 1.0.18 `present()` returned `false` immediately when `window.grecaptcha` was not defined yet — so it did not actually gate token production, and a submit beating Google's `api.js` went out with no risk token and only a logger warning.

The second half could not be fixed here: the component can observe when a flow-scripts module is constructed, but not when the vendor script that module injects becomes usable. That was fixed upstream in descope/content#2333 and released as 1.0.19, which makes invisible `present()` wait for the API with a bounded poll before giving up. With that in place, releasing a present-capable module at construction is correct rather than a trade-off.

## Changes

- `DescopeWc.ts`: pin 1.0.17 -> 1.0.19.
- `loadSdkScripts`: a module exposing `present` counts as loaded once constructed, since its token is gated at submit by the awaited `present()`. The timeout still covers modules that never signal readiness at all.

Both changes are load-bearing. 1.0.19 fixed *what `present()` does*; it did not add a load-time readiness signal. In the published 1.0.19 bundle the token callback is still invoked from only three places — `descopeRecaptchaWidgetCallback` and `descopeRecaptchaWidgetExpiredCallback` (widget mode) and inside `execute(...).then(...)` within `present()` — so in invisible mode nothing fires it at load and, without the loader change, the 5s stall returns. The same shape already applied to `arkose`, which sidesteps it by calling the callback with `null` on script load purely as a readiness signal.

1.0.19 also carries `@fingerprintjs/fingerprintjs-pro` 3.12.9 -> 3.12.11 from the 1.0.18 release.

## Verification

Published 1.0.19 tarball checked directly: `dist/grecaptcha.js` contains the bounded api.js wait, and `package.json` reports 1.0.19.

New test submits while flushing microtasks only, never advancing timers, so reaching the next call cannot depend on the timeout elapsing; it fails without the loader change and passes with it. The existing timeout test now uses a module without `present`, preserving its intent. Full web-component suite on the final pin: 455 passed, 1 skipped across 48 suites; eslint and prettier clean.

## Note for reviewers: the e2e failure is not from this change

`user-management-widget:test:e2e` is unstable on this repo, and this PR's own CI demonstrates it cleanly. On this head (`2ae8803`), in a **single CI run**, the two parallel jobs disagreed:

| Job | E2E |
| --- | --- |
| Build / Lint / Test (Node default) | ✅ succeeded (6m 3s) |
| Build / Lint / Test (Node 18) | ❌ failed (7m 50s) |

Same commit, same suite, same code — one pass, one fail, concurrently. Earlier heads showed the same thing across runs, with a *different* set of specs failing each time (`disable user` / `enable user` failed on one head and passed on retry on the next; `reset password` did the reverse), always with `page.waitForResponse: Test timeout of 60000ms exceeded`.

The widget also contains no reference to `clientScripts`, `sdkScripts`, `flow-scripts` or `grecaptcha`, so it never reaches the changed code path. See descope/descope-js#1487, which documents this same signature across unrelated branches.

Everything else on this head is green: Snyk, all five Vercel deploys, and nx `build` / `lint` / `licenseCheck` / `test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkJTJYtqKKzRQSASBVC7N2